### PR TITLE
Fix lint error in main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,6 @@ jobs:
         id: changed-py-files
         uses: tj-actions/changed-files@v46
         with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
           files: |
             **/*.py
           files_ignore: |
@@ -124,7 +123,6 @@ jobs:
         id: changed-frontend-files
         uses: tj-actions/changed-files@v46
         with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
           files: |
             frontend/**/*.{js,jsx,ts,tsx,json,css,md}
 
@@ -132,7 +130,6 @@ jobs:
         id: changed-js-files
         uses: tj-actions/changed-files@v46
         with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
           files: |
             frontend/**/*.{js,jsx}
 
@@ -215,8 +212,6 @@ jobs:
       - name: Get all changed files
         id: changed-files-all
         uses: tj-actions/changed-files@v46
-        with:
-          base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
 
       - name: Run pre-commit on changed files
         if: steps.changed-files-all.outputs.any_changed == 'true'


### PR DESCRIPTION
Fix the lint error for the failing lints in main right now:

```
Run tj-actions/changed-files@v46
changed-files
  Using local .git directory
  Running on a push event...
  Error: Not Found - https://docs.github.com/rest/git/refs#get-a-reference
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to streamline file change detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->