### PR TITLE
SHU-124: Refactor rate limiting configuration to distinguish API vs L…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -381,15 +381,15 @@ SHU_PLUGINS_ROOT="./plugins"
 
 # Enable API rate limiting (default: false - disabled for development)
 # Set to true in production to enable HTTP request throttling
-SHU_ENABLE_API_RATE_LIMITING="false"
+SHU_ENABLE_API_RATE_LIMITING=false
 
 # Global API rate limiting (requests per period)
 SHU_API_RATE_LIMIT_REQUESTS=100
-SHU_API_RATE_LIMIT_PERIOD=60  # seconds
+SHU_API_RATE_LIMIT_PERIOD=60
 
 # Per-user API rate limiting (requests per period per user)
 SHU_API_RATE_LIMIT_USER_REQUESTS=50
-SHU_API_RATE_LIMIT_USER_PERIOD=60  # seconds
+SHU_API_RATE_LIMIT_USER_PERIOD=60
 
 # =============================================================================
 # LLM PROVIDER RATE LIMITING (Defaults for new providers)
@@ -398,8 +398,8 @@ SHU_API_RATE_LIMIT_USER_PERIOD=60  # seconds
 # Per-provider overrides are configured in the admin UI and stored in the database.
 # Set to 0 for unlimited (no rate limiting).
 
-SHU_LLM_RATE_LIMIT_RPM_DEFAULT=0  # requests per minute, 0 = unlimited
-SHU_LLM_RATE_LIMIT_TPM_DEFAULT=0  # tokens per minute, 0 = unlimited
+SHU_LLM_RATE_LIMIT_RPM_DEFAULT=0
+SHU_LLM_RATE_LIMIT_TPM_DEFAULT=0
 
 
 

--- a/.env.example
+++ b/.env.example
@@ -374,19 +374,32 @@ SHU_PLUGINS_ROOT="./plugins"
 
 
 # =============================================================================
-# RATE LIMITING CONFIGURATION
+# API RATE LIMITING (HTTP Request Throttling)
 # =============================================================================
+# These settings control rate limiting for HTTP API requests (not LLM calls).
+# For LLM provider rate limits (RPM/TPM), see LLM PROVIDER RATE LIMITING below.
 
-# Enable rate limiting (default: true)
-SHU_ENABLE_RATE_LIMITING="true"
+# Enable API rate limiting (default: false - disabled for development)
+# Set to true in production to enable HTTP request throttling
+SHU_ENABLE_API_RATE_LIMITING="false"
 
-# Global rate limiting (requests per minute)
-SHU_RATE_LIMIT_REQUESTS=100
-SHU_RATE_LIMIT_PERIOD=60
+# Global API rate limiting (requests per period)
+SHU_API_RATE_LIMIT_REQUESTS=100
+SHU_API_RATE_LIMIT_PERIOD=60  # seconds
 
-# User-based rate limiting (requests per minute per user)
-SHU_RATE_LIMIT_USER_REQUESTS=50
-SHU_RATE_LIMIT_USER_PERIOD=60
+# Per-user API rate limiting (requests per period per user)
+SHU_API_RATE_LIMIT_USER_REQUESTS=50
+SHU_API_RATE_LIMIT_USER_PERIOD=60  # seconds
+
+# =============================================================================
+# LLM PROVIDER RATE LIMITING (Defaults for new providers)
+# =============================================================================
+# These are default values used when creating new LLM providers.
+# Per-provider overrides are configured in the admin UI and stored in the database.
+# Set to 0 for unlimited (no rate limiting).
+
+SHU_LLM_RATE_LIMIT_RPM_DEFAULT=0  # requests per minute, 0 = unlimited
+SHU_LLM_RATE_LIMIT_TPM_DEFAULT=0  # tokens per minute, 0 = unlimited
 
 
 
@@ -453,9 +466,9 @@ SHU_CONVERSATION_SUMMARY_SEARCH_MIN_TOKEN_LENGTH=3
 SHU_CONVERSATION_SUMMARY_SEARCH_MAX_TOKENS=10
 
 
