### PR TITLE
Kb query cleanup

### DIFF
--- a/backend/migrations/versions/007_0002_add_documents_title_index.py
+++ b/backend/migrations/versions/007_0002_add_documents_title_index.py
@@ -5,8 +5,7 @@ Revises: 007_0001_add_must_change_password
 Create Date: 2026-02-23
 
 This migration:
-1. Adds an index on documents.title for efficient ILIKE search
-2. Backfills knowledge_bases.document_count and total_chunks from actual data
+Backfills knowledge_bases.document_count and total_chunks from actual data
 
 """
 
@@ -14,17 +13,13 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "007_0002"
-down_revision = "007_0001_add_must_change_password"
+down_revision = "007_0001"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    """Add index on documents.title and backfill KB stats."""
-    # Step 1: Add title index for efficient ILIKE search
-    op.create_index("idx_documents_title", "documents", ["title"])
-
-    # Step 2: Backfill document_count for all knowledge bases
+    # Step 1: Backfill document_count for all knowledge bases
     op.execute("""
         UPDATE knowledge_bases kb
         SET document_count = COALESCE(
@@ -33,7 +28,7 @@ def upgrade() -> None:
         )
     """)
 
-    # Step 3: Backfill total_chunks for all knowledge bases
+    # Step 2: Backfill total_chunks for all knowledge bases
     op.execute("""
         UPDATE knowledge_bases kb
         SET total_chunks = COALESCE(
@@ -44,5 +39,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Remove documents.title index. Stats are not reverted (no data loss)."""
-    op.drop_index("idx_documents_title", table_name="documents")
+

--- a/backend/migrations/versions/007_0002_add_documents_title_index.py
+++ b/backend/migrations/versions/007_0002_add_documents_title_index.py
@@ -1,0 +1,48 @@
+"""Add index on documents.title and backfill KB stats.
+
+Revision ID: 007_0002
+Revises: 007_0001_add_must_change_password
+Create Date: 2026-02-23
+
+This migration:
+1. Adds an index on documents.title for efficient ILIKE search
+2. Backfills knowledge_bases.document_count and total_chunks from actual data
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "007_0002"
+down_revision = "007_0001_add_must_change_password"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add index on documents.title and backfill KB stats."""
+    # Step 1: Add title index for efficient ILIKE search
+    op.create_index("idx_documents_title", "documents", ["title"])
+
+    # Step 2: Backfill document_count for all knowledge bases
+    op.execute("""
+        UPDATE knowledge_bases kb
+        SET document_count = COALESCE(
+            (SELECT COUNT(*) FROM documents d WHERE d.knowledge_base_id = kb.id),
+            0
+        )
+    """)
+
+    # Step 3: Backfill total_chunks for all knowledge bases
+    op.execute("""
+        UPDATE knowledge_bases kb
+        SET total_chunks = COALESCE(
+            (SELECT COUNT(*) FROM document_chunks dc WHERE dc.knowledge_base_id = kb.id),
+            0
+        )
+    """)
+
+
+def downgrade() -> None:
+    """Remove documents.title index. Stats are not reverted (no data loss)."""
+    op.drop_index("idx_documents_title", table_name="documents")

--- a/backend/migrations/versions/007_0002_backfill_kb_stats.py
+++ b/backend/migrations/versions/007_0002_backfill_kb_stats.py
@@ -36,7 +36,3 @@ def upgrade() -> None:
             0
         )
     """)
-
-
-def downgrade() -> None:
-

--- a/backend/migrations/versions/007_0002_backfill_kb_stats.py
+++ b/backend/migrations/versions/007_0002_backfill_kb_stats.py
@@ -1,4 +1,4 @@
-"""Add index on documents.title and backfill KB stats.
+"""backfill KB stats.
 
 Revision ID: 007_0002
 Revises: 007_0001_add_must_change_password

--- a/backend/src/shu/models/document.py
+++ b/backend/src/shu/models/document.py
@@ -182,6 +182,39 @@ class Document(BaseModel):
         )
         return base_dict
 
+    def to_list_dict(self) -> dict[str, Any]:
+        """Convert to lightweight dictionary for list views.
+
+        Excludes heavy fields like content, synopsis_embedding, capability_manifest,
+        extraction_metadata, and source_metadata to minimize response size and
+        avoid loading deferred columns.
+        """
+        return {
+            "id": self.id,
+            "knowledge_base_id": self.knowledge_base_id,
+            "title": self.title,
+            "source_type": self.source_type,
+            "source_id": self.source_id,
+            "file_type": self.file_type,
+            "file_size": self.file_size,
+            "mime_type": self.mime_type,
+            "processing_status": self.processing_status,
+            "processing_error": self.processing_error,
+            "extraction_method": self.extraction_method,
+            "extraction_engine": self.extraction_engine,
+            "extraction_confidence": self.extraction_confidence,
+            "source_url": self.source_url,
+            "word_count": self.word_count,
+            "character_count": self.character_count,
+            "chunk_count": self.chunk_count,
+            "document_type": self.document_type,
+            "profiling_status": self.profiling_status,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "processed_at": self.processed_at.isoformat() if self.processed_at else None,
+            "source_modified_at": self.source_modified_at.isoformat() if self.source_modified_at else None,
+        }
+
     @property
     def is_processed(self) -> bool:
         """Check if document has been processed successfully."""

