### PR TITLE
`feat(auth): Add Microsoft SSO backend endpoints [SHU-500]`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,13 +177,17 @@ JWT_REFRESH_TOKEN_EXPIRE_DAYS=30
 # Google OAuth2 Configuration (REQUIRED for authentication)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-GOOGLE_REDIRECT_URI="http://localhost:8000/auth/callback"
+# DEPRECATED: Use OAUTH_REDIRECT_URI instead. Will be removed in a future release.
+# GOOGLE_REDIRECT_URI="http://localhost:8000/auth/callback"
 
 # Microsoft 365 OAuth
 MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=
-MICROSOFT_REDIRECT_URI=http://localhost:8000/auth/callback
 MICROSOFT_TENANT_ID=common
+
+# Unified OAuth Redirect URI (used by all OAuth providers: Google, Microsoft, etc.)
+# All providers share the same callback endpoint which identifies the provider via state parameter
+OAUTH_REDIRECT_URI="http://localhost:8000/auth/callback"
 
 # Frontend API Configuration (OPTIONAL)
 # URL where the frontend can reach the backend API

--- a/backend/src/shu/api/config.py
+++ b/backend/src/shu/api/config.py
@@ -35,6 +35,7 @@ async def get_public_config():
 
     config = PublicConfig(
         google_client_id=settings.google_client_id or "",
+        microsoft_client_id=settings.microsoft_client_id or "",
         app_name=settings.app_name,
         version=settings.version,
         environment=settings.environment,

--- a/backend/src/shu/auth/models.py
+++ b/backend/src/shu/auth/models.py
@@ -22,7 +22,7 @@ class User(BaseModel):
     email = Column(String, unique=True, nullable=False, index=True)
     name = Column(String, nullable=False)
     role = Column(String, default=UserRole.REGULAR_USER.value)  # Store as string
-    google_id = Column(String, unique=True, nullable=False, index=True)
+    google_id = Column(String, unique=True, nullable=True, index=True)  # Nullable for non-Google auth users
     picture_url = Column(String, nullable=True)
     is_active = Column(Boolean, default=False)  # Users require admin activation by default
     last_login = Column(TIMESTAMP(timezone=True), nullable=True)
@@ -39,6 +39,10 @@ class User(BaseModel):
     group_memberships = relationship("UserGroupMembership", foreign_keys="UserGroupMembership.user_id", back_populates="user", cascade="all, delete-orphan")
     kb_permissions = relationship("KnowledgeBasePermission", foreign_keys="KnowledgeBasePermission.user_id", back_populates="user", cascade="all, delete-orphan")
     owned_knowledge_bases = relationship("KnowledgeBase", foreign_keys="KnowledgeBase.owner_id", back_populates="owner")
+
+    # Provider relationships (OAuth identities and credentials)
+    provider_identities = relationship("ProviderIdentity", foreign_keys="ProviderIdentity.user_id", cascade="all, delete-orphan")
+    provider_credentials = relationship("ProviderCredential", foreign_keys="ProviderCredential.user_id", cascade="all, delete-orphan")
 
     def __repr__(self):
         return f"<User(email='{self.email}', role='{self.role}')>"

--- a/backend/src/shu/core/middleware.py
+++ b/backend/src/shu/core/middleware.py
@@ -134,6 +134,8 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             "/api/v1/auth/refresh",
             "/api/v1/auth/google/login",
             "/api/v1/auth/google/exchange-login",
+            "/api/v1/auth/microsoft/login",
+            "/api/v1/auth/microsoft/exchange-login",
             # Host-auth OAuth callbacks must be public (popup redirects from Google)
             "/api/v1/host/auth/callback",
             "/auth/callback",

--- a/backend/src/shu/providers/google/auth_adapter.py
+++ b/backend/src/shu/providers/google/auth_adapter.py
@@ -222,8 +222,7 @@ class GoogleAuthAdapter(BaseAuthAdapter):
                 pass
         meta: Dict[str, Any] = {}
         try:
-            # Check if OAuth is configured (client_id, client_secret, and redirect URI via unified or legacy settings)
-            redirect_uri = settings.get_oauth_redirect_uri("google") if hasattr(settings, "get_oauth_redirect_uri") else getattr(settings, "google_redirect_uri", None)
+            redirect_uri = settings.get_oauth_redirect_uri("google")
             meta = {
                 "user_oauth_configured": bool(
                     getattr(settings, "google_client_id", None)

--- a/backend/src/shu/schemas/config.py
+++ b/backend/src/shu/schemas/config.py
@@ -13,6 +13,7 @@ class UploadRestrictions(BaseModel):
 class PublicConfig(BaseModel):
     """Public configuration that can be safely exposed to frontend"""
     google_client_id: str
+    microsoft_client_id: str
     app_name: str
     version: str
     environment: str

--- a/backend/src/tests/integ/test_microsoft_sso_integration.py
+++ b/backend/src/tests/integ/test_microsoft_sso_integration.py
@@ -11,7 +11,7 @@ These tests verify Microsoft SSO authentication workflows:
 
 import sys
 import logging
-import time
+import uuid
 from typing import List, Callable
 from unittest.mock import patch, AsyncMock
 
@@ -90,7 +90,7 @@ async def test_microsoft_login_endpoint_returns_redirect(client, db, auth_header
 
 async def test_microsoft_exchange_login_new_user(client, db, auth_headers):
     """Test Microsoft SSO creates a new user when none exists."""
-    unique_id = int(time.time())
+    unique_id = uuid.uuid4().hex
     unique_email = f"ms_new_user_{unique_id}@example.com"
     mock_user = {
         "microsoft_id": f"ms_new_{unique_id}",
@@ -119,7 +119,7 @@ async def test_microsoft_exchange_login_new_user(client, db, auth_headers):
 
 async def test_microsoft_exchange_login_existing_user(client, db, auth_headers):
     """Test Microsoft SSO logs in an existing Microsoft user."""
-    unique_id = int(time.time())
+    unique_id = uuid.uuid4().hex
     unique_email = f"ms_existing_{unique_id}@example.com"
     microsoft_id = f"ms_existing_id_{unique_id}"
     
@@ -165,7 +165,7 @@ async def test_microsoft_exchange_login_existing_user(client, db, auth_headers):
 
 async def test_microsoft_exchange_login_links_to_existing_google_user(client, db, auth_headers):
     """Test Microsoft SSO links to existing user with same email (e.g., Google user)."""
-    unique_id = int(time.time())
+    unique_id = uuid.uuid4().hex
     unique_email = f"ms_link_{unique_id}@example.com"
     google_id = f"google_id_{unique_id}"
     microsoft_id = f"ms_link_id_{unique_id}"
@@ -202,7 +202,7 @@ async def test_microsoft_exchange_login_links_to_existing_google_user(client, db
 
 async def test_microsoft_exchange_login_password_conflict(client, db, auth_headers):
     """Test Microsoft SSO returns 409 when user exists with password auth."""
-    unique_id = int(time.time())
+    unique_id = uuid.uuid4().hex
     unique_email = f"ms_pwd_conflict_{unique_id}@example.com"
     
     # Create existing password user using ORM
@@ -238,7 +238,7 @@ async def test_microsoft_exchange_login_password_conflict(client, db, auth_heade
 
 async def test_microsoft_exchange_login_inactive_user(client, db, auth_headers):
     """Test Microsoft SSO returns 400 when user account is inactive."""
-    unique_id = int(time.time())
+    unique_id = uuid.uuid4().hex
     unique_email = f"ms_inactive_{unique_id}@example.com"
     microsoft_id = f"ms_inactive_id_{unique_id}"
     

--- a/backend/src/tests/integ/test_microsoft_sso_integration.py
+++ b/backend/src/tests/integ/test_microsoft_sso_integration.py
@@ -1,0 +1,325 @@
+"""
+Microsoft SSO Integration Tests for Shu
+
+These tests verify Microsoft SSO authentication workflows:
+- New user signup via Microsoft SSO
+- Existing user login via Microsoft SSO  
+- Email conflict handling (user exists with same email)
+- Password auth conflict (409 response)
+- Inactive account handling
+"""
+
+import sys
+import logging
+import time
+from typing import List, Callable
+from unittest.mock import patch, AsyncMock
+
+from integ.base_integration_test import BaseIntegrationTestSuite
+from integ.response_utils import extract_data
+
+logger = logging.getLogger(__name__)
+
+
+def _mock_microsoft_adapter():
+    """Create a mock for MicrosoftAuthAdapter.exchange_code."""
+    mock = AsyncMock()
+    mock.return_value = {
+        "access_token": "mock_ms_access_token",
+        "refresh_token": "mock_ms_refresh_token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    return mock
+
+
+def _mock_microsoft_user_info(user_data: dict):
+    """Create a mock for _get_microsoft_user_info."""
+    mock = AsyncMock()
+    mock.return_value = user_data
+    return mock
+
+
+async def _create_user_with_orm(db, email: str, name: str, google_id: str = None, 
+                                 auth_method: str = "google", is_active: bool = True,
+                                 password_hash: str = None):
+    """Create a user using the ORM pattern (consistent with integration_test_runner.py)."""
+    from shu.auth.models import User
+    
+    user = User(
+        email=email,
+        name=name,
+        google_id=google_id,
+        auth_method=auth_method,
+        is_active=is_active,
+        password_hash=password_hash,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _create_provider_identity(db, user_id: str, provider_key: str, account_id: str,
+                                     primary_email: str, display_name: str):
+    """Create a ProviderIdentity using the ORM pattern."""
+    from shu.models.provider_identity import ProviderIdentity
+    
+    identity = ProviderIdentity(
+        user_id=user_id,
+        provider_key=provider_key,
+        account_id=account_id,
+        primary_email=primary_email,
+        display_name=display_name,
+    )
+    db.add(identity)
+    await db.commit()
+    await db.refresh(identity)
+    return identity
+
+
+async def test_microsoft_login_endpoint_returns_redirect(client, db, auth_headers):
+    """Test that /auth/microsoft/login returns a redirect to Microsoft OAuth."""
+    response = await client.get("/api/v1/auth/microsoft/login", follow_redirects=False)
+    # Should redirect to Microsoft OAuth
+    assert response.status_code in (302, 307), f"Expected redirect, got {response.status_code}"
+    location = response.headers.get("location", "")
+    assert "login.microsoftonline.com" in location or "microsoft" in location.lower(), \
+        f"Expected Microsoft OAuth URL, got: {location}"
+
+
+async def test_microsoft_exchange_login_new_user(client, db, auth_headers):
+    """Test Microsoft SSO creates a new user when none exists."""
+    unique_id = int(time.time())
+    unique_email = f"ms_new_user_{unique_id}@example.com"
+    mock_user = {
+        "microsoft_id": f"ms_new_{unique_id}",
+        "email": unique_email,
+        "name": "New Microsoft User",
+        "picture": None,
+    }
+
+    with patch("shu.api.auth._get_microsoft_user_info", _mock_microsoft_user_info(mock_user)):
+        with patch("shu.providers.microsoft.auth_adapter.MicrosoftAuthAdapter.exchange_code", _mock_microsoft_adapter()):
+            response = await client.post(
+                "/api/v1/auth/microsoft/exchange-login",
+                json={"code": "mock_auth_code"}
+            )
+
+    # New user should be created (may be inactive pending admin activation)
+    assert response.status_code in (200, 201), f"Unexpected status: {response.status_code}, body: {response.text}"
+    
+    if response.status_code == 200:
+        data = extract_data(response)
+        assert "access_token" in data, f"Missing access_token in response: {data}"
+        assert "refresh_token" in data, f"Missing refresh_token in response: {data}"
+        assert "user" in data, f"Missing user in response: {data}"
+        assert data["user"]["email"] == unique_email
+
+
+async def test_microsoft_exchange_login_existing_user(client, db, auth_headers):
+    """Test Microsoft SSO logs in an existing Microsoft user."""
+    unique_id = int(time.time())
+    unique_email = f"ms_existing_{unique_id}@example.com"
+    microsoft_id = f"ms_existing_id_{unique_id}"
+    
+    # Create user using ORM
+    user = await _create_user_with_orm(
+        db,
+        email=unique_email,
+        name="Existing MS User",
+        google_id=None,  # Microsoft users don't have google_id
+        auth_method="microsoft",
+        is_active=True,
+    )
+    
+    # Create provider identity
+    await _create_provider_identity(
+        db,
+        user_id=user.id,
+        provider_key="microsoft",
+        account_id=microsoft_id,
+        primary_email=unique_email,
+        display_name="Existing MS User",
+    )
+    
+    mock_user = {
+        "microsoft_id": microsoft_id,
+        "email": unique_email,
+        "name": "Existing MS User",
+        "picture": None,
+    }
+
+    with patch("shu.api.auth._get_microsoft_user_info", _mock_microsoft_user_info(mock_user)):
+        with patch("shu.providers.microsoft.auth_adapter.MicrosoftAuthAdapter.exchange_code", _mock_microsoft_adapter()):
+            response = await client.post(
+                "/api/v1/auth/microsoft/exchange-login",
+                json={"code": "mock_auth_code"}
+            )
+
+    assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
+    data = extract_data(response)
+    assert "access_token" in data
+    assert data["user"]["email"] == unique_email
+
+
+async def test_microsoft_exchange_login_links_to_existing_google_user(client, db, auth_headers):
+    """Test Microsoft SSO links to existing user with same email (e.g., Google user)."""
+    unique_id = int(time.time())
+    unique_email = f"ms_link_{unique_id}@example.com"
+    google_id = f"google_id_{unique_id}"
+    microsoft_id = f"ms_link_id_{unique_id}"
+    
+    # Create existing Google user using ORM
+    await _create_user_with_orm(
+        db,
+        email=unique_email,
+        name="Google User",
+        google_id=google_id,
+        auth_method="google",
+        is_active=True,
+    )
+    
+    mock_user = {
+        "microsoft_id": microsoft_id,
+        "email": unique_email,
+        "name": "Google User",
+        "picture": None,
+    }
+
+    with patch("shu.api.auth._get_microsoft_user_info", _mock_microsoft_user_info(mock_user)):
+        with patch("shu.providers.microsoft.auth_adapter.MicrosoftAuthAdapter.exchange_code", _mock_microsoft_adapter()):
+            response = await client.post(
+                "/api/v1/auth/microsoft/exchange-login",
+                json={"code": "mock_auth_code"}
+            )
+
+    assert response.status_code == 200, f"Unexpected status: {response.status_code}, body: {response.text}"
+    data = extract_data(response)
+    assert "access_token" in data
+    assert data["user"]["email"] == unique_email
+
+
+async def test_microsoft_exchange_login_password_conflict(client, db, auth_headers):
+    """Test Microsoft SSO returns 409 when user exists with password auth."""
+    unique_id = int(time.time())
+    unique_email = f"ms_pwd_conflict_{unique_id}@example.com"
+    
+    # Create existing password user using ORM
+    await _create_user_with_orm(
+        db,
+        email=unique_email,
+        name="Password User",
+        google_id=None,
+        auth_method="password",
+        is_active=True,
+        password_hash="fake_hash",
+    )
+    
+    mock_user = {
+        "microsoft_id": f"ms_pwd_{unique_id}",
+        "email": unique_email,
+        "name": "Password User",
+        "picture": None,
+    }
+
+    logger.info("=== EXPECTED TEST OUTPUT: 409 conflict error for password auth user is expected ===")
+
+    with patch("shu.api.auth._get_microsoft_user_info", _mock_microsoft_user_info(mock_user)):
+        with patch("shu.providers.microsoft.auth_adapter.MicrosoftAuthAdapter.exchange_code", _mock_microsoft_adapter()):
+            response = await client.post(
+                "/api/v1/auth/microsoft/exchange-login",
+                json={"code": "mock_auth_code"}
+            )
+
+    assert response.status_code == 409, f"Expected 409, got {response.status_code}, body: {response.text}"
+    logger.info("=== EXPECTED TEST OUTPUT: 409 conflict occurred as expected ===")
+
+
+async def test_microsoft_exchange_login_inactive_user(client, db, auth_headers):
+    """Test Microsoft SSO returns 400 when user account is inactive."""
+    unique_id = int(time.time())
+    unique_email = f"ms_inactive_{unique_id}@example.com"
+    microsoft_id = f"ms_inactive_id_{unique_id}"
+    
+    # Create inactive user with Microsoft identity using ORM
+    user = await _create_user_with_orm(
+        db,
+        email=unique_email,
+        name="Inactive MS User",
+        google_id=None,
+        auth_method="microsoft",
+        is_active=False,  # Inactive user
+    )
+    
+    # Create provider identity
+    await _create_provider_identity(
+        db,
+        user_id=user.id,
+        provider_key="microsoft",
+        account_id=microsoft_id,
+        primary_email=unique_email,
+        display_name="Inactive MS User",
+    )
+    
+    mock_user = {
+        "microsoft_id": microsoft_id,
+        "email": unique_email,
+        "name": "Inactive MS User",
+        "picture": None,
+    }
+
+    logger.info("=== EXPECTED TEST OUTPUT: 400 error for inactive user is expected ===")
+
+    with patch("shu.api.auth._get_microsoft_user_info", _mock_microsoft_user_info(mock_user)):
+        with patch("shu.providers.microsoft.auth_adapter.MicrosoftAuthAdapter.exchange_code", _mock_microsoft_adapter()):
+            response = await client.post(
+                "/api/v1/auth/microsoft/exchange-login",
+                json={"code": "mock_auth_code"}
+            )
+
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}, body: {response.text}"
+    logger.info("=== EXPECTED TEST OUTPUT: 400 error for inactive user occurred as expected ===")
+
+
+async def test_microsoft_exchange_login_missing_code(client, db, auth_headers):
+    """Test Microsoft SSO returns 422 when code is missing."""
+    logger.info("=== EXPECTED TEST OUTPUT: 422 validation error for missing code is expected ===")
+    
+    response = await client.post(
+        "/api/v1/auth/microsoft/exchange-login",
+        json={}
+    )
+
+    assert response.status_code == 422, f"Expected 422, got {response.status_code}, body: {response.text}"
+    logger.info("=== EXPECTED TEST OUTPUT: 422 validation error occurred as expected ===")
+
+
+class MicrosoftSSOTestSuite(BaseIntegrationTestSuite):
+    """Integration test suite for Microsoft SSO functionality."""
+    
+    def get_test_functions(self) -> List[Callable]:
+        """Return all Microsoft SSO test functions."""
+        return [
+            test_microsoft_login_endpoint_returns_redirect,
+            test_microsoft_exchange_login_new_user,
+            test_microsoft_exchange_login_existing_user,
+            test_microsoft_exchange_login_links_to_existing_google_user,
+            test_microsoft_exchange_login_password_conflict,
+            test_microsoft_exchange_login_inactive_user,
+            test_microsoft_exchange_login_missing_code,
+        ]
+    
+    def get_suite_name(self) -> str:
+        """Return the name of this test suite."""
+        return "Microsoft SSO Integration Tests"
+    
+    def get_suite_description(self) -> str:
+        """Return description of this test suite."""
+        return "End-to-end integration tests for Microsoft SSO authentication [SHU-500]"
+
+
+if __name__ == "__main__":
+    suite = MicrosoftSSOTestSuite()
+    exit_code = suite.run()
+    sys.exit(exit_code)

--- a/docs/onboarding/microsoft-365-oauth-setup.md
+++ b/docs/onboarding/microsoft-365-oauth-setup.md
@@ -1,85 +1,95 @@
-## Microsoft 365 OAuth Setup Guide (Shu Host Auth)
+# Microsoft 365 OAuth Setup Guide (Shu Host Auth)
 
 Implementation Status: Partial
+
 - User OAuth: Implemented via MicrosoftAuthAdapter (authorization code + refresh token)
 - Service account / Application permissions (client credentials): Not implemented
 - Delegation (domain-wide) equivalent: Not implemented (see "Is there a DWD equivalent?" below)
 
 Limitations / Known Issues
+
 - PKCE is not used currently; the adapter expects client secret on the backend
 - Identity upsert (ProviderIdentity) during exchange is only implemented for Google today; Microsoft identity is not yet persisted on connect
 - Teams/Chat compliance APIs and some application permissions require special Microsoft approval and are out of scope for this slice
 
 Security Notes
+
 - Keep client secret out of frontend; set only via environment variables
 - Request the minimum scopes necessary; tokens are stored encrypted via ProviderCredential
 
 ---
 
-### 1) Prerequisites
+## 1) Prerequisites
+
 - Azure AD/Entra admin or contributor with permission to register apps
 - Shu environment running with API reachable by your browser
 - The callback URI: Shu uses a **shared callback endpoint** for all OAuth providers at `/auth/callback` (public alias) or `/api/v1/host/auth/callback`. The provider is identified via the `state` parameter.
 
-Environment variables (set in .env):
-- MICROSOFT_CLIENT_ID
-- MICROSOFT_CLIENT_SECRET
-- OAUTH_REDIRECT_URI - Shared callback URL for all providers (e.g., http://localhost:8000/auth/callback)
-- MICROSOFT_TENANT_ID (optional; defaults to "common" for multi-tenant)
+Environment variables (set in `.env`):
 
-These map to src/shu/core/config.py settings: microsoft_client_id, microsoft_client_secret, oauth_redirect_uri, microsoft_tenant_id
+- `MICROSOFT_CLIENT_ID`
+- `MICROSOFT_CLIENT_SECRET`
+- `OAUTH_REDIRECT_URI` - Shared callback URL for all providers (e.g., `http://localhost:8000/auth/callback`)
+- `MICROSOFT_TENANT_ID` (optional; defaults to "common" for multi-tenant)
+
+These map to `src/shu/core/config.py` settings: `microsoft_client_id`, `microsoft_client_secret`, `oauth_redirect_uri`, `microsoft_tenant_id`
 
 Note: Shu uses a single provider-agnostic callback endpoint. The `OAUTH_REDIRECT_URI` setting is shared by all OAuth providers (Google, Microsoft, etc.). Legacy `GOOGLE_REDIRECT_URI` and `MICROSOFT_REDIRECT_URI` are still supported for backward compatibility but deprecated.
 
 ---
 
-### 2) Tenant Alignment (Azure Portal + Microsoft 365)
+## 2) Tenant Alignment (Azure Portal + Microsoft 365)
 
 The app registration must be in the **same Azure AD tenant** as your Microsoft 365 users, or configured as multi-tenant. This is a common issue when Azure Portal and M365 Admin Center are accessed with different accounts.
 
 **Check which tenant you're in:**
+
 - Azure Portal: Click your profile icon (top right) → "Switch directory" to see available tenants
 - M365 Admin Center: Settings → Org settings → Organization profile → Tenant ID
 
-**Option A: Register app in your M365 tenant (Recommended for single-tenant)**
+### Option A: Register app in your M365 tenant (Recommended for single-tenant)
 
 Your M365 subscription includes an Azure AD tenant. Use it:
+
 1. Sign into [Azure Portal](https://portal.azure.com) using your **M365 admin email**
 2. If prompted, create an Azure account with that email (no subscription needed for app registrations)
 3. Register the app there - it will be in the same tenant as your M365 users
 
-**Option B: Make your app multi-tenant**
+### Option B: Make your app multi-tenant
 
 If the app is in a different Azure tenant:
+
 1. Go to Azure Portal → App registrations → Your app → Authentication
 2. Under "Supported account types", select:
    - "Accounts in any organizational directory (Any Azure AD directory - Multitenant)"
 3. Save
-4. Set MICROSOFT_TENANT_ID to `common` (or leave unset)
+4. Set `MICROSOFT_TENANT_ID` to `common` (or leave unset)
 
-**Option C: Add your Azure account to M365 tenant**
+### Option C: Add your Azure account to M365 tenant
 
 1. In M365 Admin Center, add your Azure portal email as a user with Global Administrator role
 2. Now both portals are accessible from the same account
 
 ---
 
-### 3) Register an App in Azure Portal (Entra ID)
+## 3) Register an App in Azure Portal (Entra ID)
+
 1. Go to Azure Portal → Microsoft Entra ID → App registrations → New registration
 2. Name: Shu (local) or similar
 3. Supported account types:
-   - Single tenant: Users in your M365 tenant only (set MICROSOFT_TENANT_ID to your tenant ID)
-   - Multi-tenant: Users from any Azure AD tenant (set MICROSOFT_TENANT_ID to `common`)
-4. Redirect URI: Web → set to your MICROSOFT_REDIRECT_URI (e.g., http://localhost:8000/api/v1/host/auth/callback)
+   - Single tenant: Users in your M365 tenant only (set `MICROSOFT_TENANT_ID` to your tenant ID)
+   - Multi-tenant: Users from any Azure AD tenant (set `MICROSOFT_TENANT_ID` to `common`)
+4. Redirect URI: Web → set to your `OAUTH_REDIRECT_URI` (e.g., `http://localhost:8000/api/v1/host/auth/callback`)
 5. Register
 6. In the app:
-   - Certificates & secrets → Client secrets → New client secret → copy the value (set MICROSOFT_CLIENT_SECRET)
-   - Overview → Application (client) ID → set MICROSOFT_CLIENT_ID
-   - If single tenant, Directory (tenant) ID → set MICROSOFT_TENANT_ID
+   - Certificates & secrets → Client secrets → New client secret → copy the value (set `MICROSOFT_CLIENT_SECRET`)
+   - Overview → Application (client) ID → set `MICROSOFT_CLIENT_ID`
+   - If single tenant, Directory (tenant) ID → set `MICROSOFT_TENANT_ID`
 
 ---
 
-### 4) Configure API Permissions (Scopes)
+## 4) Configure API Permissions (Scopes)
+
 - Go to API permissions → Add a permission → Microsoft Graph → Delegated permissions
 - Add only what you need, e.g.:
   - Mail.Read, Mail.ReadBasic (Gmail analog)
@@ -89,36 +99,40 @@ If the app is in a different Azure tenant:
 - Click "Grant admin consent" for your tenant if your organization requires admin consent
 
 Notes
+
 - The adapter will include offline_access automatically during both authorize and exchange
 - Scopes requested by Shu must also be enabled/consented in the app registration; insufficient consent will cause exchange to fail or later API calls to be unauthorized
 
 ---
 
-### 5) Wire Shu Environment
+## 5) Wire Shu Environment
+
 Set the env vars and restart Shu so settings load:
-- MICROSOFT_CLIENT_ID
-- MICROSOFT_CLIENT_SECRET
-- MICROSOFT_REDIRECT_URI (must match exactly the URI configured in Azure)
-- MICROSOFT_TENANT_ID (or leave unset to use common)
+
+- `MICROSOFT_CLIENT_ID`
+- `MICROSOFT_CLIENT_SECRET`
+- `OAUTH_REDIRECT_URI` (must match exactly the URI configured in Azure)
+- `MICROSOFT_TENANT_ID` (or leave unset to use common)
 
 ---
 
-### 6) Connect a Microsoft Account (User OAuth)
+## 6) Connect a Microsoft Account (User OAuth)
+
 You can use the Connected Accounts UI (preferred), or call the Host Auth endpoints directly.
 
 API flow
+
 1. Build authorization URL
-   - GET /api/v1/host/auth/authorize?provider=microsoft&scopes=scope1,scope2
+   - GET `/api/v1/host/auth/authorize?provider=microsoft&scopes=scope1,scope2`
    - Example scopes: Files.Read,Mail.Read,offline_access (offline_access will be added automatically if omitted)
-2. Browser completes consent and is redirected to MICROSOFT_REDIRECT_URI (/api/v1/host/auth/callback)
+2. Browser completes consent and is redirected to `OAUTH_REDIRECT_URI` (`/api/v1/host/auth/callback`)
 3. Exchange the code
-   - POST /api/v1/host/auth/exchange with JSON:
-     {"provider":"microsoft","code":"<code>","scopes":["Files.Read","Mail.Read"]}
+   - POST `/api/v1/host/auth/exchange` with JSON:
+     `{"provider":"microsoft","code":"<code>","scopes":["Files.Read","Mail.Read"]}`
 
 Quick curl examples
 
-<augment_code_snippet mode="EXCERPT">
-````bash
+```bash
 # 1) Get authorization URL (open in browser)
 curl -s "http://localhost:8000/api/v1/host/auth/authorize?provider=microsoft&scopes=Files.Read,Mail.Read" -H "Authorization: Bearer <your_api_token>"
 
@@ -129,55 +143,61 @@ curl -s -X POST http://localhost:8000/api/v1/host/auth/exchange \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your_api_token>" \
   -d '{"provider":"microsoft","code":"<paste-code>","scopes":["Files.Read","Mail.Read"]}'
-````
-</augment_code_snippet>
+```
 
 Verification
-- GET /api/v1/host/auth/status?providers=microsoft returns
-  { "microsoft": { "user_connected": true|false, "granted_scopes": ["..."] } }
+
+- GET `/api/v1/host/auth/status?providers=microsoft` returns
+  `{ "microsoft": { "user_connected": true|false, "granted_scopes": ["..."] } }`
 
 ---
 
-### 7) Using the Token in Plugins
+## 7) Using the Token in Plugins
+
 - Plugins should declare per-operation auth in manifest (op_auth) and use host.auth at runtime
 - host.auth will obtain a Microsoft access token (refresh if needed) when provider=microsoft and auth_mode=user
 - If required scopes are not a subset of the connected grant, token resolution returns None and the call should surface an auth error
 
 ---
 
-### 8) Is there a Google DWD equivalent for Microsoft?
+## 8) Is there a Google DWD equivalent for Microsoft?
+
 Conceptual equivalent: Application permissions (app-only) using the OAuth 2.0 client credentials grant
+
 - Instead of a user delegating consent, the app itself is granted tenant-wide permissions by an admin
 - Examples: Mail.Read (application), Files.Read.All (application), Sites.Read.All (application)
 - Exchange Online may additionally require Application Access Policies to scope app access to specific mailboxes
 - Some Teams/Chat and compliance endpoints require special Microsoft approval
 
 Current status in Shu
+
 - Not implemented in MicrosoftAuthAdapter
-- service_account_token() and delegation_check() raise/return not implemented
+- `service_account_token()` and `delegation_check()` raise/return not implemented
 - To support app-only in the future we would:
-  - Add client credentials flow in the adapter using MICROSOFT_CLIENT_ID/SECRET and tenant
+  - Add client credentials flow in the adapter using `MICROSOFT_CLIENT_ID`/`SECRET` and tenant
   - Allow plugins to request auth_mode=service_account or domain_delegate analog where appropriate
   - Provide readiness checks similar to Google (but Microsoft has no direct delegation check endpoint; readiness is validated by obtaining an app-only token and probing a minimal Graph call)
 
 Recommendation for now
+
 - Use User OAuth for Microsoft integrations in this delivery slice
 - For org-wide ingestion requirements, plan a separate task to add application permissions support; ensure admin consent and mailbox scoping policies are addressed
 
 ---
 
-### 9) Troubleshooting
-- invalid_client or unauthorized_client during exchange: verify MICROSOFT_CLIENT_ID/SECRET/REDIRECT_URI match the app registration and tenant
+## 9) Troubleshooting
+
+- `invalid_client` or `unauthorized_client` during exchange: verify `MICROSOFT_CLIENT_ID`/`SECRET`/`OAUTH_REDIRECT_URI` match the app registration and tenant
 - AADSTS50020 (user account does not exist in tenant): app is single-tenant but user is from a different tenant; either register the app in the user's M365 tenant or make the app multi-tenant (see section 2)
 - AADSTS65001 (consent required): grant admin consent for requested scopes in Azure Portal or have the user consent if allowed
-- AADSTS700016 (application not found): the app registration is in a different tenant than expected; check MICROSOFT_TENANT_ID matches where the app is registered
+- AADSTS700016 (application not found): the app registration is in a different tenant than expected; check `MICROSOFT_TENANT_ID` matches where the app is registered
 - Token returned but API 403: the scope is missing or the API requires application permission instead of delegated; adjust scopes and/or app permission type
 - Callback mismatch: the redirect URI must exactly match the configured value (including path)
 
 ---
 
-### 10) References
-- Microsoft identity platform OAuth 2.0 authorization code flow (v2.0)
-- Microsoft Graph permissions reference
-- Application access policies for Exchange Online
+## 10) References
 
+- [Microsoft identity platform OAuth 2.0 authorization code flow (v2.0)](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+- [Microsoft Graph permissions reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
+- [Application access policies for Exchange Online](https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access)

--- a/docs/onboarding/microsoft-365-oauth-setup.md
+++ b/docs/onboarding/microsoft-365-oauth-setup.md
@@ -1,0 +1,183 @@
+## Microsoft 365 OAuth Setup Guide (Shu Host Auth)
+
+Implementation Status: Partial
+- User OAuth: Implemented via MicrosoftAuthAdapter (authorization code + refresh token)
+- Service account / Application permissions (client credentials): Not implemented
+- Delegation (domain-wide) equivalent: Not implemented (see "Is there a DWD equivalent?" below)
+
+Limitations / Known Issues
+- PKCE is not used currently; the adapter expects client secret on the backend
+- Identity upsert (ProviderIdentity) during exchange is only implemented for Google today; Microsoft identity is not yet persisted on connect
+- Teams/Chat compliance APIs and some application permissions require special Microsoft approval and are out of scope for this slice
+
+Security Notes
+- Keep client secret out of frontend; set only via environment variables
+- Request the minimum scopes necessary; tokens are stored encrypted via ProviderCredential
+
+---
+
+### 1) Prerequisites
+- Azure AD/Entra admin or contributor with permission to register apps
+- Shu environment running with API reachable by your browser
+- The callback URI: Shu uses a **shared callback endpoint** for all OAuth providers at `/auth/callback` (public alias) or `/api/v1/host/auth/callback`. The provider is identified via the `state` parameter.
+
+Environment variables (set in .env):
+- MICROSOFT_CLIENT_ID
+- MICROSOFT_CLIENT_SECRET
+- OAUTH_REDIRECT_URI - Shared callback URL for all providers (e.g., http://localhost:8000/auth/callback)
+- MICROSOFT_TENANT_ID (optional; defaults to "common" for multi-tenant)
+
+These map to src/shu/core/config.py settings: microsoft_client_id, microsoft_client_secret, oauth_redirect_uri, microsoft_tenant_id
+
+Note: Shu uses a single provider-agnostic callback endpoint. The `OAUTH_REDIRECT_URI` setting is shared by all OAuth providers (Google, Microsoft, etc.). Legacy `GOOGLE_REDIRECT_URI` and `MICROSOFT_REDIRECT_URI` are still supported for backward compatibility but deprecated.
+
+---
+
+### 2) Tenant Alignment (Azure Portal + Microsoft 365)
+
+The app registration must be in the **same Azure AD tenant** as your Microsoft 365 users, or configured as multi-tenant. This is a common issue when Azure Portal and M365 Admin Center are accessed with different accounts.
+
+**Check which tenant you're in:**
+- Azure Portal: Click your profile icon (top right) → "Switch directory" to see available tenants
+- M365 Admin Center: Settings → Org settings → Organization profile → Tenant ID
+
+**Option A: Register app in your M365 tenant (Recommended for single-tenant)**
+
+Your M365 subscription includes an Azure AD tenant. Use it:
+1. Sign into [Azure Portal](https://portal.azure.com) using your **M365 admin email**
+2. If prompted, create an Azure account with that email (no subscription needed for app registrations)
+3. Register the app there - it will be in the same tenant as your M365 users
+
+**Option B: Make your app multi-tenant**
+
+If the app is in a different Azure tenant:
+1. Go to Azure Portal → App registrations → Your app → Authentication
+2. Under "Supported account types", select:
+   - "Accounts in any organizational directory (Any Azure AD directory - Multitenant)"
+3. Save
+4. Set MICROSOFT_TENANT_ID to `common` (or leave unset)
+
+**Option C: Add your Azure account to M365 tenant**
+
+1. In M365 Admin Center, add your Azure portal email as a user with Global Administrator role
+2. Now both portals are accessible from the same account
+
+---
+
+### 3) Register an App in Azure Portal (Entra ID)
+1. Go to Azure Portal → Microsoft Entra ID → App registrations → New registration
+2. Name: Shu (local) or similar
+3. Supported account types:
+   - Single tenant: Users in your M365 tenant only (set MICROSOFT_TENANT_ID to your tenant ID)
+   - Multi-tenant: Users from any Azure AD tenant (set MICROSOFT_TENANT_ID to `common`)
+4. Redirect URI: Web → set to your MICROSOFT_REDIRECT_URI (e.g., http://localhost:8000/api/v1/host/auth/callback)
+5. Register
+6. In the app:
+   - Certificates & secrets → Client secrets → New client secret → copy the value (set MICROSOFT_CLIENT_SECRET)
+   - Overview → Application (client) ID → set MICROSOFT_CLIENT_ID
+   - If single tenant, Directory (tenant) ID → set MICROSOFT_TENANT_ID
+
+---
+
+### 4) Configure API Permissions (Scopes)
+- Go to API permissions → Add a permission → Microsoft Graph → Delegated permissions
+- Add only what you need, e.g.:
+  - Mail.Read, Mail.ReadBasic (Gmail analog)
+  - Files.Read, Files.Read.All, Sites.Read.All (OneDrive/SharePoint)
+  - Calendars.Read (Calendar)
+  - offline_access (required for refresh tokens; also added automatically by Shu)
+- Click "Grant admin consent" for your tenant if your organization requires admin consent
+
+Notes
+- The adapter will include offline_access automatically during both authorize and exchange
+- Scopes requested by Shu must also be enabled/consented in the app registration; insufficient consent will cause exchange to fail or later API calls to be unauthorized
+
+---
+
+### 5) Wire Shu Environment
+Set the env vars and restart Shu so settings load:
+- MICROSOFT_CLIENT_ID
+- MICROSOFT_CLIENT_SECRET
+- MICROSOFT_REDIRECT_URI (must match exactly the URI configured in Azure)
+- MICROSOFT_TENANT_ID (or leave unset to use common)
+
+---
+
+### 6) Connect a Microsoft Account (User OAuth)
+You can use the Connected Accounts UI (preferred), or call the Host Auth endpoints directly.
+
+API flow
+1. Build authorization URL
+   - GET /api/v1/host/auth/authorize?provider=microsoft&scopes=scope1,scope2
+   - Example scopes: Files.Read,Mail.Read,offline_access (offline_access will be added automatically if omitted)
+2. Browser completes consent and is redirected to MICROSOFT_REDIRECT_URI (/api/v1/host/auth/callback)
+3. Exchange the code
+   - POST /api/v1/host/auth/exchange with JSON:
+     {"provider":"microsoft","code":"<code>","scopes":["Files.Read","Mail.Read"]}
+
+Quick curl examples
+
+<augment_code_snippet mode="EXCERPT">
+````bash
+# 1) Get authorization URL (open in browser)
+curl -s "http://localhost:8000/api/v1/host/auth/authorize?provider=microsoft&scopes=Files.Read,Mail.Read" -H "Authorization: Bearer <your_api_token>"
+
+# After completing consent in browser, capture `code` from the redirect handler (the UI handles this for you).
+
+# 2) Exchange code for tokens
+curl -s -X POST http://localhost:8000/api/v1/host/auth/exchange \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your_api_token>" \
+  -d '{"provider":"microsoft","code":"<paste-code>","scopes":["Files.Read","Mail.Read"]}'
+````
+</augment_code_snippet>
+
+Verification
+- GET /api/v1/host/auth/status?providers=microsoft returns
+  { "microsoft": { "user_connected": true|false, "granted_scopes": ["..."] } }
+
+---
+
+### 7) Using the Token in Plugins
+- Plugins should declare per-operation auth in manifest (op_auth) and use host.auth at runtime
+- host.auth will obtain a Microsoft access token (refresh if needed) when provider=microsoft and auth_mode=user
+- If required scopes are not a subset of the connected grant, token resolution returns None and the call should surface an auth error
+
+---
+
+### 8) Is there a Google DWD equivalent for Microsoft?
+Conceptual equivalent: Application permissions (app-only) using the OAuth 2.0 client credentials grant
+- Instead of a user delegating consent, the app itself is granted tenant-wide permissions by an admin
+- Examples: Mail.Read (application), Files.Read.All (application), Sites.Read.All (application)
+- Exchange Online may additionally require Application Access Policies to scope app access to specific mailboxes
+- Some Teams/Chat and compliance endpoints require special Microsoft approval
+
+Current status in Shu
+- Not implemented in MicrosoftAuthAdapter
+- service_account_token() and delegation_check() raise/return not implemented
+- To support app-only in the future we would:
+  - Add client credentials flow in the adapter using MICROSOFT_CLIENT_ID/SECRET and tenant
+  - Allow plugins to request auth_mode=service_account or domain_delegate analog where appropriate
+  - Provide readiness checks similar to Google (but Microsoft has no direct delegation check endpoint; readiness is validated by obtaining an app-only token and probing a minimal Graph call)
+
+Recommendation for now
+- Use User OAuth for Microsoft integrations in this delivery slice
+- For org-wide ingestion requirements, plan a separate task to add application permissions support; ensure admin consent and mailbox scoping policies are addressed
+
+---
+
+### 9) Troubleshooting
+- invalid_client or unauthorized_client during exchange: verify MICROSOFT_CLIENT_ID/SECRET/REDIRECT_URI match the app registration and tenant
+- AADSTS50020 (user account does not exist in tenant): app is single-tenant but user is from a different tenant; either register the app in the user's M365 tenant or make the app multi-tenant (see section 2)
+- AADSTS65001 (consent required): grant admin consent for requested scopes in Azure Portal or have the user consent if allowed
+- AADSTS700016 (application not found): the app registration is in a different tenant than expected; check MICROSOFT_TENANT_ID matches where the app is registered
+- Token returned but API 403: the scope is missing or the API requires application permission instead of delegated; adjust scopes and/or app permission type
+- Callback mismatch: the redirect URI must exactly match the configured value (including path)
+
+---
+
+### 10) References
+- Microsoft identity platform OAuth 2.0 authorization code flow (v2.0)
+- Microsoft Graph permissions reference
+- Application access policies for Exchange Online
+

--- a/frontend/public/ms-symbollockup_mssymbol_19.svg
+++ b/frontend/public/ms-symbollockup_mssymbol_19.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21"><title>MS-SymbolLockup</title><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>

--- a/frontend/src/components/AuthPage.js
+++ b/frontend/src/components/AuthPage.js
@@ -7,6 +7,7 @@ import configService from '../services/config';
 const AuthPage = () => {
   const [authMode, setAuthMode] = useState('password'); // 'google', 'password', 'register'
   const [googleSsoEnabled, setGoogleSsoEnabled] = useState(false);
+  const [microsoftSsoEnabled, setMicrosoftSsoEnabled] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -16,9 +17,11 @@ const AuthPage = () => {
         await configService.fetchConfig();
         if (!isMounted) return;
         setGoogleSsoEnabled(configService.isGoogleSsoEnabled());
+        setMicrosoftSsoEnabled(configService.isMicrosoftSsoEnabled());
       } catch (error) {
         if (!isMounted) return;
         setGoogleSsoEnabled(false);
+        setMicrosoftSsoEnabled(false);
       }
     };
 
@@ -55,6 +58,7 @@ const AuthPage = () => {
             onSwitchToRegister={handleSwitchToRegister}
             onSwitchToGoogle={handleSwitchToGoogle}
             isGoogleSsoEnabled={googleSsoEnabled}
+            isMicrosoftSsoEnabled={microsoftSsoEnabled}
           />
         );
     case 'register':
@@ -66,6 +70,7 @@ const AuthPage = () => {
           onSwitchToRegister={handleSwitchToRegister}
           onSwitchToGoogle={handleSwitchToGoogle}
           isGoogleSsoEnabled={googleSsoEnabled}
+          isMicrosoftSsoEnabled={microsoftSsoEnabled}
         />
       );
   }

--- a/frontend/src/components/PasswordLogin.js
+++ b/frontend/src/components/PasswordLogin.js
@@ -17,14 +17,16 @@ import { useTheme as useAppTheme } from '../contexts/ThemeContext';
 import { getBrandingAppName } from '../utils/constants';
 import { useMicrosoftOAuth } from '../hooks/useMicrosoftOAuth';
 
-// Microsoft icon SVG component
+// Microsoft logo - using official asset from Microsoft identity platform branding guidelines
+// https://learn.microsoft.com/en-us/entra/identity-platform/howto-add-branding-in-apps
 const MicrosoftIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg">
-    <rect x="1" y="1" width="9" height="9" fill="#f25022"/>
-    <rect x="11" y="1" width="9" height="9" fill="#7fba00"/>
-    <rect x="1" y="11" width="9" height="9" fill="#00a4ef"/>
-    <rect x="11" y="11" width="9" height="9" fill="#ffb900"/>
-  </svg>
+  <img 
+    src="/ms-symbollockup_mssymbol_19.svg" 
+    alt="" 
+    width="20" 
+    height="20" 
+    style={{ display: 'block' }}
+  />
 );
 
 const PasswordLogin = ({ 

--- a/frontend/src/components/PasswordLogin.js
+++ b/frontend/src/components/PasswordLogin.js
@@ -15,25 +15,61 @@ import GoogleIcon from '@mui/icons-material/Google';
 import api, { extractDataFromResponse } from '../services/api';
 import { useTheme as useAppTheme } from '../contexts/ThemeContext';
 import { getBrandingAppName } from '../utils/constants';
+import { useMicrosoftOAuth } from '../hooks/useMicrosoftOAuth';
 
-const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnabled = false }) => {
+// Microsoft icon SVG component
+const MicrosoftIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1" y="1" width="9" height="9" fill="#f25022"/>
+    <rect x="11" y="1" width="9" height="9" fill="#7fba00"/>
+    <rect x="1" y="11" width="9" height="9" fill="#00a4ef"/>
+    <rect x="11" y="11" width="9" height="9" fill="#ffb900"/>
+  </svg>
+);
+
+const PasswordLogin = ({ 
+  onSwitchToRegister, 
+  onSwitchToGoogle, 
+  isGoogleSsoEnabled = false,
+  isMicrosoftSsoEnabled = false,
+}) => {
   const [formData, setFormData] = useState({
     email: '',
     password: ''
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
   const { branding } = useAppTheme();
   const appDisplayName = getBrandingAppName(branding);
   const logoUrl = branding?.logoUrl;
+
+  // Microsoft OAuth hook
+  const { startLogin: startMicrosoftLogin, loading: microsoftLoading } = useMicrosoftOAuth({
+    onSuccess: ({ accessToken, refreshToken }) => {
+      localStorage.setItem('shu_token', accessToken);
+      if (refreshToken) {
+        localStorage.setItem('shu_refresh_token', refreshToken);
+      }
+      window.location.href = '/';
+    },
+    onError: (errorMessage) => {
+      setError(errorMessage);
+    },
+    onPendingActivation: () => {
+      setSuccessMessage(
+        'Your account has been created but requires administrator activation before you can sign in.'
+      );
+    },
+  });
 
   const handleChange = (e) => {
     setFormData({
       ...formData,
       [e.target.name]: e.target.value
     });
-    // Clear error when user starts typing
     if (error) setError(null);
+    if (successMessage) setSuccessMessage(null);
   };
 
   const validateForm = () => {
@@ -60,9 +96,9 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
 
     setLoading(true);
     setError(null);
+    setSuccessMessage(null);
 
     try {
-      // Login with password
       const response = await api.post('/auth/login/password', {
         email: formData.email,
         password: formData.password
@@ -71,11 +107,9 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
       const responseData = extractDataFromResponse(response);
       const { access_token, refresh_token } = responseData;
 
-      // Store tokens
       localStorage.setItem('shu_token', access_token);
       localStorage.setItem('shu_refresh_token', refresh_token);
 
-      // Redirect to main app (the auth wrapper will handle the redirect)
       window.location.href = '/';
 
     } catch (err) {
@@ -87,6 +121,14 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
       setLoading(false);
     }
   };
+
+  const handleMicrosoftLogin = () => {
+    setError(null);
+    setSuccessMessage(null);
+    startMicrosoftLogin();
+  };
+
+  const isAnyLoading = loading || microsoftLoading;
 
   return (
     <Container maxWidth="sm">
@@ -104,9 +146,9 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
               src={logoUrl}
               alt={appDisplayName}
               style={{
-                height: '60px', // Fixed height for normal proportions
-                width: 'auto', // Maintain aspect ratio
-                maxWidth: '100%', // Don't exceed container width
+                height: '60px',
+                width: 'auto',
+                maxWidth: '100%',
                 marginBottom: '1rem',
               }}
             />
@@ -124,6 +166,12 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
             </Alert>
           )}
 
+          {successMessage && (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              {successMessage}
+            </Alert>
+          )}
+
           <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1 }}>
             <TextField
               margin="normal"
@@ -137,7 +185,7 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
               type="email"
               value={formData.email}
               onChange={handleChange}
-              disabled={loading}
+              disabled={isAnyLoading}
             />
             
             <TextField
@@ -151,7 +199,7 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
               autoComplete="current-password"
               value={formData.password}
               onChange={handleChange}
-              disabled={loading}
+              disabled={isAnyLoading}
             />
 
             <Button
@@ -160,7 +208,7 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
               variant="contained"
               size="large"
               startIcon={loading ? <CircularProgress size={20} /> : <LoginIcon />}
-              disabled={loading}
+              disabled={isAnyLoading}
               sx={{ mt: 3, mb: 2, py: 1.5 }}
             >
               {loading ? 'Signing in...' : 'Sign In'}
@@ -180,10 +228,34 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
                   size="large"
                   startIcon={<GoogleIcon />}
                   onClick={onSwitchToGoogle}
-                  disabled={loading}
+                  disabled={isAnyLoading}
                   sx={{ mb: 2, py: 1.5 }}
                 >
                   Sign in with Google
+                </Button>
+              </>
+            )}
+
+            {isMicrosoftSsoEnabled && (
+              <>
+                {!isGoogleSsoEnabled && (
+                  <Divider sx={{ my: 2 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      OR
+                    </Typography>
+                  </Divider>
+                )}
+
+                <Button
+                  fullWidth
+                  variant="outlined"
+                  size="large"
+                  startIcon={microsoftLoading ? <CircularProgress size={20} /> : <MicrosoftIcon />}
+                  onClick={handleMicrosoftLogin}
+                  disabled={isAnyLoading}
+                  sx={{ mb: 2, py: 1.5 }}
+                >
+                  {microsoftLoading ? 'Signing in...' : 'Sign in with Microsoft'}
                 </Button>
               </>
             )}
@@ -192,7 +264,7 @@ const PasswordLogin = ({ onSwitchToRegister, onSwitchToGoogle, isGoogleSsoEnable
               <Button
                 variant="text"
                 onClick={onSwitchToRegister}
-                disabled={loading}
+                disabled={isAnyLoading}
               >
                 Don't have an account? Register
               </Button>

--- a/frontend/src/hooks/useMicrosoftOAuth.js
+++ b/frontend/src/hooks/useMicrosoftOAuth.js
@@ -1,0 +1,151 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { authAPI, extractDataFromResponse } from '../services/api';
+import { getApiV1Base } from '../services/baseUrl';
+import { log } from '../utils/log';
+
+// OAuth popup timeout in milliseconds (3 minutes)
+const OAUTH_POPUP_TIMEOUT_MS = 180000;
+
+/**
+ * Custom hook for Microsoft OAuth popup authentication flow.
+ * 
+ * @param {Object} options
+ * @param {Function} options.onSuccess - Called with tokens on successful login
+ * @param {Function} options.onError - Called with error message on failure
+ * @param {Function} options.onPendingActivation - Called when account needs admin activation
+ * @returns {Object} { startLogin, loading }
+ */
+export function useMicrosoftOAuth({ onSuccess, onError, onPendingActivation }) {
+  const [loading, setLoading] = useState(false);
+  
+  // Refs for popup and listener management
+  const messageHandlerRef = useRef(null);
+  const timeoutRef = useRef(null);
+  const popupRef = useRef(null);
+
+  // Cleanup function
+  const cleanup = useCallback(() => {
+    if (messageHandlerRef.current) {
+      window.removeEventListener('message', messageHandlerRef.current);
+      messageHandlerRef.current = null;
+    }
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    try {
+      if (popupRef.current) {
+        popupRef.current.close();
+      }
+    } catch (_) {
+      // Ignore errors closing popup
+    }
+    popupRef.current = null;
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return cleanup;
+  }, [cleanup]);
+
+  const startLogin = useCallback(async () => {
+    setLoading(true);
+    
+    try {
+      const url = `${getApiV1Base()}/auth/microsoft/login`;
+      const popup = window.open(
+        url,
+        'shu-microsoft-oauth',
+        'width=500,height=650,menubar=no,toolbar=no,location=no,status=no'
+      );
+
+      popupRef.current = popup || null;
+
+      if (!popup) {
+        // Popup blocked - fallback to top-level redirect
+        log.info('Microsoft OAuth popup blocked, falling back to redirect');
+        window.location.href = url;
+        return;
+      }
+
+      const expectedOrigin = new URL(getApiV1Base()).origin;
+
+      const onMessage = async (event) => {
+        try {
+          if (event.origin !== expectedOrigin) return;
+          const data = event.data || {};
+          if (!data || !data.code || data.provider !== 'microsoft') return;
+
+          // Cleanup listener/timeout and close popup
+          cleanup();
+
+          const resp = await authAPI.exchangeMicrosoftLogin(data.code);
+          const payload = extractDataFromResponse(resp);
+          
+          // Check for pending activation (201 response without tokens)
+          if (!payload || !payload.access_token) {
+            log.info('Microsoft OAuth: account pending activation');
+            if (onPendingActivation) {
+              onPendingActivation();
+            }
+            setLoading(false);
+            return;
+          }
+
+          // Success - call onSuccess with tokens
+          log.info('Microsoft OAuth: login successful');
+          if (onSuccess) {
+            onSuccess({
+              accessToken: payload.access_token,
+              refreshToken: payload.refresh_token,
+              user: payload.user,
+            });
+          }
+          setLoading(false);
+        } catch (ex) {
+          // Check if this is a 201 pending activation response
+          if (ex.response?.status === 201) {
+            log.info('Microsoft OAuth: account pending activation (201 response)');
+            if (onPendingActivation) {
+              onPendingActivation();
+            }
+            setLoading(false);
+            return;
+          }
+          
+          const errorMessage = ex.response?.data?.detail || ex.message || 'Microsoft login failed';
+          log.error('Microsoft OAuth exchange failed', { error: errorMessage });
+          if (onError) {
+            onError(errorMessage);
+          }
+          setLoading(false);
+        }
+      };
+
+      messageHandlerRef.current = onMessage;
+      window.addEventListener('message', onMessage);
+
+      // Timeout after configured duration
+      timeoutRef.current = setTimeout(() => {
+        cleanup();
+        setLoading(false);
+        log.warn('Microsoft OAuth popup timed out');
+        if (onError) {
+          onError('Login window timed out. Please try again.');
+        }
+      }, OAUTH_POPUP_TIMEOUT_MS);
+      
+    } catch (err) {
+      const errorMessage = err.message || 'Failed to start Microsoft login';
+      log.error('Microsoft OAuth start failed', { error: errorMessage });
+      if (onError) {
+        onError(errorMessage);
+      }
+      setLoading(false);
+    }
+  }, [cleanup, onSuccess, onError, onPendingActivation]);
+
+  return { startLogin, loading };
+}
+
+export default useMicrosoftOAuth;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -244,6 +244,7 @@ export const authAPI = {
   deactivateUser: (userId) => api.patch(`/auth/users/${userId}/deactivate`),
 
   exchangeGoogleLogin: (code) => api.post('/auth/google/exchange-login', { code }),
+  exchangeMicrosoftLogin: (code) => api.post('/auth/microsoft/exchange-login', { code }),
 };
 
 // Health endpoints

--- a/frontend/src/services/config.js
+++ b/frontend/src/services/config.js
@@ -76,6 +76,15 @@ class ConfigService {
     return typeof clientId === 'string' && clientId.trim().length > 0;
   }
 
+  getMicrosoftClientId() {
+    return this.config?.microsoft_client_id;
+  }
+
+  isMicrosoftSsoEnabled() {
+    const clientId = this.getMicrosoftClientId();
+    return typeof clientId === 'string' && clientId.trim().length > 0;
+  }
+
   getAppName() {
     // Fallback to backend default to avoid stale hardcoding
     return this.config?.app_name || 'Shu';


### PR DESCRIPTION
- Add unified OAUTH_REDIRECT_URI config with backward compatibility for legacy settings
- Add _get_microsoft_user_info() function to fetch user profile from Microsoft Graph API
- Add /auth/microsoft/login endpoint for OAuth redirect
- Add /auth/microsoft/exchange-login endpoint for code exchange and JWT issuance
- Add UserService.authenticate_or_create_microsoft_user() with ProviderIdentity support
- Update Google and Microsoft auth adapters to use unified redirect URI

NOTE: There is a plan to refactor SSO authentication to move provider-specific user info retrieval from `auth.py` into the provider adapters, making the auth router truly provider-agnostic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft OAuth single sign-on added alongside Google and password auth; provider identities can be linked.

* **Frontend**
  * Login UI now shows Microsoft sign-in, unified loading state, pending-activation feedback, and popup-based OAuth flow.

* **Backend**
  * Microsoft SSO endpoints and user linking/creation flows; unified OAuth redirect URI across providers.

* **Configuration**
  * Public config exposes Microsoft client ID and OAUTH_REDIRECT_URI support.

* **Documentation**
  * Added Microsoft 365 OAuth setup guide.

* **Tests**
  * Integration tests for Microsoft SSO flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->