-# Strict Rate Limiting Configuration
-SHU_STRICT_RATE_LIMIT_REQUESTS=10
-SHU_STRICT_RATE_LIMIT_USER_REQUESTS=5
+# Strict API Rate Limiting (for auth endpoints - brute force protection)
+SHU_STRICT_API_RATE_LIMIT_REQUESTS=10
+SHU_STRICT_API_RATE_LIMIT_USER_REQUESTS=5
 SHU_MAX_PAGINATION_LIMIT=1000
 
 # =============================================================================

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -142,12 +142,17 @@ class Settings(BaseSettings):
     worker_poll_interval: float = Field(1.0, alias="SHU_WORKER_POLL_INTERVAL")  # seconds
     worker_shutdown_timeout: float = Field(30.0, alias="SHU_WORKER_SHUTDOWN_TIMEOUT")  # seconds
 
-    # Rate limiting
-    enable_rate_limiting: bool = Field(True, alias="SHU_ENABLE_RATE_LIMITING")
-    rate_limit_requests: int = Field(100, alias="SHU_RATE_LIMIT_REQUESTS")
-    rate_limit_period: int = Field(60, alias="SHU_RATE_LIMIT_PERIOD")  # seconds
-    rate_limit_user_requests: int = Field(50, alias="SHU_RATE_LIMIT_USER_REQUESTS")  # per user
-    rate_limit_user_period: int = Field(60, alias="SHU_RATE_LIMIT_USER_PERIOD")  # seconds
+    # API Rate Limiting (HTTP request throttling, not LLM-specific)
+    enable_api_rate_limiting: bool = Field(False, alias="SHU_ENABLE_API_RATE_LIMITING")
+    api_rate_limit_requests: int = Field(100, alias="SHU_API_RATE_LIMIT_REQUESTS")  # requests per period
+    api_rate_limit_period: int = Field(60, alias="SHU_API_RATE_LIMIT_PERIOD")  # seconds
+    api_rate_limit_user_requests: int = Field(50, alias="SHU_API_RATE_LIMIT_USER_REQUESTS")  # per user per period
+    api_rate_limit_user_period: int = Field(60, alias="SHU_API_RATE_LIMIT_USER_PERIOD")  # seconds
+
+    # LLM Provider Rate Limiting Defaults (0 = unlimited)
+    # These are used as defaults when creating new providers; per-provider overrides are stored in the database
+    llm_rate_limit_rpm_default: int = Field(0, alias="SHU_LLM_RATE_LIMIT_RPM_DEFAULT")  # requests per minute, 0 = unlimited
+    llm_rate_limit_tpm_default: int = Field(0, alias="SHU_LLM_RATE_LIMIT_TPM_DEFAULT")  # tokens per minute, 0 = unlimited
 
     # Quotas (per-plugin/per-user)
     plugin_quota_daily_requests_default: int = Field(0, alias="SHU_PLUGIN_QUOTA_DAILY_REQUESTS_DEFAULT")
@@ -360,9 +365,9 @@ class Settings(BaseSettings):
     user_language_default: str = Field("en", alias="SHU_USER_LANGUAGE_DEFAULT")
     user_timezone_default: str = Field("UTC", alias="SHU_USER_TIMEZONE_DEFAULT")
 
-    # Strict Rate Limiting Configuration
-    strict_rate_limit_requests: int = Field(10, alias="SHU_STRICT_RATE_LIMIT_REQUESTS")
-    strict_rate_limit_user_requests: int = Field(5, alias="SHU_STRICT_RATE_LIMIT_USER_REQUESTS")
+    # Strict API Rate Limiting (for auth endpoints - brute force protection)
+    strict_api_rate_limit_requests: int = Field(10, alias="SHU_STRICT_API_RATE_LIMIT_REQUESTS")
+    strict_api_rate_limit_user_requests: int = Field(5, alias="SHU_STRICT_API_RATE_LIMIT_USER_REQUESTS")
     max_pagination_limit: int = Field(1000, alias="SHU_MAX_PAGINATION_LIMIT")
 
     # OCR Configuration

