### PR TITLE
Attachment cleanup unified scheduler

### DIFF
--- a/backend/migrations/versions/007_0002_add_documents_title_index.py
+++ b/backend/migrations/versions/007_0002_add_documents_title_index.py
@@ -5,8 +5,7 @@ Revises: 007_0001_add_must_change_password
 Create Date: 2026-02-23
 
 This migration:
-1. Adds an index on documents.title for efficient ILIKE search
-2. Backfills knowledge_bases.document_count and total_chunks from actual data
+Backfills knowledge_bases.document_count and total_chunks from actual data
 
 """
 
@@ -14,17 +13,13 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "007_0002"
-down_revision = "007_0001_add_must_change_password"
+down_revision = "007_0001"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    """Add index on documents.title and backfill KB stats."""
-    # Step 1: Add title index for efficient ILIKE search
-    op.create_index("idx_documents_title", "documents", ["title"])
-
-    # Step 2: Backfill document_count for all knowledge bases
+    # Step 1: Backfill document_count for all knowledge bases
     op.execute("""
         UPDATE knowledge_bases kb
         SET document_count = COALESCE(
@@ -33,7 +28,7 @@ def upgrade() -> None:
         )
     """)
 
-    # Step 3: Backfill total_chunks for all knowledge bases
+    # Step 2: Backfill total_chunks for all knowledge bases
     op.execute("""
         UPDATE knowledge_bases kb
         SET total_chunks = COALESCE(
@@ -44,5 +39,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Remove documents.title index. Stats are not reverted (no data loss)."""
-    op.drop_index("idx_documents_title", table_name="documents")
+

--- a/backend/migrations/versions/007_0002_add_documents_title_index.py
+++ b/backend/migrations/versions/007_0002_add_documents_title_index.py
@@ -1,0 +1,48 @@
+"""Add index on documents.title and backfill KB stats.
+
+Revision ID: 007_0002
+Revises: 007_0001_add_must_change_password
+Create Date: 2026-02-23
+
+This migration:
+1. Adds an index on documents.title for efficient ILIKE search
+2. Backfills knowledge_bases.document_count and total_chunks from actual data
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "007_0002"
+down_revision = "007_0001_add_must_change_password"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add index on documents.title and backfill KB stats."""
+    # Step 1: Add title index for efficient ILIKE search
+    op.create_index("idx_documents_title", "documents", ["title"])
+
+    # Step 2: Backfill document_count for all knowledge bases
+    op.execute("""
+        UPDATE knowledge_bases kb
+        SET document_count = COALESCE(
+            (SELECT COUNT(*) FROM documents d WHERE d.knowledge_base_id = kb.id),
+            0
+        )
+    """)
+
+    # Step 3: Backfill total_chunks for all knowledge bases
+    op.execute("""
+        UPDATE knowledge_bases kb
+        SET total_chunks = COALESCE(
+            (SELECT COUNT(*) FROM document_chunks dc WHERE dc.knowledge_base_id = kb.id),
+            0
+        )
+    """)
+
+
+def downgrade() -> None:
+    """Remove documents.title index. Stats are not reverted (no data loss)."""
+    op.drop_index("idx_documents_title", table_name="documents")

--- a/backend/migrations/versions/007_0002_backfill_kb_stats.py
+++ b/backend/migrations/versions/007_0002_backfill_kb_stats.py
@@ -36,7 +36,3 @@ def upgrade() -> None:
             0
         )
     """)
-
-
-def downgrade() -> None:
-

--- a/backend/migrations/versions/007_0002_backfill_kb_stats.py
+++ b/backend/migrations/versions/007_0002_backfill_kb_stats.py
@@ -1,4 +1,4 @@
-"""Add index on documents.title and backfill KB stats.
+"""backfill KB stats.
 
 Revision ID: 007_0002
 Revises: 007_0001_add_must_change_password

