### PR TITLE
SHU-562: Frontend bug fixes

### DIFF
--- a/frontend/src/components/ExperienceRunDialog.js
+++ b/frontend/src/components/ExperienceRunDialog.js
@@ -348,9 +348,7 @@ export default function ExperienceRunDialog({ open, onClose, experienceId, exper
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} disabled={status === 'running'}>
-          Close
-        </Button>
+        <Button onClick={onClose}>Close</Button>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/ExperienceRunDialog.js
+++ b/frontend/src/components/ExperienceRunDialog.js
@@ -150,9 +150,9 @@ export default function ExperienceRunDialog({ open, onClose, experienceId, exper
       }
     } catch (err) {
       if (err.name === 'AbortError') {
-        console.log('Execution aborted');
+        log.info('Execution aborted');
       } else {
-        console.error('Execution error:', err);
+        log.error('Execution error:', err);
         setError(err.message || 'Failed to execute experience');
         setStatus('failed');
       }

--- a/frontend/src/components/GoogleLogin.js
+++ b/frontend/src/components/GoogleLogin.js
@@ -6,7 +6,7 @@ import { authAPI, extractDataFromResponse } from '../services/api';
 import configService from '../services/config';
 import { log } from '../utils/log';
 import { useTheme as useAppTheme } from '../contexts/ThemeContext';
-import { getBrandingAppName } from '../utils/constants';
+import { getBrandingAppName, getBrandingFaviconUrlForTheme } from '../utils/constants';
 import { getApiV1Base } from '../services/baseUrl';
 
 const GoogleLogin = ({ onSwitchToPassword }) => {
@@ -18,9 +18,9 @@ const GoogleLogin = ({ onSwitchToPassword }) => {
   const [showRedirect, setShowRedirect] = useState(false);
 
   const { login } = useAuth();
-  const { branding } = useAppTheme();
+  const { branding, resolvedMode } = useAppTheme();
   const appDisplayName = getBrandingAppName(branding);
-  const faviconUrl = branding?.faviconUrl;
+  const faviconUrl = getBrandingFaviconUrlForTheme(branding, resolvedMode);
 
   useEffect(() => {
     const initializeComponent = async () => {
@@ -260,19 +260,21 @@ const GoogleLogin = ({ onSwitchToPassword }) => {
           alignItems: 'center',
         }}
       >
-        <Paper elevation={3} sx={{ padding: 4, width: '100%' }}>
-          <Box sx={{ textAlign: 'center', mb: 3 }}>
-            <img
-              src={faviconUrl}
-              alt={appDisplayName}
-              style={{
-                height: '60px', // Fixed height for normal proportions
-                width: 'auto', // Maintain aspect ratio
-                maxWidth: '100%', // Don't exceed container width
-                marginBottom: '1rem',
-              }}
-            />
-            <Typography component="h1" variant="h4" gutterBottom>
+        <Paper elevation={3} sx={{ overflow: 'hidden', width: '100%', border: 2, borderColor: 'primary.main' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: 'primary.main',
+              px: 3,
+              py: 2,
+            }}
+          >
+            <img src={faviconUrl} alt={appDisplayName} style={{ height: 48, width: 'auto' }} />
+          </Box>
+          <Box sx={{ textAlign: 'center', p: 4, pt: 3 }}>
+            <Typography component="h1" variant="h5" gutterBottom>
               Sign in to {appDisplayName}
             </Typography>
             <Typography variant="body1" color="text.secondary">
@@ -280,70 +282,72 @@ const GoogleLogin = ({ onSwitchToPassword }) => {
             </Typography>
           </Box>
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          )}
+          <Box sx={{ px: 4, pb: 4 }}>
+            {error && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {error}
+              </Alert>
+            )}
 
-          {successMessage && (
-            <Alert severity="success" sx={{ mb: 2 }}>
-              {successMessage}
-            </Alert>
-          )}
+            {successMessage && (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                {successMessage}
+              </Alert>
+            )}
 
-          {(!configLoaded || !googleLoaded) && (
-            <Alert severity="info" sx={{ mb: 2 }}>
-              {!configLoaded ? 'Loading configuration...' : 'Loading Google OAuth library...'}
-            </Alert>
-          )}
+            {(!configLoaded || !googleLoaded) && (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                {!configLoaded ? 'Loading configuration...' : 'Loading Google OAuth library...'}
+              </Alert>
+            )}
 
-          {/* Primary Google button (GIS FedCM). Renders when library is available */}
-          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-            <div ref={gsiBtnRef} />
-          </Box>
+            {/* Primary Google button (GIS FedCM). Renders when library is available */}
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+              <div ref={gsiBtnRef} />
+            </Box>
 
-          {/* Help + optional redirect fallback (hidden by default) */}
-          <Box sx={{ textAlign: 'center', mt: 1 }}>
-            <Typography variant="body2" color="text.secondary">
-              Having trouble signing in?
-              <Button
-                variant="text"
-                size="small"
-                sx={{ ml: 1 }}
-                onClick={() => setShowRedirect((v) => !v)}
-                disabled={!configLoaded}
-              >
-                {showRedirect ? 'Hide redirect' : 'Try redirect'}
-              </Button>
-            </Typography>
-
-            {showRedirect && (
-              <Box sx={{ mt: 1 }}>
+            {/* Help + optional redirect fallback (hidden by default) */}
+            <Box sx={{ textAlign: 'center', mt: 1 }}>
+              <Typography variant="body2" color="text.secondary">
+                Having trouble signing in?
                 <Button
-                  variant="outlined"
-                  size="medium"
-                  onClick={handleRedirectLogin}
-                  disabled={loading || !configLoaded}
-                  startIcon={loading ? <CircularProgress size={16} /> : <GoogleIcon fontSize="small" />}
+                  variant="text"
+                  size="small"
+                  sx={{ ml: 1 }}
+                  onClick={() => setShowRedirect((v) => !v)}
+                  disabled={!configLoaded}
                 >
-                  {loading ? 'Starting...' : 'Sign in with Google (redirect)'}
+                  {showRedirect ? 'Hide redirect' : 'Try redirect'}
+                </Button>
+              </Typography>
+
+              {showRedirect && (
+                <Box sx={{ mt: 1 }}>
+                  <Button
+                    variant="outlined"
+                    size="medium"
+                    onClick={handleRedirectLogin}
+                    disabled={loading || !configLoaded}
+                    startIcon={loading ? <CircularProgress size={16} /> : <GoogleIcon fontSize="small" />}
+                  >
+                    {loading ? 'Starting...' : 'Sign in with Google (redirect)'}
+                  </Button>
+                </Box>
+              )}
+            </Box>
+
+            {onSwitchToPassword && (
+              <Box sx={{ textAlign: 'center', mt: 2 }}>
+                <Button variant="text" onClick={onSwitchToPassword} disabled={loading}>
+                  Sign in with email and password instead
                 </Button>
               </Box>
             )}
+
+            <Typography variant="caption" display="block" sx={{ textAlign: 'center', mt: 2 }}>
+              Only authorized {appDisplayName} accounts can access this system
+            </Typography>
           </Box>
-
-          {onSwitchToPassword && (
-            <Box sx={{ textAlign: 'center', mt: 2 }}>
-              <Button variant="text" onClick={onSwitchToPassword} disabled={loading}>
-                Sign in with email and password instead
-              </Button>
-            </Box>
-          )}
-
-          <Typography variant="caption" display="block" sx={{ textAlign: 'center', mt: 2 }}>
-            Only authorized {appDisplayName} accounts can access this system
-          </Typography>
         </Paper>
       </Box>
     </Container>

--- a/frontend/src/components/LLMProviders.js
+++ b/frontend/src/components/LLMProviders.js
@@ -310,8 +310,8 @@ const LLMProviders = () => {
 
   // Update provider mutation
   const updateProviderMutation = useMutation(({ id, data }) => llmAPI.updateProvider(id, data), {
-    onSuccess: () => {
-      const provider = editProvider;
+    onSuccess: (_data, variables) => {
+      const provider = variables.provider;
       queryClient.invalidateQueries('llm-providers');
       setEditDialogOpen(false);
       setEditProvider(null);
@@ -468,7 +468,7 @@ const LLMProviders = () => {
         endpoints: stripLabels(endpointsOverrideEdit),
         provider_capabilities: stripLabels(pickCapabilities(editProvider.provider_capabilities, providerCapabilities)),
       };
-      updateProviderMutation.mutate({ id: editProvider.id, data: payload });
+      updateProviderMutation.mutate({ id: editProvider.id, data: payload, provider: editProvider });
     }
   };
 

--- a/frontend/src/components/LLMProviders.js
+++ b/frontend/src/components/LLMProviders.js
@@ -26,7 +26,6 @@ import {
   PlayArrow as TestIcon,
   Settings as SettingsIcon,
   Search as DiscoverIcon,
-  Sync as SyncIcon,
   CheckBox as CheckBoxIcon,
   CheckBoxOutlineBlank as CheckBoxOutlineBlankIcon,
   Close as RemoveIcon,
@@ -73,6 +72,9 @@ const LLMProviders = () => {
   // Manual model entry state
   const [manualModelId, setManualModelId] = useState('');
   const [manualModels, setManualModels] = useState([]);
+
+  // No-models confirmation dialog state
+  const [noModelsConfirmOpen, setNoModelsConfirmOpen] = useState(false);
 
   const [newProvider, setNewProvider] = useState(() => ({
     name: '',
@@ -293,11 +295,13 @@ const LLMProviders = () => {
 
   // Create provider mutation
   const createProviderMutation = useMutation((providerData) => llmAPI.createProvider(providerData), {
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const createdProvider = extractDataFromResponse(response);
       queryClient.invalidateQueries('llm-providers');
       setCreateDialogOpen(false);
       resetNewProvider();
       setError(null);
+      handleManageModels(createdProvider);
     },
     onError: (err) => {
       setError(formatError(err).message);
@@ -307,10 +311,14 @@ const LLMProviders = () => {
   // Update provider mutation
   const updateProviderMutation = useMutation(({ id, data }) => llmAPI.updateProvider(id, data), {
     onSuccess: () => {
+      const provider = editProvider;
       queryClient.invalidateQueries('llm-providers');
       setEditDialogOpen(false);
       setEditProvider(null);
       setError(null);
+      if (provider) {
+        handleManageModels(provider);
+      }
     },
     onError: (err) => {
       setError(formatError(err).message);
@@ -563,21 +571,39 @@ const LLMProviders = () => {
       queryClient.invalidateQueries('llm-providers');
       queryClient.invalidateQueries('all-llm-models');
 
-      setModelDialogOpen(false);
       setError(null);
-
-      // Show success message
-      setTestResults({
-        ...testResults,
-        [selectedProvider.id]: {
-          success: true,
-          message: `Successfully synced ${selectedModels.size} models`,
-        },
-      });
+      setSelectedModels(new Set());
+      setDiscoveredModels([]);
+      setManualModels([]);
+      return true;
     } catch (err) {
       setError(formatError(err).message);
+      return false;
     } finally {
       setModelSyncLoading(false);
+    }
+  };
+
+  const handleFinishModelManagement = async () => {
+    // Sync any selected models first, then close
+    if (selectedModels.size > 0) {
+      const synced = await handleSyncModels();
+      if (!synced) {
+        return; // Sync failed, stay on dialog
+      }
+      setModelDialogOpen(false);
+      return;
+    }
+
+    // No models selected - use shared dismiss logic
+    handleDismissModelManagement();
+  };
+
+  const handleDismissModelManagement = () => {
+    if (selectedProvider && getProviderModelCount(selectedProvider.id) === 0) {
+      setNoModelsConfirmOpen(true);
+    } else {
+      setModelDialogOpen(false);
     }
   };
 
@@ -869,7 +895,7 @@ const LLMProviders = () => {
             variant="contained"
             disabled={createProviderMutation.isLoading || !newProvider.name || !newProvider.api_endpoint}
           >
-            {createProviderMutation.isLoading ? 'Creating...' : 'Create Provider'}
+            {createProviderMutation.isLoading ? 'Saving...' : 'Next'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -913,7 +939,7 @@ const LLMProviders = () => {
         <DialogActions>
           <Button onClick={() => setEditDialogOpen(false)}>Cancel</Button>
           <Button onClick={handleSaveProvider} variant="contained" disabled={updateProviderMutation.isLoading}>
-            {updateProviderMutation.isLoading ? 'Saving...' : 'Save Changes'}
+            {updateProviderMutation.isLoading ? 'Saving...' : 'Next'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -954,7 +980,7 @@ const LLMProviders = () => {
       </Dialog>
 
       {/* Model Management Dialog */}
-      <Dialog open={modelDialogOpen} onClose={() => setModelDialogOpen(false)} maxWidth="md" fullWidth>
+      <Dialog open={modelDialogOpen} onClose={handleDismissModelManagement} maxWidth="md" fullWidth>
         <DialogTitle>Manage Models - {selectedProvider?.name}</DialogTitle>
         <DialogContent>
           <Box sx={{ pt: 1 }}>
@@ -1209,39 +1235,36 @@ const LLMProviders = () => {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setModelDialogOpen(false)}>Cancel</Button>
-          {discoveredModels.length === 0 && manualModels.length === 0 ? (
-            <Button
-              variant="contained"
-              startIcon={<DiscoverIcon />}
-              onClick={handleDiscoverModels}
-              disabled={modelDiscoveryLoading}
-            >
-              {modelDiscoveryLoading ? 'Discovering...' : 'Discover Models'}
-            </Button>
-          ) : (
-            <>
-              {discoveredModels.length === 0 && (
-                <Button
-                  variant="outlined"
-                  startIcon={<DiscoverIcon />}
-                  onClick={handleDiscoverModels}
-                  disabled={modelDiscoveryLoading}
-                  sx={{ mr: 1 }}
-                >
-                  {modelDiscoveryLoading ? 'Discovering...' : 'Discover More'}
-                </Button>
-              )}
-              <Button
-                variant="contained"
-                startIcon={<SyncIcon />}
-                onClick={handleSyncModels}
-                disabled={modelSyncLoading || selectedModels.size === 0}
-              >
-                {modelSyncLoading ? 'Syncing...' : `Sync ${selectedModels.size} Models`}
-              </Button>
-            </>
-          )}
+          <Button onClick={handleDismissModelManagement}>Cancel</Button>
+          <Button variant="contained" onClick={handleFinishModelManagement} disabled={modelSyncLoading}>
+            {modelSyncLoading ? 'Saving...' : 'Save Changes'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* No Models Confirmation Dialog */}
+      <Dialog open={noModelsConfirmOpen} onClose={() => setNoModelsConfirmOpen(false)}>
+        <DialogTitle>No Models Added</DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mt: 1 }}>
+            You haven&apos;t added any models to this provider. Without models, you won&apos;t be able to create model
+            configurations for this provider.
+          </Alert>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+            Are you sure you want to continue without adding models?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setNoModelsConfirmOpen(false)}>Go Back</Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              setNoModelsConfirmOpen(false);
+              setModelDialogOpen(false);
+            }}
+          >
+            Continue Without Models
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/frontend/src/components/LLMProviders.js
+++ b/frontend/src/components/LLMProviders.js
@@ -544,6 +544,7 @@ const LLMProviders = () => {
       const selectedManualModels = selectedModelsList.filter((modelId) => manualModelIds.includes(modelId));
 
       // Create manual models first
+      const failedManualModels = [];
       for (const modelId of selectedManualModels) {
         const manualModel = manualModels.find((model) => model.id === modelId);
         if (manualModel) {
@@ -556,9 +557,14 @@ const LLMProviders = () => {
             });
           } catch (err) {
             log.warn(`Failed to create manual model ${modelId}:`, err);
-            // Continue with other models even if one fails
+            failedManualModels.push(modelId);
           }
         }
+      }
+
+      if (failedManualModels.length > 0) {
+        setError(`Failed to create manual model(s): ${failedManualModels.join(', ')}`);
+        return false;
       }
 
       // Then sync discovered models (if any)

--- a/frontend/src/components/PasswordLogin.js
+++ b/frontend/src/components/PasswordLogin.js
@@ -4,7 +4,7 @@ import LoginIcon from '@mui/icons-material/Login';
 import GoogleIcon from '@mui/icons-material/Google';
 import api, { extractDataFromResponse } from '../services/api';
 import { useTheme as useAppTheme } from '../contexts/ThemeContext';
-import { getBrandingAppName } from '../utils/constants';
+import { getBrandingAppName, getBrandingFaviconUrlForTheme } from '../utils/constants';
 import { useMicrosoftOAuth } from '../hooks/useMicrosoftOAuth';
 
 // Microsoft logo - using official asset from Microsoft identity platform branding guidelines
@@ -26,9 +26,9 @@ const PasswordLogin = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
-  const { branding } = useAppTheme();
+  const { branding, resolvedMode } = useAppTheme();
   const appDisplayName = getBrandingAppName(branding);
-  const faviconUrl = branding?.faviconUrl;
+  const faviconUrl = getBrandingFaviconUrlForTheme(branding, resolvedMode);
 
   // Microsoft OAuth hook
   const { startLogin: startMicrosoftLogin, loading: microsoftLoading } = useMicrosoftOAuth({
@@ -130,136 +130,140 @@ const PasswordLogin = ({
           alignItems: 'center',
         }}
       >
-        <Paper elevation={3} sx={{ padding: 4, width: '100%' }}>
-          <Box sx={{ textAlign: 'center', mb: 3 }}>
-            <img
-              src={faviconUrl}
-              alt={appDisplayName}
-              style={{
-                height: '60px',
-                width: 'auto',
-                maxWidth: '100%',
-                marginBottom: '1rem',
-              }}
-            />
-            <Typography component="h1" variant="h4" gutterBottom>
-              Sign-in to {appDisplayName}
+        <Paper elevation={3} sx={{ overflow: 'hidden', width: '100%', border: 2, borderColor: 'primary.main' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: 'primary.main',
+              px: 3,
+              py: 2,
+            }}
+          >
+            <img src={faviconUrl} alt={appDisplayName} style={{ height: 48, width: 'auto' }} />
+          </Box>
+          <Box sx={{ textAlign: 'center', p: 4, pt: 3 }}>
+            <Typography component="h1" variant="h5" gutterBottom>
+              Sign in to {appDisplayName}
             </Typography>
             <Typography variant="body1" color="text.secondary">
               Sign in to your account
             </Typography>
           </Box>
 
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          )}
-
-          {successMessage && (
-            <Alert severity="success" sx={{ mb: 2 }}>
-              {successMessage}
-            </Alert>
-          )}
-
-          <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1 }}>
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              id="email"
-              label="Email Address"
-              name="email"
-              autoComplete="email"
-              autoFocus
-              type="email"
-              value={formData.email}
-              onChange={handleChange}
-              disabled={isAnyLoading}
-            />
-
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              name="password"
-              label="Password"
-              type="password"
-              id="password"
-              autoComplete="current-password"
-              value={formData.password}
-              onChange={handleChange}
-              disabled={isAnyLoading}
-            />
-
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              size="large"
-              startIcon={loading ? <CircularProgress size={20} /> : <LoginIcon />}
-              disabled={isAnyLoading}
-              sx={{ mt: 3, mb: 2, py: 1.5 }}
-            >
-              {loading ? 'Signing in...' : 'Sign In'}
-            </Button>
-
-            {isGoogleSsoEnabled && (
-              <>
-                <Divider sx={{ my: 2 }}>
-                  <Typography variant="body2" color="text.secondary">
-                    OR
-                  </Typography>
-                </Divider>
-
-                <Button
-                  fullWidth
-                  variant="outlined"
-                  size="large"
-                  startIcon={<GoogleIcon />}
-                  onClick={onSwitchToGoogle}
-                  disabled={isAnyLoading}
-                  sx={{ mb: 2, py: 1.5 }}
-                >
-                  Sign in with Google
-                </Button>
-              </>
+          <Box sx={{ px: 4, pb: 4 }}>
+            {error && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {error}
+              </Alert>
             )}
 
-            {isMicrosoftSsoEnabled && (
-              <>
-                {!isGoogleSsoEnabled && (
+            {successMessage && (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                {successMessage}
+              </Alert>
+            )}
+
+            <Box component="form" onSubmit={handleSubmit} sx={{ mt: 1 }}>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="email"
+                label="Email Address"
+                name="email"
+                autoComplete="email"
+                autoFocus
+                type="email"
+                value={formData.email}
+                onChange={handleChange}
+                disabled={isAnyLoading}
+              />
+
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="password"
+                label="Password"
+                type="password"
+                id="password"
+                autoComplete="current-password"
+                value={formData.password}
+                onChange={handleChange}
+                disabled={isAnyLoading}
+              />
+
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                size="large"
+                startIcon={loading ? <CircularProgress size={20} /> : <LoginIcon />}
+                disabled={isAnyLoading}
+                sx={{ mt: 3, mb: 2, py: 1.5 }}
+              >
+                {loading ? 'Signing in...' : 'Sign In'}
+              </Button>
+
+              {isGoogleSsoEnabled && (
+                <>
                   <Divider sx={{ my: 2 }}>
                     <Typography variant="body2" color="text.secondary">
                       OR
                     </Typography>
                   </Divider>
-                )}
 
-                <Button
-                  fullWidth
-                  variant="outlined"
-                  size="large"
-                  startIcon={microsoftLoading ? <CircularProgress size={20} /> : <MicrosoftIcon />}
-                  onClick={handleMicrosoftLogin}
-                  disabled={isAnyLoading}
-                  sx={{ mb: 2, py: 1.5 }}
-                >
-                  {microsoftLoading ? 'Signing in...' : 'Sign in with Microsoft'}
+                  <Button
+                    fullWidth
+                    variant="outlined"
+                    size="large"
+                    startIcon={<GoogleIcon />}
+                    onClick={onSwitchToGoogle}
+                    disabled={isAnyLoading}
+                    sx={{ mb: 2, py: 1.5 }}
+                  >
+                    Sign in with Google
+                  </Button>
+                </>
+              )}
+
+              {isMicrosoftSsoEnabled && (
+                <>
+                  {!isGoogleSsoEnabled && (
+                    <Divider sx={{ my: 2 }}>
+                      <Typography variant="body2" color="text.secondary">
+                        OR
+                      </Typography>
+                    </Divider>
+                  )}
+
+                  <Button
+                    fullWidth
+                    variant="outlined"
+                    size="large"
+                    startIcon={microsoftLoading ? <CircularProgress size={20} /> : <MicrosoftIcon />}
+                    onClick={handleMicrosoftLogin}
+                    disabled={isAnyLoading}
+                    sx={{ mb: 2, py: 1.5 }}
+                  >
+                    {microsoftLoading ? 'Signing in...' : 'Sign in with Microsoft'}
+                  </Button>
+                </>
+              )}
+
+              <Box sx={{ textAlign: 'center', mt: 2 }}>
+                <Button variant="text" onClick={onSwitchToRegister} disabled={isAnyLoading}>
+                  Don't have an account? Register
                 </Button>
-              </>
-            )}
-
-            <Box sx={{ textAlign: 'center', mt: 2 }}>
-              <Button variant="text" onClick={onSwitchToRegister} disabled={isAnyLoading}>
-                Don't have an account? Register
-              </Button>
+              </Box>
             </Box>
-          </Box>
 
-          <Typography variant="caption" display="block" sx={{ textAlign: 'center', mt: 2 }}>
-            Only authorized {appDisplayName} accounts can access this system
-          </Typography>
+            <Typography variant="caption" display="block" sx={{ textAlign: 'center', mt: 2 }}>
+              Only authorized {appDisplayName} accounts can access this system
+            </Typography>
+          </Box>
         </Paper>
       </Box>
     </Container>

--- a/frontend/src/components/chat/ModernChat/LongConversationDialog.jsx
+++ b/frontend/src/components/chat/ModernChat/LongConversationDialog.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Box, Button, Stack, Typography } from '@mui/material';
+
+const LongConversationBanner = React.memo(function LongConversationBanner({
+  open,
+  messageCount,
+  onStartNew,
+  onDismiss,
+}) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ px: 2, py: 1.5 }}>
+      <Typography variant="subtitle2" gutterBottom>
+        Conversation Getting Long
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+        This conversation has {messageCount} messages. Long conversations can affect response quality and performance.
+      </Typography>
+      <Stack direction="row" spacing={1} justifyContent="flex-end">
+        <Button size="small" onClick={onDismiss}>
+          Continue Anyway
+        </Button>
+        <Button size="small" variant="contained" onClick={onStartNew}>
+          Start New Conversation
+        </Button>
+      </Stack>
+    </Box>
+  );
+});
+
+export default LongConversationBanner;

--- a/frontend/src/components/chat/ModernChat/ModernChatView.jsx
+++ b/frontend/src/components/chat/ModernChat/ModernChatView.jsx
@@ -17,6 +17,7 @@ import EnsembleModeDialog from './EnsembleModeDialog';
 import RenameConversationDialog from './RenameConversationDialog';
 import DeleteConversationDialog from './DeleteConversationDialog';
 import ChatSettingsDialog from './ChatSettingsDialog';
+import LongConversationDialog from './LongConversationDialog';
 
 const SIDEBAR_WIDTH = 300;
 
@@ -41,6 +42,7 @@ const ModernChatView = ({
   renameDialogProps,
   deleteDialogProps,
   settingsDialogProps,
+  longConversationDialogProps,
   pluginsEnabled,
   getSelectedConfig,
   handleCreateConversation,
@@ -121,7 +123,11 @@ const ModernChatView = ({
                   </Alert>
                 )}
 
-                <InputBar {...inputBarProps} isMobile={isMobile} />
+                {longConversationDialogProps.open ? (
+                  <LongConversationDialog {...longConversationDialogProps} />
+                ) : (
+                  <InputBar {...inputBarProps} isMobile={isMobile} />
+                )}
               </Paper>
 
               {pluginsEnabled && <PluginPickerDialog {...pluginPickerDialogProps} />}

--- a/frontend/src/components/chat/ModernChat/hooks/useChatUiState.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useChatUiState.js
@@ -19,6 +19,8 @@ const useChatUiState = () => {
   const [renameDialog, setRenameDialog] = useState(initialRenameState);
   const [renameError, setRenameError] = useState('');
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
+  const [longConversationDialogOpen, setLongConversationDialogOpen] = useState(false);
+  const [longConversationDismissedIds, setLongConversationDismissedIds] = useState(new Set());
   const [documentPreview, setDocumentPreview] = useState(initialDocumentPreview);
 
   const openSummaryMenu = useCallback((anchorEl) => {
@@ -80,6 +82,26 @@ const useChatUiState = () => {
     setSettingsDialogOpen(false);
   }, []);
 
+  const openLongConversationDialog = useCallback(() => {
+    setLongConversationDialogOpen(true);
+  }, []);
+
+  const closeLongConversationDialog = useCallback(() => {
+    setLongConversationDialogOpen(false);
+  }, []);
+
+  const dismissLongConversationDialog = useCallback((conversationId) => {
+    setLongConversationDialogOpen(false);
+    if (conversationId) {
+      setLongConversationDismissedIds((prev) => new Set(prev).add(conversationId));
+    }
+  }, []);
+
+  const isLongConversationDismissed = useCallback(
+    (conversationId) => longConversationDismissedIds.has(conversationId),
+    [longConversationDismissedIds]
+  );
+
   const openDocumentPreview = useCallback(({ kbId, documentId }) => {
     if (!kbId || !documentId) {
       return;
@@ -117,6 +139,11 @@ const useChatUiState = () => {
     documentPreview,
     openDocumentPreview,
     closeDocumentPreview,
+    longConversationDialogOpen,
+    openLongConversationDialog,
+    closeLongConversationDialog,
+    dismissLongConversationDialog,
+    isLongConversationDismissed,
   };
 };
 

--- a/frontend/src/components/chat/ModernChat/hooks/useMessageStream.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useMessageStream.js
@@ -86,6 +86,11 @@ const useMessageStream = ({
     [messagesResponse, selectedConversation?.id]
   );
 
+  const totalMessageCount = useMemo(() => {
+    const tc = messagesResponse?.data?.meta?.total_count;
+    return typeof tc === 'number' ? tc : null;
+  }, [messagesResponse]);
+
   const resetConversationState = useCallback(() => {
     setHasMoreMessages(false);
     setLoadingOlderMessages(false);
@@ -240,6 +245,7 @@ const useMessageStream = ({
     hasMoreMessages,
     loadingOlderMessages,
     loadOlderMessages,
+    totalMessageCount,
   };
 };
 

--- a/frontend/src/components/chat/ModernChat/utils/chatConfig.js
+++ b/frontend/src/components/chat/ModernChat/utils/chatConfig.js
@@ -54,6 +54,9 @@ export const SUMMARY_SEARCH_DEBOUNCE_MS = parsePositiveInt('VITE_SUMMARY_SEARCH_
 export const DEFAULT_SUMMARY_SEARCH_MIN_TERM_LENGTH = parsePositiveInt('VITE_SUMMARY_SEARCH_MIN_TERM_LENGTH', 3);
 export const DEFAULT_SUMMARY_SEARCH_MAX_TOKENS = parsePositiveInt('VITE_SUMMARY_SEARCH_MAX_TOKENS', 10);
 
+// Long conversation warning
+export const LONG_CONVERSATION_THRESHOLD = parsePositiveInt('VITE_LONG_CONVERSATION_THRESHOLD', 50);
+
 // UI Strings / Storage keys
 export const STORAGE_KEY_RAG_REWRITE_MODE = 'shu.chat.ragRewriteMode';
 export const PLACEHOLDER_THINKING = 'Thinking…';

--- a/frontend/src/components/layout/TopBar.jsx
+++ b/frontend/src/components/layout/TopBar.jsx
@@ -107,8 +107,10 @@ const TopBar = ({
               height: '100%',
             }}
           >
-            {sectionIcon ? <Box sx={{ mr: 1, display: 'flex', alignItems: 'center' }}>{sectionIcon}</Box> : null}
-            <Typography variant="h6" sx={{ color: '#FFFFFF', fontWeight: 600 }}>
+            {sectionIcon ? (
+              <Box sx={{ mr: 1, display: 'flex', alignItems: 'center', color: textColor }}>{sectionIcon}</Box>
+            ) : null}
+            <Typography variant="h6" sx={{ color: textColor, fontWeight: 600 }}>
               {sectionTitle}
             </Typography>
           </Box>
@@ -123,11 +125,16 @@ const TopBar = ({
           onClick={handleUserMenuOpen}
           className="user-menu"
           sx={{
-            color: '#FFFFFF',
+            color: textColor,
             '&:hover': { backgroundColor: 'rgba(255,255,255,0.1)' },
           }}
         >
-          <UserAvatar user={user} size={32} fallbackChar={user?.name?.charAt(0) || 'U'} />
+          <UserAvatar
+            user={user}
+            size={32}
+            fallbackChar={user?.name?.charAt(0) || 'U'}
+            sx={{ color: textColor, backgroundColor: 'rgba(255,255,255,0.15)' }}
+          />
         </IconButton>
 
         <Menu id="user-menu" anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleUserMenuClose}>

--- a/frontend/src/utils/brandingUtils.js
+++ b/frontend/src/utils/brandingUtils.js
@@ -122,7 +122,18 @@ export const getTopbarTextColor = (branding, resolvedMode) => {
 export const derivePrimaryVariants = (hex) => {
   const LIGHTEN = 40;
   const DARKEN = 30;
-  const parsed = parseInt(hex.replace('#', ''), 16);
+  const raw = (hex || '').replace('#', '');
+  const normalized =
+    raw.length === 3
+      ? raw
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : raw;
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return { lighter: hex, darker: hex };
+  }
+  const parsed = parseInt(normalized, 16);
   const r = (parsed >> 16) & 0xff;
   const g = (parsed >> 8) & 0xff;
   const b = parsed & 0xff;

--- a/frontend/src/utils/brandingUtils.js
+++ b/frontend/src/utils/brandingUtils.js
@@ -109,3 +109,26 @@ export const getTopbarTextColor = (branding, resolvedMode) => {
   }
   return resolved.lightTopbarTextColor || '#FFFFFF';
 };
+
+/* eslint-disable no-magic-numbers */
+/**
+ * Derive lighter and darker variants from a hex color string.
+ * Used to regenerate primary.light / primary.dark when branding
+ * overrides only primary.main.
+ *
+ * @param {string} hex - A 6-digit hex color (e.g. '#2E5A87')
+ * @returns {{ lighter: string, darker: string }}
+ */
+export const derivePrimaryVariants = (hex) => {
+  const LIGHTEN = 40;
+  const DARKEN = 30;
+  const parsed = parseInt(hex.replace('#', ''), 16);
+  const r = (parsed >> 16) & 0xff;
+  const g = (parsed >> 8) & 0xff;
+  const b = parsed & 0xff;
+  const toHex = (n) => n.toString(16).padStart(2, '0');
+  const lighter = `#${toHex(Math.min(255, r + LIGHTEN))}${toHex(Math.min(255, g + LIGHTEN))}${toHex(Math.min(255, b + LIGHTEN))}`;
+  const darker = `#${toHex(Math.max(0, r - DARKEN))}${toHex(Math.max(0, g - DARKEN))}${toHex(Math.max(0, b - DARKEN))}`;
+  return { lighter, darker };
+};
+/* eslint-enable no-magic-numbers */

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -595,18 +595,27 @@ export const getThemeConfig = (mode = 'light', branding) => {
 
   // When branding overrides primary.main, the light/dark variants still hold
   // the base-theme defaults. Regenerate them so the full palette stays consistent.
-  const pm = config.palette.primary.main;
-  const { lighter, darker } = derivePrimaryVariants(pm);
-  config.palette.primary.light = lighter;
-  config.palette.primary.dark = darker;
+  const pm = config?.palette?.primary?.main;
+  const overridePrimary = overrides?.palette?.primary ?? {};
+  const hasOverrideMain = typeof overridePrimary.main === 'string';
+  const derived = hasOverrideMain && pm ? derivePrimaryVariants(pm) : null;
+  if (derived) {
+    if (!overridePrimary.light) {
+      config.palette.primary.light = derived.lighter;
+    }
+    if (!overridePrimary.dark) {
+      config.palette.primary.dark = derived.darker;
+    }
+  }
 
   // Sync MuiListItemButton overrides with the resolved primary palette.
   const listBtn = config.components?.MuiListItemButton?.styleOverrides?.root;
-  if (listBtn) {
+  const overrideListBtn = overrides?.components?.MuiListItemButton?.styleOverrides?.root;
+  if (listBtn && derived && !overrideListBtn) {
     if (listBtn['&.Mui-selected']) {
       listBtn['&.Mui-selected'].backgroundColor = pm;
       if (listBtn['&.Mui-selected']['&:hover']) {
-        listBtn['&.Mui-selected']['&:hover'].backgroundColor = darker;
+        listBtn['&.Mui-selected']['&:hover'].backgroundColor = derived.darker;
       }
     }
     if (listBtn['& .MuiListItemIcon-root']) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes # SHU-562

## Changes Made
<!-- List the main changes made in this PR -->
- Enable the close button on experience executions to interrupt them early
- Two step provider setup to guide user through the model discovery process:
  - Provider Create/Edit dialogs now use "Next" instead of "Create Provider"/"Save Changes" — saves the provider in the background, then automatically opens the Manage Models dialog for that provider.
  - createProviderMutation onSuccess — extracts the created provider from the API response and calls handleManageModels(createdProvider) to redirect to step 2.
  - updateProviderMutation onSuccess — captures the editProvider reference before clearing state, then calls handleManageModels(provider) to redirect to step 2.
  - Manage Models dialog footer simplified — removed the separate "Discover Models" and "Sync N Models" buttons. Replaced with a single "Save Changes" button that syncs any selected models and then closes the dialog.
  - handleSyncModels no longer auto-closes the dialog — returns true/false for success/failure so the caller can decide what to do.
  - handleFinishModelManagement (new) — called by "Save Changes". Syncs selected models if any, then closes. If sync fails, stays on the dialog.
  - handleDismissModelManagement (new) — shared handler for Cancel, Escape, and clicking outside. Checks if the provider has zero enabled models and shows a confirmation warning if so.
  - No Models confirmation dialog (new) — warns that without models, model configurations can't be created. Offers "Go Back" or "Continue Without Models".
- Conversation length management:
  - LongConversationDialog.jsx — Simple MUI dialog with "Continue Anyway" and "Start New Conversation" buttons
  - useChatUiState.js — Added longConversationDialogOpen state, a Set to track dismissed conversation IDs, and open/dismiss/check callbacks
  - ModernChat.js — Added LONG_CONVERSATION_THRESHOLD = 50 environment variable, a useEffect that opens the dialog when flattenedMessages.length >= 50 (unless already dismissed for that conversation), and the longConversationDialogProps object wired to handleCreateConversation
  - ModernChatView.jsx — Imported and rendered the new dialog
- Branding fixes
  - The "Topbar Text Colors" branding setting was only applied to the app name. We fixed it to affect all topbar elements:
    - Section title — changed from hardcoded #FFFFFF to textColor
    - Section icon — added color: textColor to the icon container
    - User menu IconButton — changed from hardcoded #FFFFFF to textColor
    - UserAvatar — passed color: textColor and backgroundColor: 'rgba(255,255,255,0.15)' via sx so the fallback character is readable and the avatar doesn't render as an opaque white circle
  - Login page branding image
    - Theme-aware favicon — switched both to use getBrandingFaviconUrlForTheme(branding, resolvedMode) so dark mode users see the dark favicon
    - Topbar-style banner — replaced the bare <img> with a full-width primary.main-colored banner at the top of the login card, displaying the favicon the same way it appears in the actual topbar
    - Primary border — added a border: 2, borderColor: 'primary.main' on the Paper to visually tie the card to the banner
    - Topbar text color — imported getTopbarTextColor for use in the banner app name text (later removed by you, keeping just the favicon)

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a long‑conversation dialog to warn when a chat grows large and offer "Continue" or "Start New".

* **Improvements**
  * Redesigned login screens with branded header banners, reflowed layout, and unified SSO/password flows.
  * Streamlined provider model management with clearer confirmation and finalization steps.
  * Improved theme/branding handling (favicon, color variants, top bar/avatar coloring).
  * Close buttons remain enabled during running operations for better control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->