--- a/backend/src/shu/core/rate_limiting.py
+++ b/backend/src/shu/core/rate_limiting.py
@@ -253,7 +253,7 @@ class RateLimitService:
             settings = get_settings_instance()
 
         self._settings = settings
-        self._enabled = getattr(settings, "enable_rate_limiting", True)
+        self._enabled = getattr(settings, "enable_api_rate_limiting", False)
 
         # Initialize limiters lazily
         self._api_limiter: Optional[TokenBucketRateLimiter] = None
@@ -275,13 +275,13 @@ class RateLimitService:
     def _get_api_limiter(self) -> TokenBucketRateLimiter:
         """
         Get the TokenBucketRateLimiter used for API rate limiting, creating and configuring it from settings if not already initialized.
-        
+
         Returns:
-            TokenBucketRateLimiter: Limiter configured for the "rl:api" namespace. Capacity is taken from `settings.rate_limit_requests` (default 100) and `refill_per_second` is computed as capacity divided by `settings.rate_limit_period` (default 60).
+            TokenBucketRateLimiter: Limiter configured for the "rl:api" namespace. Capacity is taken from `settings.api_rate_limit_requests` (default 100) and `refill_per_second` is computed as capacity divided by `settings.api_rate_limit_period` (default 60).
         """
         if self._api_limiter is None:
