### PR TITLE
Fix: GHA typos; GHA unit test envs

### DIFF
--- a/.github/workflows/notify-deploy.yml
+++ b/.github/workflows/notify-deploy.yml
@@ -7,7 +7,7 @@
 # REQUIRED CONFIGURATION:
 #   Repository variable (Settings → Secrets and variables → Actions → Variables):
 #     DEPLOY_REPO - The org/repo path to your deployment repository
-#                   Example: openshu/shu-deploy
+#                   Example: open-shu/shu-deploy
 #
 #   Repository secret:
 #     DEPLOY_REPO_PAT - A Personal Access Token with 'repo' scope that has

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -7,6 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
+    env:
+      # Minimal env vars required for Settings() to initialize without failing validation.
+      # This URL only needs to be syntactically valid for unit tests; CI does not touch the DB.
+      SHU_DATABASE_URL: postgresql://test:test@localhost:5432/shu_test
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,4 +1,4 @@
-name: Integ Tests
+name: Unit Tests
 
 on: [push]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ By submitting a contribution, you agree to the [Contributor License Agreement](C
 
 ```bash
 # Clone the repository
-git clone https://github.com/openshu/shu.git
+git clone https://github.com/open-shu/shu.git
 cd shu
 
 # Copy environment template


### PR DESCRIPTION
- Fixed typo with OpenShu in repo names to be Open-Shu
- Possible fix for GHA unit test running