### PR TITLE
Auto activate users when they sign-up (no longer requires admin activation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,6 +213,11 @@ REACT_APP_CONVERSATION_LIST_LIMIT=50
 # The first user to log in will automatically be made an admin regardless of this list
 ADMIN_EMAILS=["admin@yourcompany.com","another-admin@yourcompany.com"]
 
+# Auto-activate new users on first SSO login (default: false)
+# WARNING: Only enable in trusted environments (internal teams, dev setups).
+# When false, new non-admin users require manual admin activation.
+SHU_AUTO_ACTIVATE_USERS=false
+
 # Global API key (Tier 0) for service-to-service access
 SHU_API_KEY=""
 # When using SHU_API_KEY, map it to this user's email for RBAC context

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -84,6 +84,10 @@ class Settings(BaseSettings):
     # Admin configuration
     admin_emails: list[str] = Field(default_factory=list, alias="ADMIN_EMAILS")
 
+    # Auto-activate new users on first SSO login (default: false)
+    # When true, new non-admin users are immediately active without admin approval.
+    auto_activate_users: bool = Field(False, alias="SHU_AUTO_ACTIVATE_USERS")
+
     # Embedding configuration
     default_embedding_model: str = Field("sentence-transformers/all-MiniLM-L6-v2", alias="SHU_EMBEDDING_MODEL")
     embedding_device: str = "cpu"

--- a/backend/src/shu/services/experience_executor.py
+++ b/backend/src/shu/services/experience_executor.py
@@ -291,6 +291,7 @@ class ExperienceExecutor:
 
         # Consume events - timeout is enforced within execute_streaming
         async for event in self.execute_streaming(experience, user_id, input_params, current_user, run_id=run_id):
+        async for event in self.execute_streaming(experience, user_id, input_params, current_user, run_id=run_id):
             if event.type == ExperienceEventType.RUN_STARTED:
                 run_id = event.data.get("run_id")
                 if run_id:

--- a/backend/src/shu/services/user_service.py
+++ b/backend/src/shu/services/user_service.py
@@ -128,7 +128,7 @@ class UserService:
         return result.scalar_one_or_none() is None
 
     def is_active(self, user_role: UserRole, is_first_user: bool) -> bool:
-        return is_first_user or user_role == UserRole.ADMIN
+        return is_first_user or user_role == UserRole.ADMIN or self.settings.auto_activate_users
 
     async def get_user_auth_method(self, db: AsyncSession, email: str) -> str | None:
         auth_method_result = await db.execute(select(User.auth_method).where(func.lower(User.email) == email.lower()))

--- a/backend/src/tests/unit/services/test_user_service.py
+++ b/backend/src/tests/unit/services/test_user_service.py
@@ -1,0 +1,47 @@
+"""Unit tests for UserService.is_active() with auto_activate_users setting."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shu.auth.models import UserRole
+from shu.services.user_service import UserService
+
+
+class TestIsActive:
+    """Tests for UserService.is_active() covering auto_activate_users combinations."""
+
+    @pytest.fixture
+    def user_service(self):
+        service = UserService()
+        service.settings = MagicMock()
+        service.settings.auto_activate_users = False
+        service.settings.admin_emails = []
+        return service
+
+    def test_first_user_always_active(self, user_service):
+        """First user is always active regardless of role or auto_activate setting."""
+        assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=True) is True
+
+    def test_admin_always_active(self, user_service):
+        """Admin users are always active regardless of auto_activate setting."""
+        assert user_service.is_active(UserRole.ADMIN, is_first_user=False) is True
+
+    def test_regular_user_inactive_by_default(self, user_service):
+        """Regular users are inactive when auto_activate is false (default)."""
+        assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=False) is False
+
+    def test_regular_user_active_when_auto_activate_enabled(self, user_service):
+        """Regular users are immediately active when auto_activate is true."""
+        user_service.settings.auto_activate_users = True
+        assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=False) is True
+
+    def test_auto_activate_does_not_change_admin_behavior(self, user_service):
+        """Admin activation is unchanged when auto_activate is enabled."""
+        user_service.settings.auto_activate_users = True
+        assert user_service.is_active(UserRole.ADMIN, is_first_user=False) is True
+
+    def test_auto_activate_does_not_change_first_user_behavior(self, user_service):
+        """First-user activation is unchanged when auto_activate is enabled."""
+        user_service.settings.auto_activate_users = True
+        assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=True) is True


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to automatically activate users upon their first single sign-on login, enabling more efficient user onboarding and reducing manual activation steps

* **Tests**
  * Added comprehensive unit tests for user activation behavior under different configuration states, including tests for admin users, first users, and regular users
<!-- end of auto-generated comment: release notes by coderabbit.ai -->