--- a/backend/migrations/versions/007_0003_add_attachment_expires_at_index.py
+++ b/backend/migrations/versions/007_0003_add_attachment_expires_at_index.py
@@ -1,0 +1,25 @@
+"""Migration 007_0003: Add index on attachments.expires_at for cleanup queries.
+
+The AttachmentCleanupService queries expired attachments periodically. Without
+an index, this becomes a full table scan as the attachments table grows.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "007_0003"
+down_revision = "007_0002"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_attachments_expires_at"
+
+
+def upgrade() -> None:
+    """Add index on attachments.expires_at for efficient cleanup queries."""
+    op.create_index(INDEX_NAME, "attachments", ["expires_at"], if_not_exists=True)
+
+
+def downgrade() -> None:
+    """Remove the expires_at index."""
+    op.drop_index(INDEX_NAME, table_name="attachments", if_exists=True)

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -224,16 +224,7 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
         logger.error(f"Failed to preload embedding model: {e}", exc_info=True)
         # Don't raise here, as the app can still function without preloaded model
 
-    # Start attachments TTL cleanup scheduler
-    try:
-        from .services.attachment_cleanup import start_attachment_cleanup_scheduler
-
-        app.state.attachments_cleanup_task = await start_attachment_cleanup_scheduler()
-        logger.info("Attachment cleanup scheduler started")
-    except Exception as e:
-        logger.warning(f"Failed to start attachment cleanup scheduler: {e}")
-
-    # Start unified scheduler (plugin feeds + experiences)
+    # Start unified scheduler (plugin feeds + experiences + maintenance tasks)
     try:
         from .services.scheduler_service import start_scheduler
 
@@ -308,7 +299,6 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
 
     # Cancel and await background schedulers for clean shutdown
     task_attrs = [
-        ("attachments_cleanup", "attachments_cleanup_task"),
         ("scheduler", "scheduler_task"),
     ]
     tasks_to_cancel = []

--- a/backend/src/shu/models/attachment.py
+++ b/backend/src/shu/models/attachment.py
@@ -37,8 +37,8 @@ class Attachment(BaseModel):
     extraction_duration = Column(Float, nullable=True)
     extraction_metadata = Column(JSON, nullable=True)
 
-    # Expiration
-    expires_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    # Expiration (indexed for efficient cleanup queries)
+    expires_at = Column(TIMESTAMP(timezone=True), nullable=True, index=True)
 
     # Relationships
     conversation = relationship("Conversation", back_populates="attachments", lazy="selectin")

--- a/backend/src/shu/models/document.py
+++ b/backend/src/shu/models/document.py
@@ -182,6 +182,39 @@ class Document(BaseModel):
         )
         return base_dict
 
+    def to_list_dict(self) -> dict[str, Any]:
+        """Convert to lightweight dictionary for list views.
+
+        Excludes heavy fields like content, synopsis_embedding, capability_manifest,
+        extraction_metadata, and source_metadata to minimize response size and
+        avoid loading deferred columns.
+        """
+        return {
+            "id": self.id,
+            "knowledge_base_id": self.knowledge_base_id,
+            "title": self.title,
+            "source_type": self.source_type,
+            "source_id": self.source_id,
+            "file_type": self.file_type,
+            "file_size": self.file_size,
+            "mime_type": self.mime_type,
+            "processing_status": self.processing_status,
+            "processing_error": self.processing_error,
+            "extraction_method": self.extraction_method,
+            "extraction_engine": self.extraction_engine,
+            "extraction_confidence": self.extraction_confidence,
+            "source_url": self.source_url,
+            "word_count": self.word_count,
+            "character_count": self.character_count,
+            "chunk_count": self.chunk_count,
+            "document_type": self.document_type,
+            "profiling_status": self.profiling_status,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "processed_at": self.processed_at.isoformat() if self.processed_at else None,
+            "source_modified_at": self.source_modified_at.isoformat() if self.source_modified_at else None,
+        }
+
     @property
     def is_processed(self) -> bool:
         """Check if document has been processed successfully."""

--- a/backend/src/shu/services/attachment_cleanup.py
+++ b/backend/src/shu/services/attachment_cleanup.py
@@ -1,6 +1,5 @@
 """Scheduled cleanup for chat attachments."""
 
-import asyncio
 import logging
 import os
 from datetime import UTC, datetime
@@ -9,7 +8,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import get_settings_instance
-from ..core.database import get_db_session
 from ..models.attachment import Attachment
 
 logger = logging.getLogger(__name__)
@@ -47,28 +45,3 @@ class AttachmentCleanupService:
         if not dry_run:
             await self.db.commit()
         return deleted
-
-
-async def start_attachment_cleanup_scheduler():
-    settings = get_settings_instance()
-    interval = getattr(settings, "chat_attachment_cleanup_interval_seconds", 6 * 3600)
-
-    async def _runner() -> None:
-        while True:
-            try:
-                db = await get_db_session()
-                async with db as session:
-                    service = AttachmentCleanupService(session)
-                    count = await service.cleanup_expired_attachments()
-                    if count:
-                        logger.info(f"Attachment cleanup deleted {count} expired attachments")
-            except Exception as e:
-                logger.warning(f"Attachment cleanup run failed: {e}")
-            finally:
-                try:
-                    await asyncio.sleep(interval)
-                except asyncio.CancelledError:
-                    break
-
-    # Fire-and-forget task; caller should hold task handle if they need cancellation
-    return asyncio.create_task(_runner(), name="attachments:cleanup:scheduler")

--- a/backend/src/shu/services/scheduler_service.py
+++ b/backend/src/shu/services/scheduler_service.py
@@ -399,7 +399,7 @@ class UnifiedSchedulerService:
         return results
 
 
-async def start_scheduler() -> asyncio.Task:
+async def start_scheduler() -> asyncio.Task:  # noqa: PLR0915
     """Start the unified scheduler background task.
 
     Replaces both start_plugins_scheduler() and start_experiences_scheduler()