-            requests = getattr(self._settings, "rate_limit_requests", 100)
-            period = getattr(self._settings, "rate_limit_period", 60)
+            requests = getattr(self._settings, "api_rate_limit_requests", 100)
+            period = getattr(self._settings, "api_rate_limit_period", 60)
             self._api_limiter = TokenBucketRateLimiter(
                 namespace="rl:api",
                 capacity=requests,
@@ -293,15 +293,15 @@ class RateLimitService:
     def _get_auth_limiter(self) -> TokenBucketRateLimiter:
         """
         Get or create a TokenBucketRateLimiter configured for authentication with strict, slow-refill limits.
-        
-        Reads `strict_rate_limit_requests` from settings (default 10) for capacity and sets `refill_per_second` to 1.
-        
+
+        Reads `strict_api_rate_limit_requests` from settings (default 10) for capacity and sets `refill_per_second` to 1.
+
         Returns:
             TokenBucketRateLimiter: Limiter instance used for auth rate limiting.
         """
         if self._auth_limiter is None:
             # Use strict limits for auth endpoints
-            requests = getattr(self._settings, "strict_rate_limit_requests", 10)
+            requests = getattr(self._settings, "strict_api_rate_limit_requests", 10)
             self._auth_limiter = TokenBucketRateLimiter(
                 namespace="rl:auth",
                 capacity=requests,

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -473,7 +473,7 @@ def setup_middleware(app: FastAPI) -> None:
         logger.warning("TrustedHostMiddleware not enforcing host validation; set SHU_ALLOWED_HOSTS for non-dev deployments")
 
     # Rate limiting middleware (applied after authentication to have user context)
-    if settings.enable_rate_limiting:
+    if settings.enable_api_rate_limiting:
         try:
             app.add_middleware(RateLimitMiddleware)
             logger.info("Rate limiting middleware enabled")

--- a/backend/src/shu/models/llm_provider.py
+++ b/backend/src/shu/models/llm_provider.py
@@ -33,9 +33,9 @@ class LLMProvider(BaseModel):
     # Provider capabilities
     is_active = Column(Boolean, default=True, nullable=False, index=True)
     
-    # Rate limiting (per-provider limits, 0 = disabled)
-    rate_limit_rpm = Column(Integer, default=60, nullable=False)  # Requests per minute
-    rate_limit_tpm = Column(Integer, default=60000, nullable=False)  # Tokens per minute
+    # Rate limiting (per-provider limits, 0 = unlimited/disabled)
+    rate_limit_rpm = Column(Integer, default=0, nullable=False)  # Requests per minute, 0 = unlimited
+    rate_limit_tpm = Column(Integer, default=0, nullable=False)  # Tokens per minute, 0 = unlimited
     budget_limit_monthly = Column(DECIMAL(10, 2), nullable=True)  # Monthly budget limit
     
     # Additional configuration

--- a/backend/src/shu/plugins/executor.py
+++ b/backend/src/shu/plugins/executor.py
@@ -231,11 +231,11 @@ class Executor:
         self._provider_limiter = None  # provider/model limiter
         try:
             s = get_settings_instance()
-            if s.enable_rate_limiting:
+            if s.enable_api_rate_limiting:
                 from ..core.rate_limiting import TokenBucketRateLimiter
                 # Per-user defaults using settings directly
-                rpm = s.rate_limit_user_requests
-                period = s.rate_limit_user_period
+                rpm = s.api_rate_limit_user_requests
+                period = s.api_rate_limit_user_period
                 capacity = max(1, rpm)
                 refill_per_second = max(1, int(rpm / max(1, period)))
                 self._limiter = TokenBucketRateLimiter(
@@ -488,8 +488,8 @@ class Executor:
             daily = int(limits.get("quota_daily_requests") or s.plugin_quota_daily_requests_default or 0)
             monthly = int(limits.get("quota_monthly_requests") or s.plugin_quota_monthly_requests_default or 0)
             # Rate limit using settings directly
-            rl_req = int(limits.get("rate_limit_user_requests") or s.rate_limit_user_requests or 60)
-            rl_period = int(limits.get("rate_limit_user_period") or s.rate_limit_user_period or 60)
+            rl_req = int(limits.get("rate_limit_user_requests") or s.api_rate_limit_user_requests or 60)
+            rl_period = int(limits.get("rate_limit_user_period") or s.api_rate_limit_user_period or 60)
             # Provider caps (optional per-tool override)
             provider_name = str(limits.get("provider_name") or "").strip()
             provider_rpm = int(limits.get("provider_rpm") or 0)

--- a/backend/src/tests/integ/integration_test_runner.py
+++ b/backend/src/tests/integ/integration_test_runner.py
@@ -13,7 +13,7 @@ import os
 
 # Disable rate limiting for test runs - the test suite makes many API calls
 # and rate limiting causes cascade failures unrelated to actual test logic
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "false")
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "false")
 
 # =============================================================================
 

--- a/backend/src/tests/integ/run_all_integration_tests.py
+++ b/backend/src/tests/integ/run_all_integration_tests.py
@@ -13,7 +13,7 @@ import os
 
 # Disable rate limiting for test runs - the test suite makes many API calls
 # and rate limiting causes cascade failures unrelated to actual test logic
-os.environ["SHU_ENABLE_RATE_LIMITING"] = "false"
+os.environ["SHU_ENABLE_API_RATE_LIMITING"] = "false"
 
 # =============================================================================
 

--- a/backend/src/tests/integ/test_plugins_scheduler_integration.py
+++ b/backend/src/tests/integ/test_plugins_scheduler_integration.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 os.environ.setdefault("SHU_PLUGINS_SCHEDULER_ENABLED", "true")
 os.environ.setdefault("SHU_PLUGINS_SCHEDULER_TICK_SECONDS", "1")
 os.environ.setdefault("SHU_PLUGINS_SCHEDULER_BATCH_LIMIT", "5")
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "false")
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "false")
 # Make stale RUNNING cleanup aggressive for tests
 os.environ.setdefault("SHU_PLUGINS_SCHEDULER_RUNNING_TIMEOUT_SECONDS", "1")
 

--- a/backend/src/tests/integ/test_quotas_integration.py
+++ b/backend/src/tests/integ/test_quotas_integration.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 # Set env BEFORE importing test runner/app so settings pick up test overrides
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "true")  # rate limiter shouldn't interfere at these counts
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "true")  # rate limiter shouldn't interfere at these counts
 os.environ["SHU_PLUGIN_QUOTA_DAILY_REQUESTS_DEFAULT"] = "2"  # allow 2 per day
 os.environ["SHU_PLUGIN_QUOTA_MONTHLY_REQUESTS_DEFAULT"] = "0"  # disable monthly for this test
 