--- a/backend/src/tests/unit/services/test_knowledge_base_service.py
+++ b/backend/src/tests/unit/services/test_knowledge_base_service.py
@@ -7,6 +7,9 @@ stats are properly maintained.
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from shu.models.document import Document
+from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
 class TestRecalculateKBStats:
     """Tests for recalculate_kb_stats method."""
@@ -14,7 +17,7 @@ class TestRecalculateKBStats:
     @pytest.mark.asyncio
     async def test_recalculate_kb_stats_updates_denormalized_columns(self):
         """Verify recalculate_kb_stats updates KB document_count and total_chunks."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         # Mock database session
         mock_db = AsyncMock()
@@ -52,7 +55,7 @@ class TestRecalculateKBStats:
     @pytest.mark.asyncio
     async def test_recalculate_kb_stats_handles_empty_kb(self):
         """Verify recalculate_kb_stats handles KB with no documents."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
 
@@ -78,7 +81,7 @@ class TestRecalculateKBStats:
     @pytest.mark.asyncio
     async def test_recalculate_kb_stats_handles_null_scalars(self):
         """Verify recalculate_kb_stats handles NULL scalar results gracefully."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
 
@@ -105,7 +108,7 @@ class TestRecalculateKBStats:
     @pytest.mark.asyncio
     async def test_recalculate_kb_stats_handles_missing_kb(self):
         """Verify recalculate_kb_stats handles non-existent KB gracefully."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
 
@@ -134,7 +137,7 @@ class TestGetOverallKnowledgeBaseStats:
     @pytest.mark.asyncio
     async def test_aggregates_from_denormalized_stats(self):
         """Verify get_overall_knowledge_base_stats aggregates from KB columns."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
 
@@ -166,7 +169,7 @@ class TestGetOverallKnowledgeBaseStats:
     @pytest.mark.asyncio
     async def test_handles_null_sums(self):
         """Verify get_overall_knowledge_base_stats handles NULL sums (no KBs)."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
 
@@ -192,7 +195,7 @@ class TestGetDocumentFilterCondition:
 
     def test_search_uses_title_only(self):
         """Verify search filter only searches title, not content."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = MagicMock()
         service = KnowledgeBaseService(mock_db)
@@ -217,7 +220,7 @@ class TestDocumentToListDict:
 
     def test_excludes_heavy_fields(self):
         """Verify to_list_dict excludes content, embeddings, and other heavy fields."""
-        from shu.models.document import Document
+
 
         doc = Document(
             id="test-id",
@@ -253,7 +256,7 @@ class TestDocumentToListDict:
 
     def test_includes_all_list_view_fields(self):
         """Verify to_list_dict includes all fields needed for list views."""
-        from shu.models.document import Document
+
         from datetime import datetime, UTC
 
         now = datetime.now(UTC)
@@ -304,7 +307,7 @@ class TestAdjustDocumentStats:
     @pytest.mark.asyncio
     async def test_adjust_document_stats_increments(self):
         """Verify adjust_document_stats increments counts correctly."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock()
@@ -320,7 +323,7 @@ class TestAdjustDocumentStats:
     @pytest.mark.asyncio
     async def test_adjust_document_stats_decrements(self):
         """Verify adjust_document_stats decrements counts correctly."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock()
@@ -335,7 +338,7 @@ class TestAdjustDocumentStats:
     @pytest.mark.asyncio
     async def test_adjust_document_stats_skips_zero_delta(self):
         """Verify adjust_document_stats does nothing when both deltas are zero."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock()
@@ -351,7 +354,7 @@ class TestAdjustDocumentStats:
     @pytest.mark.asyncio
     async def test_adjust_document_stats_handles_doc_only(self):
         """Verify adjust_document_stats works with only doc_delta."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock()
@@ -367,7 +370,7 @@ class TestAdjustDocumentStats:
     @pytest.mark.asyncio
     async def test_adjust_document_stats_handles_chunk_only(self):
         """Verify adjust_document_stats works with only chunk_delta."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock()