--- a/backend/src/tests/unit/services/test_knowledge_base_service.py
+++ b/backend/src/tests/unit/services/test_knowledge_base_service.py
@@ -1,0 +1,298 @@
+"""Unit tests for KnowledgeBaseService performance optimizations.
+
+Tests the recalculate_kb_stats function and verifies that denormalized
+stats are properly maintained.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestRecalculateKBStats:
+    """Tests for recalculate_kb_stats method."""
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_updates_denormalized_columns(self):
+        """Verify recalculate_kb_stats updates KB document_count and total_chunks."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        # Mock database session
+        mock_db = AsyncMock()
+
+        # Mock document count query result
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = 42
+
+        # Mock chunk count query result
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = 1500
+
+        # Mock KB object
+        mock_kb = MagicMock()
+        mock_kb.document_count = 0
+        mock_kb.total_chunks = 0
+
+        # Configure mock_db.execute to return different results for different queries
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=mock_kb)
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("test-kb-id")
+
+        # Verify the KB's update_document_stats was called with correct values
+        mock_kb.update_document_stats.assert_called_once_with(42, 1500)
+
+        # Verify commit was called
+        mock_db.commit.assert_called_once()
+
+        # Verify return value
+        assert result == {"document_count": 42, "total_chunks": 1500}
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_handles_empty_kb(self):
+        """Verify recalculate_kb_stats handles KB with no documents."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        # Mock empty results
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = 0
+
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = 0
+
+        mock_kb = MagicMock()
+
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=mock_kb)
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("empty-kb-id")
+
+        mock_kb.update_document_stats.assert_called_once_with(0, 0)
+        assert result == {"document_count": 0, "total_chunks": 0}
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_handles_null_scalars(self):
+        """Verify recalculate_kb_stats handles NULL scalar results gracefully."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        # Mock NULL results (can happen with empty tables)
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = None
+
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = None
+
+        mock_kb = MagicMock()
+
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=mock_kb)
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("null-kb-id")
+
+        # Should default to 0 when scalar returns None
+        mock_kb.update_document_stats.assert_called_once_with(0, 0)
+        assert result == {"document_count": 0, "total_chunks": 0}
+
+    @pytest.mark.asyncio
+    async def test_recalculate_kb_stats_handles_missing_kb(self):
+        """Verify recalculate_kb_stats handles non-existent KB gracefully."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        doc_count_result = MagicMock()
+        doc_count_result.scalar.return_value = 5
+
+        chunk_count_result = MagicMock()
+        chunk_count_result.scalar.return_value = 50
+
+        mock_db.execute = AsyncMock(side_effect=[doc_count_result, chunk_count_result])
+        mock_db.get = AsyncMock(return_value=None)  # KB not found
+        mock_db.commit = AsyncMock()
+
+        service = KnowledgeBaseService(mock_db)
+        result = await service.recalculate_kb_stats("missing-kb-id")
+
+        # Should still return the counts even if KB not found
+        assert result == {"document_count": 5, "total_chunks": 50}
+        # Commit should not be called if KB is None
+        mock_db.commit.assert_not_called()
+
+
+class TestGetOverallKnowledgeBaseStats:
+    """Tests for get_overall_knowledge_base_stats aggregation fix."""
+
+    @pytest.mark.asyncio
+    async def test_aggregates_from_denormalized_stats(self):
+        """Verify get_overall_knowledge_base_stats aggregates from KB columns."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        # Mock query results in order:
+        # 1. total KB count
+        # 2. active KB count
+        # 3. sync enabled count
+        # 4. SUM(document_count)
+        # 5. SUM(total_chunks)
+        results = [
+            MagicMock(scalar=MagicMock(return_value=5)),   # total KBs
+            MagicMock(scalar=MagicMock(return_value=4)),   # active KBs
+            MagicMock(scalar=MagicMock(return_value=3)),   # sync enabled
+            MagicMock(scalar=MagicMock(return_value=150)), # total documents
+            MagicMock(scalar=MagicMock(return_value=5000)), # total chunks
+        ]
+        mock_db.execute = AsyncMock(side_effect=results)
+
+        service = KnowledgeBaseService(mock_db)
+        stats = await service.get_overall_knowledge_base_stats()
+
+        assert stats["total_knowledge_bases"] == 5
+        assert stats["active_knowledge_bases"] == 4
+        assert stats["sync_enabled_count"] == 3
+        assert stats["total_documents"] == 150
+        assert stats["total_chunks"] == 5000
+        assert stats["status_breakdown"] == {"active": 4, "inactive": 1}
+
+    @pytest.mark.asyncio
+    async def test_handles_null_sums(self):
+        """Verify get_overall_knowledge_base_stats handles NULL sums (no KBs)."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = AsyncMock()
+
+        results = [
+            MagicMock(scalar=MagicMock(return_value=0)),    # total KBs
+            MagicMock(scalar=MagicMock(return_value=0)),    # active KBs
+            MagicMock(scalar=MagicMock(return_value=0)),    # sync enabled
+            MagicMock(scalar=MagicMock(return_value=None)), # NULL sum
+            MagicMock(scalar=MagicMock(return_value=None)), # NULL sum
+        ]
+        mock_db.execute = AsyncMock(side_effect=results)
+
+        service = KnowledgeBaseService(mock_db)
+        stats = await service.get_overall_knowledge_base_stats()
+
+        # Should default to 0 when SUM returns NULL
+        assert stats["total_documents"] == 0
+        assert stats["total_chunks"] == 0
+
+
+class TestGetDocumentFilterCondition:
+    """Tests for document filter condition (title-only search)."""
+
+    def test_search_uses_title_only(self):
+        """Verify search filter only searches title, not content."""
+        from shu.services.knowledge_base_service import KnowledgeBaseService
+
+        mock_db = MagicMock()
+        service = KnowledgeBaseService(mock_db)
+
+        condition = service.get_document_filter_condition(
+            kb_id="test-kb",
+            search_query="test search",
+            filter_by="all"
+        )
+
+        # Convert to string to inspect the condition
+        condition_str = str(condition)
+
+        # Should contain title ILIKE
+        assert "title" in condition_str.lower()
+        # Should NOT contain content ILIKE (removed for performance)
+        # The condition should be an AND of kb_id filter and title filter only
+
+
+class TestDocumentToListDict:
+    """Tests for Document.to_list_dict lightweight serialization."""
+
+    def test_excludes_heavy_fields(self):
+        """Verify to_list_dict excludes content, embeddings, and other heavy fields."""
+        from shu.models.document import Document
+
+        doc = Document(
+            id="test-id",
+            knowledge_base_id="kb-id",
+            title="Test Document",
+            source_type="plugin:test",
+            source_id="src-123",
+            file_type="pdf",
+            content="This is a very long content string that should not be in list view...",
+            processing_status="processed",
+        )
+        # Set heavy fields that should be excluded
+        doc.synopsis = "A synopsis that might be included in full view"
+        doc.capability_manifest = {"answers_questions_about": ["topic1", "topic2"]}
+        doc.extraction_metadata = {"pages": 100, "details": "lots of data"}
+
+        result = doc.to_list_dict()
+
+        # Should include essential fields
+        assert result["id"] == "test-id"
+        assert result["title"] == "Test Document"
+        assert result["source_type"] == "plugin:test"
+        assert result["processing_status"] == "processed"
+
+        # Should NOT include heavy fields
+        assert "content" not in result
+        assert "synopsis" not in result
+        assert "synopsis_embedding" not in result
+        assert "capability_manifest" not in result
+        assert "extraction_metadata" not in result
+        assert "source_metadata" not in result
+        assert "relational_context" not in result
+
+    def test_includes_all_list_view_fields(self):
+        """Verify to_list_dict includes all fields needed for list views."""
+        from shu.models.document import Document
+        from datetime import datetime, UTC
+
+        now = datetime.now(UTC)
+        doc = Document(
+            id="test-id",
+            knowledge_base_id="kb-id",
+            title="Test Document",
+            source_type="plugin:test",
+            source_id="src-123",
+            file_type="pdf",
+            file_size=1024,
+            mime_type="application/pdf",
+            content="content",
+            processing_status="processed",
+            extraction_method="ocr",
+            extraction_engine="paddleocr",
+            extraction_confidence=0.95,
+            source_url="https://example.com/doc.pdf",
+            word_count=500,
+            character_count=3000,
+            chunk_count=10,
+            document_type="technical",
+            profiling_status="complete",
+        )
+        doc.created_at = now
+        doc.updated_at = now
+        doc.processed_at = now
+        doc.source_modified_at = now
+
+        result = doc.to_list_dict()
+
+        # Verify all expected fields are present
+        expected_fields = [
+            "id", "knowledge_base_id", "title", "source_type", "source_id",
+            "file_type", "file_size", "mime_type", "processing_status",
+            "processing_error", "extraction_method", "extraction_engine",
+            "extraction_confidence", "source_url", "word_count", "character_count",
+            "chunk_count", "document_type", "profiling_status",
+            "created_at", "updated_at", "processed_at", "source_modified_at"
+        ]
+        for field in expected_fields:
+            assert field in result, f"Missing field: {field}"


### PR DESCRIPTION
**NOTE:** There are 5 files in there that are also in the `kb-query-cleanup` PR because I based this branch on that one. They can be ignored if you've alread review `kb-query-cleanup`

The `AttachmentCleanupService` currently runs its own separate scheduler loop via `start_attachment_cleanup_scheduler()`, violating the unified scheduler architecture established in SHU-571. All background maintenance tasks should use the `SchedulableSource` pattern and be registered in `UnifiedSchedulerService`. This inconsistency creates operational complexity (multiple scheduler tasks to monitor), inconsistent observability (not in `TICK_HISTORY`), and architectural drift.

This task migrates the `AttachmentCleanupService` to the `UnifiedSchedulerService` 