--- a/backend/src/tests/integ/test_rate_limiting_integration.py
+++ b/backend/src/tests/integ/test_rate_limiting_integration.py
@@ -2,9 +2,9 @@ import os
 import logging
 
 # Set env BEFORE importing test runner/app so settings pick up test overrides
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "true")
-os.environ["SHU_RATE_LIMIT_USER_REQUESTS"] = "2"  # 2 requests per period
-os.environ["SHU_RATE_LIMIT_USER_PERIOD"] = "60"   # per 60 seconds
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "true")
+os.environ["SHU_API_RATE_LIMIT_USER_REQUESTS"] = "2"  # 2 requests per period
+os.environ["SHU_API_RATE_LIMIT_USER_PERIOD"] = "60"   # per 60 seconds
 
 from integ.base_integration_test import BaseIntegrationTestSuite, create_test_runner_script  # noqa: E402
 

--- a/backend/src/tests/integ/test_rate_limiting_integration.py
+++ b/backend/src/tests/integ/test_rate_limiting_integration.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 # Set env BEFORE importing test runner/app so settings pick up test overrides
-os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "true")
+os.environ["SHU_ENABLE_API_RATE_LIMITING"] = "true"
 os.environ["SHU_API_RATE_LIMIT_USER_REQUESTS"] = "2"  # 2 requests per period
 os.environ["SHU_API_RATE_LIMIT_USER_PERIOD"] = "60"   # per 60 seconds
 

--- a/backend/src/tests/integ/test_tool_overrides_integration.py
+++ b/backend/src/tests/integ/test_tool_overrides_integration.py
@@ -2,9 +2,9 @@ import os
 import logging
 
 # Ensure rate limiting is enabled but with lenient globals so override effects are visible
-os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "true")
-os.environ["SHU_RATE_LIMIT_USER_REQUESTS"] = "100"
-os.environ["SHU_RATE_LIMIT_USER_PERIOD"] = "60"
+os.environ["SHU_ENABLE_API_RATE_LIMITING"] = "true"
+os.environ["SHU_API_RATE_LIMIT_USER_REQUESTS"] = "100"
+os.environ["SHU_API_RATE_LIMIT_USER_PERIOD"] = "60"
 os.environ.setdefault("SHU_PLUGIN_QUOTA_DAILY_REQUESTS_DEFAULT", "0")
 os.environ.setdefault("SHU_PLUGIN_QUOTA_MONTHLY_REQUESTS_DEFAULT", "0")
 

--- a/backend/src/tests/integ/test_tool_overrides_integration.py
+++ b/backend/src/tests/integ/test_tool_overrides_integration.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 # Ensure rate limiting is enabled but with lenient globals so override effects are visible
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "true")
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "true")
 os.environ["SHU_RATE_LIMIT_USER_REQUESTS"] = "100"
 os.environ["SHU_RATE_LIMIT_USER_PERIOD"] = "60"
 os.environ.setdefault("SHU_PLUGIN_QUOTA_DAILY_REQUESTS_DEFAULT", "0")

--- a/backend/src/tests/integ/tools_integration_tests.py
+++ b/backend/src/tests/integ/tools_integration_tests.py
@@ -10,7 +10,7 @@ import os, sys
 from typing import Any, Dict
 
 # Disable rate limiting for this test module to avoid redis dependency
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "0")
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "0")
 
 from sqlalchemy import select
 

--- a/backend/src/tests/integ/tools_output_schema_tests.py
+++ b/backend/src/tests/integ/tools_output_schema_tests.py
@@ -6,7 +6,7 @@ import asyncio
 import os, sys
 
 # Disable rate limiting to isolate validation behavior
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "0")
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "0")
 
 from shu.models.plugin_registry import PluginDefinition
 from integ.integration_test_runner import run_integration_tests