@@ -383,7 +386,7 @@ class TestAdjustDocumentStats:
     @pytest.mark.asyncio
     async def test_adjust_document_stats_rollback_on_error(self):
         """Verify adjust_document_stats rolls back on error."""
-        from shu.services.knowledge_base_service import KnowledgeBaseService
+
 
         mock_db = AsyncMock()
         mock_db.execute = AsyncMock(side_effect=Exception("DB error"))

--- a/backend/src/tests/unit/services/test_knowledge_base_service.py
+++ b/backend/src/tests/unit/services/test_knowledge_base_service.py
@@ -1,0 +1,298 @@
+"""Unit tests for KnowledgeBaseService performance optimizations.
+
+Tests the recalculate_kb_stats function and verifies that denormalized
+stats are properly maintained.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestRecalculateKBStats:
+    """Tests for recalculate_kb_stats method."""
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_updates_denormalized_columns(self):
+        """Verify recalculate_kb_stats updates KB document_count and total_chunks."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        # Mock database session
+        mock_db = AsyncMock()
+
+        # Mock document count query result
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = 42
+
+        # Mock chunk count query result
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = 1500
+
+        # Mock KB object
+        mock_kb = MagicMock()
+        mock_kb.document_count = 0
+        mock_kb.total_chunks = 0
+
+        # Configure mock_db.execute to return different results for different queries
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=mock_kb)
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("test-kb-id")
+
+        # Verify the KB's update_document_stats was called with correct values
+        mock_kb.update_document_stats.assert_called_once_with(42, 1500)
+
+        # Verify commit was called
+        mock_db.commit.assert_called_once()
+
+        # Verify return value
+        assert result == {"document_count": 42, "total_chunks": 1500}
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_handles_empty_kb(self):
+        """Verify recalculate_kb_stats handles KB with no documents."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        # Mock empty results
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = 0
+
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = 0
+
+        mock_kb = MagicMock()
+
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=mock_kb)
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("empty-kb-id")
+
+        mock_kb.update_document_stats.assert_called_once_with(0, 0)
+        assert result == {"document_count": 0, "total_chunks": 0}
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_handles_null_scalars(self):
+        """Verify recalculate_kb_stats handles NULL scalar results gracefully."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        # Mock NULL results (can happen with empty tables)
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = None
+
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = None
+
+        mock_kb = MagicMock()
+
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=mock_kb)
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("null-kb-id")
+
+        # Should default to 0 when scalar returns None
+        mock_kb.update_document_stats.assert_called_once_with(0, 0)
+        assert result == {"document_count": 0, "total_chunks": 0}
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_handles_missing_kb(self):
+        """Verify recalculate_kb_stats handles non-existent KB gracefully."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = 5
+
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = 50
+
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=None)  # KB not found
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("missing-kb-id")
+
+        # Should still return the counts even if KB not found
+        assert result == {"document_count": 5, "total_chunks": 50}
+        # Commit should not be called if KB is None
+        mock_db.commit.assert_not_called()
+
+
+class TestGetOverallKnowledgeBaseStats:
+    """Tests for get_overall_knowledge_base_stats aggregation fix."""
+
+    @pytest.mark.asyncio
+    async def test_aggregates_from_denormalized_stats(self):
+        """Verify get_overall_knowledge_base_stats aggregates from KB columns."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        # Mock query results in order:
+        # 1. total KB count
+        # 2. active KB count
+        # 3. sync enabled count
+        # 4. SUM(document_count)
+        # 5. SUM(total_chunks)
+        results = [
+            MagicMock(scalar=MagicMock(return_value=5)),   # total KBs
+            MagicMock(scalar=MagicMock(return_value=4)),   # active KBs
+            MagicMock(scalar=MagicMock(return_value=3)),   # sync enabled
+            MagicMock(scalar=MagicMock(return_value=150)), # total documents
+            MagicMock(scalar=MagicMock(return_value=5000)), # total chunks
+        ]
+        mock_db.execute = AsyncMock(side_effect=results)
+
+        service = KnowledgeBaseService(mock_db)
+        stats = await service.get_overall_knowledge_base_stats()
+
+        assert stats["total_knowledge_bases"] == 5
+        assert stats["active_knowledge_bases"] == 4
+        assert stats["sync_enabled_count"] == 3
+        assert stats["total_documents"] == 150
+        assert stats["total_chunks"] == 5000
+        assert stats["status_breakdown"] == {"active": 4, "inactive": 1}
+
+    @pytest.mark.asyncio
+    async def test_handles_null_sums(self):
+        """Verify get_overall_knowledge_base_stats handles NULL sums (no KBs)."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        results = [
+            MagicMock(scalar=MagicMock(return_value=0)),    # total KBs
+            MagicMock(scalar=MagicMock(return_value=0)),    # active KBs
+            MagicMock(scalar=MagicMock(return_value=0)),    # sync enabled
+            MagicMock(scalar=MagicMock(return_value=None)), # NULL sum
+            MagicMock(scalar=MagicMock(return_value=None)), # NULL sum
+        ]
+        mock_db.execute = AsyncMock(side_effect=results)
+
+        service = KnowledgeBaseService(mock_db)
+        stats = await service.get_overall_knowledge_base_stats()
+
+        # Should default to 0 when SUM returns NULL
+        assert stats["total_documents"] == 0
+        assert stats["total_chunks"] == 0
+
+
+class TestGetDocumentFilterCondition:
+    """Tests for document filter condition (title-only search)."""
+
+    def test_search_uses_title_only(self):
+        """Verify search filter only searches title, not content."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = MagicMock()
+        service = KnowledgeBaseService(mock_db)
+
+        condition = service.get_document_filter_condition(
+            kb_id="test-kb",
+            search_query="test search",
+            filter_by="all"
+        )
+
+        # Convert to string to inspect the condition
+        condition_str = str(condition)
+
+        # Should contain title ILIKE
+        assert "title" in condition_str.lower()
+        # Should NOT contain content ILIKE (removed for performance)
+        # The condition should be an AND of kb_id filter and title filter only
+
+
+class TestDocumentToListDict:
+    """Tests for Document.to_list_dict lightweight serialization."""
+
+    def test_excludes_heavy_fields(self):
+        """Verify to_list_dict excludes content, embeddings, and other heavy fields."""
+        from shu.models.document import Document
+
+        doc = Document(
+            id="test-id",
+            knowledge_base_id="kb-id",
+            title="Test Document",
+            source_type="plugin:test",
+            source_id="src-123",
+            file_type="pdf",
+            content="This is a very long content string that should not be in list view...",
+            processing_status="processed",
+        )
+        # Set heavy fields that should be excluded
+        doc.synopsis = "A synopsis that might be included in full view"
+        doc.capability_manifest = {"answers_questions_about": ["topic1", "topic2"]}
+        doc.extraction_metadata = {"pages": 100, "details": "lots of data"}
+
+        result = doc.to_list_dict()
+
+        # Should include essential fields
+        assert result["id"] == "test-id"
+        assert result["title"] == "Test Document"
+        assert result["source_type"] == "plugin:test"
+        assert result["processing_status"] == "processed"
+
+        # Should NOT include heavy fields
+        assert "content" not in result
+        assert "synopsis" not in result
+        assert "synopsis_embedding" not in result
+        assert "capability_manifest" not in result
+        assert "extraction_metadata" not in result
+        assert "source_metadata" not in result
+        assert "relational_context" not in result
+
+    def test_includes_all_list_view_fields(self):
+        """Verify to_list_dict includes all fields needed for list views."""
+        from shu.models.document import Document
+        from datetime import datetime, UTC
+
+        now = datetime.now(UTC)
+        doc = Document(
+            id="test-id",
+            knowledge_base_id="kb-id",
+            title="Test Document",
+            source_type="plugin:test",
+            source_id="src-123",
+            file_type="pdf",
+            file_size=1024,
+            mime_type="application/pdf",
+            content="content",
+            processing_status="processed",
+            extraction_method="ocr",
+            extraction_engine="paddleocr",
+            extraction_confidence=0.95,
+            source_url="https://example.com/doc.pdf",
+            word_count=500,
+            character_count=3000,
+            chunk_count=10,
+            document_type="technical",
+            profiling_status="complete",
+        )
+        doc.created_at = now
+        doc.updated_at = now
+        doc.processed_at = now
+        doc.source_modified_at = now
+
+        result = doc.to_list_dict()
+
+        # Verify all expected fields are present
+        expected_fields = [
+            "id", "knowledge_base_id", "title", "source_type", "source_id",
+            "file_type", "file_size", "mime_type", "processing_status",
+            "processing_error", "extraction_method", "extraction_engine",
+            "extraction_confidence", "source_url", "word_count", "character_count",
+            "chunk_count", "document_type", "profiling_status",
+            "created_at", "updated_at", "processed_at", "source_modified_at"
+        ]
+        for field in expected_fields:
+            assert field in result, f"Missing field: {field}"


### PR DESCRIPTION
The Knowledge Base management screen in admin is slow to load, taking several seconds even with only 5 KBs. Investigation reveals multiple inefficient query patterns that will not scale as organizations add more KBs with thousands of documents and tens of thousands of chunks. This task addresses the root causes to ensure sub-second response times regardless of data volume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Optimized knowledge base statistics retrieval through denormalized data caching, reducing query overhead.
  * Refined document search to focus on title matching.

* **Tests**
  * Added comprehensive test coverage for statistics management and data serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->