--- a/backend/src/tests/integ/tools_rate_limit_tests.py
+++ b/backend/src/tests/integ/tools_rate_limit_tests.py
@@ -9,10 +9,10 @@ import asyncio
 import os, sys
 
 # Enable rate limiting for this test
-os.environ["SHU_ENABLE_RATE_LIMITING"] = "1"
+os.environ["SHU_ENABLE_API_RATE_LIMITING"] = "1"
 # Configure a very small bucket to force 429 on immediate consecutive calls
-os.environ["SHU_RATE_LIMIT_USER_REQUESTS"] = "1"   # capacity
-os.environ["SHU_RATE_LIMIT_USER_PERIOD"] = "60"    # seconds (only used to compute refill)
+os.environ["SHU_API_RATE_LIMIT_USER_REQUESTS"] = "1"   # capacity
+os.environ["SHU_API_RATE_LIMIT_USER_PERIOD"] = "60"    # seconds (only used to compute refill)
 
 from shu.models.plugin_registry import PluginDefinition
 from integ.integration_test_runner import run_integration_tests

--- a/backend/src/tests/integ/tools_schema_tests.py
+++ b/backend/src/tests/integ/tools_schema_tests.py
@@ -6,7 +6,7 @@ import asyncio
 import os, sys
 
 # Disable rate limiting to isolate validation behavior
-os.environ.setdefault("SHU_ENABLE_RATE_LIMITING", "0")
+os.environ.setdefault("SHU_ENABLE_API_RATE_LIMITING", "0")
 
 from shu.models.plugin_registry import PluginDefinition
 from integ.integration_test_runner import run_integration_tests

--- a/backend/src/tests/unit/services/test_rate_limiting.py
+++ b/backend/src/tests/unit/services/test_rate_limiting.py
@@ -236,7 +236,7 @@ class TestProviderRateLimits:
 
         # Create mock settings - no global LLM limits needed
         mock_settings = MagicMock()
-        mock_settings.enable_rate_limiting = True
+        mock_settings.enable_api_rate_limiting = True
 
         service = RateLimitService(settings=mock_settings)
 
@@ -257,7 +257,7 @@ class TestProviderRateLimits:
 
         # Create mock settings - no global LLM limits needed
         mock_settings = MagicMock()
-        mock_settings.enable_rate_limiting = True
+        mock_settings.enable_api_rate_limiting = True
 
         service = RateLimitService(settings=mock_settings)
 
@@ -292,36 +292,36 @@ class TestRateLimitService:
         from shu.core.rate_limiting import RateLimitService
 
         mock_settings = MagicMock()
-        mock_settings.enable_rate_limiting = True
-        mock_settings.rate_limit_requests = 100
-        mock_settings.rate_limit_period = 60
-        mock_settings.strict_rate_limit_requests = 10
+        mock_settings.enable_api_rate_limiting = True
+        mock_settings.api_rate_limit_requests = 100
+        mock_settings.api_rate_limit_period = 60
+        mock_settings.strict_api_rate_limit_requests = 10
         # Note: LLM rate limits are per-provider, not global
 
         service = RateLimitService(settings=mock_settings)
 
         assert service.enabled is True
-    
+
     def test_service_disabled(self):
         """Service respects disabled setting."""
         from shu.core.rate_limiting import RateLimitService
-        
+
         mock_settings = MagicMock()
-        mock_settings.enable_rate_limiting = False
-        
+        mock_settings.enable_api_rate_limiting = False
+
         service = RateLimitService(settings=mock_settings)
-        
+
         assert service.enabled is False
-    
+
     @pytest.mark.asyncio
     async def test_check_api_limit_disabled_allows(self):
         """Disabled service allows all requests."""
         from shu.core.rate_limiting import RateLimitService
-        
+
         mock_settings = MagicMock()
-        mock_settings.enable_rate_limiting = False
-        
+        mock_settings.enable_api_rate_limiting = False
+
         service = RateLimitService(settings=mock_settings)
         result = await service.check_api_limit("user:123")
-        
+
         assert result.allowed is True

--- a/frontend/src/components/LLMProviders.js
+++ b/frontend/src/components/LLMProviders.js
@@ -77,8 +77,8 @@ const [manualModels, setManualModels] = useState([]);
     organization_id: '',
     is_active: true,
     provider_capabilities: createDefaultProviderCapabilities(),
-    rate_limit_rpm: 60,
-    rate_limit_tpm: 60000,
+    rate_limit_rpm: 0,  // 0 = unlimited
+    rate_limit_tpm: 0,  // 0 = unlimited
     budget_limit_monthly: null
   }));
   const [error, setError] = useState(null);
@@ -182,6 +182,19 @@ const [manualModels, setManualModels] = useState([]);
       }));
     }
   }, [createDialogOpen, providerCapabilitiesCreate, providerCapabilitiesDirtyCreate]);
+
+  // Sync rate limit defaults from provider type definition when creating
+  useEffect(() => {
+    if (createDialogOpen && providerTypeDefCreate) {
+      const rpmDefault = providerTypeDefCreate.rate_limit_rpm_default ?? 0;
+      const tpmDefault = providerTypeDefCreate.rate_limit_tpm_default ?? 0;
+      setNewProvider((prev) => ({
+        ...prev,
+        rate_limit_rpm: rpmDefault,
+        rate_limit_tpm: tpmDefault,
+      }));
+    }
+  }, [createDialogOpen, providerTypeDefCreate]);
 
   useEffect(() => {
     if (editDialogOpen && providerTypeDef?.base_url_template && !apiEndpointDirtyEdit && (!editProvider?.api_endpoint)) {
@@ -384,8 +397,8 @@ const resetNewProvider = () => {
       organization_id: '',
       is_active: true,
     provider_capabilities: createDefaultProviderCapabilities(),
-    rate_limit_rpm: 60,
-    rate_limit_tpm: 60000,
+    rate_limit_rpm: 0,  // 0 = unlimited
+    rate_limit_tpm: 0,  // 0 = unlimited
     budget_limit_monthly: null,
   });
   setApiEndpointDirtyCreate(false);


### PR DESCRIPTION
…LM provider limits

- Renamed API rate limit settings to include "API" prefix for clarity:
  - SHU_RATE_LIMIT_REQUESTS → SHU_API_RATE_LIMIT_REQUESTS
  - SHU_RATE_LIMIT_PERIOD → SHU_API_RATE_LIMIT_PERIOD
  - SHU_RATE_LIMIT_USER_REQUESTS → SHU_API_RATE_LIMIT_USER_REQUESTS
  - SHU_RATE_LIMIT_USER_PERIOD → SHU_API_RATE_LIMIT_USER_PERIOD
  - SHU_STRICT_RATE_LIMIT_REQUESTS → SHU_STRICT_API_RATE_LIMIT_REQUESTS
  - SHU_STRICT_RATE_LIMIT_USER_REQUESTS → SHU_STRICT_API_RATE_LIMIT_USER_REQUESTS
- Added global defaults for LLM provider rate limits:
  - SHU_LLM_RATE_LIMIT_RPM_DEFAULT (0 = unlimited)
  - SHU_LLM_RATE_LIMIT_TPM_DEFAULT (0 = unlimited)
- Changed LLM provider defaults from 60 RPM / 60000 TPM to 0 (unlimited)
- Added rate limit defaults to ProviderTypeDefinitionSchema so frontend fetches from backend
- Frontend now uses backend-provided defaults when creating new providers
- Updated .env.example with clear section headers distinguishing API vs LLM rate limiting
- Updated integration tests (tools_rate_limit_tests.py, test_rate_limiting_integration.py)
- Updated unit tests (test_rate_limiting.py)
- Updated task documentation (SHU-422, SHU-124)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP egress policy to control outbound network calls.
  * Provider creation now applies system-defined LLM rate-limit defaults.

* **Chores**
  * Reorganized rate-limiting configuration to API-specific settings and renamed controls.
  * Global API rate limiting now defaults to disabled in development; strict limiter names updated.
  * Changed LLM default limits to unlimited (0).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->