### PR TITLE
Multi surface retrieval v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -416,6 +416,19 @@ SHU_MAX_CHUNKS_PER_DOCUMENT_DEFAULT=2
 # Query Processing Configuration (global defaults)
 SHU_RAG_MINIMUM_QUERY_WORDS_DEFAULT=3
 
+# Multi-Surface Search Configuration
+# Multi-surface search executes multiple retrieval strategies (chunk vector,
+# synopsis match) in parallel and fuses their scores for better relevance.
+#
+# Per-surface candidate limit (how many raw hits each surface fetches before fusion)
+# This should be larger than the final output limit to give fusion enough candidates.
+SHU_MULTI_SURFACE_CHUNK_LIMIT=50
+# Timeout for each surface execution in milliseconds
+SHU_MULTI_SURFACE_TIMEOUT_MS=2000
+# Surface weights for score fusion (should sum to 1.0)
+SHU_MULTI_SURFACE_CHUNK_VECTOR_WEIGHT=0.60
+SHU_MULTI_SURFACE_SYNOPSIS_MATCH_WEIGHT=0.40
+
 # =============================================================================
 # USER PREFERENCES DEFAULTS (LEGITIMATE USER SETTINGS)
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -369,8 +369,8 @@ SHU_QUERY_SYNTHESIS_MAX_QUERIES=20
 
 # =============================================================================
 
-# Default search similarity threshold (0.0-1.0, default: 0.7)
-SHU_RAG_SEARCH_THRESHOLD_DEFAULT=0.7
+# Default search similarity threshold (0.0-1.0, default: 0.3)
+SHU_RAG_SEARCH_THRESHOLD_DEFAULT=0.3
 
 # Default maximum results to return (default: 10)
 SHU_RAG_MAX_RESULTS_DEFAULT=10
@@ -402,7 +402,7 @@ SHU_RAG_FULL_DOC_TOKEN_CAP_DEFAULT=80000
 SHU_RAG_PROMPT_TEMPLATE_DEFAULT="custom"
 
 # Hybrid Search Configuration (global defaults)
-SHU_HYBRID_SIMILARITY_WEIGHT_DEFAULT=0.7
+SHU_HYBRID_SIMILARITY_WEIGHT_DEFAULT=0.3
 SHU_HYBRID_KEYWORD_WEIGHT_DEFAULT=0.3
 
 # Title Search Configuration (global defaults)

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -427,7 +427,7 @@ class Settings(BaseSettings):
     llm_temperature_default: float = Field(0.7, alias="SHU_LLM_TEMPERATURE_DEFAULT")
 
     # RAG Configuration Defaults (global fallbacks)
-    rag_search_threshold_default: float = Field(0.7, alias="SHU_RAG_SEARCH_THRESHOLD_DEFAULT")
+    rag_search_threshold_default: float = Field(0.3, alias="SHU_RAG_SEARCH_THRESHOLD_DEFAULT")
     rag_max_results_default: int = Field(10, alias="SHU_RAG_MAX_RESULTS_DEFAULT")
     rag_chunk_overlap_ratio_default: float = Field(0.2, alias="SHU_RAG_CHUNK_OVERLAP_RATIO_DEFAULT")
     rag_search_type_default: str = Field("hybrid", alias="SHU_RAG_SEARCH_TYPE_DEFAULT")

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -117,6 +117,12 @@ class Settings(BaseSettings):
     vector_index_type: str = Field("hnsw", alias="SHU_VECTOR_INDEX_TYPE")
     vector_index_lists: int = Field(100, alias="SHU_VECTOR_INDEX_LISTS")
 
+    # Multi-surface retrieval configuration
+    multi_surface_chunk_limit: int = Field(50, alias="SHU_MULTI_SURFACE_CHUNK_LIMIT")
+    multi_surface_timeout_ms: int = Field(2000, alias="SHU_MULTI_SURFACE_TIMEOUT_MS")
+    multi_surface_chunk_vector_weight: float = Field(0.60, alias="SHU_MULTI_SURFACE_CHUNK_VECTOR_WEIGHT")
+    multi_surface_synopsis_match_weight: float = Field(0.40, alias="SHU_MULTI_SURFACE_SYNOPSIS_MATCH_WEIGHT")
+
     # Performance configuration
     batch_size: int = Field(10, alias="SHU_BATCH_SIZE")
     embedding_threads: int = Field(4, alias="SHU_EMBEDDING_THREADS")  # Thread pool size for CPU-bound embedding work

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -437,7 +437,7 @@ class Settings(BaseSettings):
     rag_prompt_template_default: str = Field("custom", alias="SHU_RAG_PROMPT_TEMPLATE_DEFAULT")
 
     # Hybrid Search Configuration (global defaults)
-    hybrid_similarity_weight_default: float = Field(0.7, alias="SHU_HYBRID_SIMILARITY_WEIGHT_DEFAULT")
+    hybrid_similarity_weight_default: float = Field(0.3, alias="SHU_HYBRID_SIMILARITY_WEIGHT_DEFAULT")
     hybrid_keyword_weight_default: float = Field(0.3, alias="SHU_HYBRID_KEYWORD_WEIGHT_DEFAULT")
 
     # Title Search Configuration (global defaults)

--- a/backend/src/shu/models/knowledge_base.py
+++ b/backend/src/shu/models/knowledge_base.py
@@ -47,7 +47,7 @@ class KnowledgeBase(BaseModel):
     rag_prompt_template = Column(
         String(20), default="custom", nullable=False
     )  # 'academic', 'business', 'technical', 'custom'
-    rag_search_threshold = Column(JSON, default=0.7, nullable=False)  # Float stored as JSON for precision
+    rag_search_threshold = Column(JSON, default=0.3, nullable=False)  # Float stored as JSON for precision
     rag_max_results = Column(Integer, default=10, nullable=False)
     rag_chunk_overlap_ratio = Column(JSON, default=0.2, nullable=False)  # Float stored as JSON for precision
     rag_search_type = Column(String(20), default="hybrid", nullable=False)  # 'similarity', 'keyword', 'hybrid'

--- a/backend/src/shu/schemas/knowledge_base.py
+++ b/backend/src/shu/schemas/knowledge_base.py
@@ -57,7 +57,7 @@ class RAGConfig(BaseModel):
         description="Prompt template type: 'academic', 'business', 'technical', or 'custom'",
     )
     search_threshold: float = Field(
-        default=0.7,
+        default=0.3,
         ge=0.1,
         le=1.0,
         description="Minimum similarity score for content to be considered relevant (0.1-1.0)",

--- a/backend/src/shu/schemas/knowledge_base.py
+++ b/backend/src/shu/schemas/knowledge_base.py
@@ -131,7 +131,7 @@ class RAGConfigResponse(BaseModel):
     reference_format: str = Field("markdown", description="Reference format")
     context_format: str = Field("detailed", description="Context format")
     prompt_template: str = Field("custom", description="Prompt template type")
-    search_threshold: float = Field(0.7, description="Minimum similarity score for relevance")
+    search_threshold: float = Field(0.3, description="Minimum similarity score for relevance")
     max_results: int = Field(10, description="Maximum number of chunks to retrieve")
     chunk_overlap_ratio: float = Field(0.2, description="Chunk overlap ratio for context continuity")
     search_type: str = Field("hybrid", description="Search type: similarity, keyword, or hybrid")

--- a/backend/src/shu/schemas/profiling.py
+++ b/backend/src/shu/schemas/profiling.py
@@ -131,6 +131,7 @@ class ProfilingResult(BaseModel):
     chunk_profiles: list[ChunkProfileResult] = Field(default_factory=list, description="Profiles for each chunk")
     profiling_mode: ProfilingMode = Field(..., description="How the document was profiled (always CHUNK_AGGREGATION)")
     success: bool = Field(True, description="Overall success status")
+    skipped: bool = Field(False, description="True if job had nothing to do (e.g., document not found)")
     error: str | None = Field(None, description="Error message if failed")
     tokens_used: int = Field(0, description="Total tokens used for profiling")
     duration_ms: int = Field(0, description="Total profiling duration in milliseconds")

--- a/backend/src/shu/schemas/query.py
+++ b/backend/src/shu/schemas/query.py
@@ -103,12 +103,12 @@ class QueryRequest(BaseModel):
 class QueryResult(BaseModel):
     """Schema for individual query results."""
 
-    chunk_id: str = Field(..., description="Document chunk ID")
+    chunk_id: str | None = Field(None, description="Document chunk ID (None for document-level matches)")
     document_id: str = Field(..., description="Document ID")
     document_title: str = Field(..., description="Document title")
     content: str = Field(..., description="Chunk content")
     similarity_score: float = Field(..., description="Similarity score")
-    chunk_index: int = Field(..., description="Chunk position in document")
+    chunk_index: int | None = Field(None, description="Chunk position in document (None for document-level matches)")
     start_char: int | None = Field(None, description="Start position in document")
     end_char: int | None = Field(None, description="End position in document")
 
@@ -116,7 +116,7 @@ class QueryResult(BaseModel):
     file_type: str = Field(..., description="Document file type")
     source_url: str | None = Field(None, description="Source URL")
     source_id: str | None = Field(None, description="Original source ID")
-    created_at: datetime = Field(..., description="Document creation timestamp")
+    created_at: datetime | None = Field(None, description="Document creation timestamp")
 
     class Config:
         """Pydantic configuration."""

--- a/backend/src/shu/schemas/query.py
+++ b/backend/src/shu/schemas/query.py
@@ -22,6 +22,7 @@ class QueryType(str, Enum):
     SIMILARITY = "similarity"
     KEYWORD = "keyword"
     HYBRID = "hybrid"
+    MULTI_SURFACE = "multi_surface"
 
 
 class RagRewriteMode(str, Enum):
@@ -70,7 +71,7 @@ class QueryRequest(BaseModel):
     @classmethod
     def validate_query_type(cls, v: str) -> str:
         """Validate query type."""
-        valid_types = ["similarity", "keyword", "hybrid"]
+        valid_types = ["similarity", "keyword", "hybrid", "multi_surface"]
         if v not in valid_types:
             raise ValueError(f"Query type must be one of: {valid_types}")
         return v

--- a/backend/src/shu/schemas/query.py
+++ b/backend/src/shu/schemas/query.py
@@ -58,6 +58,20 @@ class QueryRequest(BaseModel):
         default=RagRewriteMode.RAW_QUERY,
         description="Strategy for preparing the retrieval query before execution",
     )
+    # Title weighting options (for keyword and hybrid search)
+    title_weighting_enabled: bool | None = Field(
+        None, description="Enable title weighting boost (None = use KB config default)"
+    )
+    title_weight_multiplier: float | None = Field(
+        None, ge=1.0, le=10.0, description="Title weight multiplier (None = use KB config default)"
+    )
+    # Multi-surface search weights (for multi_surface search type)
+    chunk_vector_weight: float | None = Field(
+        None, ge=0.0, le=1.0, description="Weight for chunk vector surface (None = use config default)"
+    )
+    synopsis_match_weight: float | None = Field(
+        None, ge=0.0, le=1.0, description="Weight for synopsis match surface (None = use config default)"
+    )
 
     @field_validator("query")
     @classmethod

--- a/backend/src/shu/services/experience_executor.py
+++ b/backend/src/shu/services/experience_executor.py
@@ -757,7 +757,7 @@ class ExperienceExecutor:
                 query=query,
                 query_type=rag_config.get("search_type", "hybrid"),
                 limit=rag_config.get("max_results", 10),
-                similarity_threshold=rag_config.get("search_threshold", 0.7),
+                similarity_threshold=rag_config.get("search_threshold", 0.3),
                 include_metadata=True,
             )
 

--- a/backend/src/shu/services/profiling_orchestrator.py
+++ b/backend/src/shu/services/profiling_orchestrator.py
@@ -70,6 +70,7 @@ class ProfilingOrchestrator:
                 chunk_profiles=[],
                 profiling_mode=ProfilingMode.CHUNK_AGGREGATION,
                 success=False,
+                skipped=True,
                 error=f"Document {document_id} not found",
             )
 

--- a/backend/src/shu/services/profiling_orchestrator.py
+++ b/backend/src/shu/services/profiling_orchestrator.py
@@ -340,9 +340,9 @@ class ProfilingOrchestrator:
         queries_embedded = 0
         vector_store = await get_vector_store()
 
-        # Embed synopsis
+        # Embed synopsis using document encoder (synopses are paragraph-length text)
         if document.synopsis and document.synopsis.strip():
-            embeddings = await self._embed_texts([document.synopsis])
+            embeddings = await self._embed_texts([str(document.synopsis)])
             if not embeddings:
                 logger.warning("synopsis_embedding_empty", document_id=document.id)
             else:

--- a/backend/src/shu/services/query_service.py
+++ b/backend/src/shu/services/query_service.py
@@ -1747,8 +1747,10 @@ class QueryService:
                 processed = self.preprocess_query(query)
                 keyword_score = self._calculate_keyword_score(chunk.content, processed["keyword_terms"])
 
-                # Combine scores (same weights as hybrid search)
-                combined_score = similarity_score * 0.7 + keyword_score * 0.3
+                # Combine scores using configured hybrid search weights
+                similarity_weight = self.config_manager.get_hybrid_similarity_weight()
+                keyword_weight = self.config_manager.get_hybrid_keyword_weight()
+                combined_score = similarity_score * similarity_weight + keyword_score * keyword_weight
 
                 scored_chunks.append((chunk, combined_score))
 

--- a/backend/src/shu/services/query_service.py
+++ b/backend/src/shu/services/query_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ..core.config import ConfigurationManager
+from ..core.database import get_async_session_local
 from ..core.embedding_service import get_embedding_service
 from ..core.exceptions import ShuException
 from ..core.vector_store import get_vector_store
@@ -2111,7 +2112,7 @@ class QueryService:
                 timeout_ms=settings.multi_surface_timeout_ms,
             )
 
-            # Execute search
+            # Execute search (pass session factory for safe parallel execution)
             kb_uuid = UUID(knowledge_base_id)
             fused_results = await search_service.search(
                 query=query,
@@ -2119,7 +2120,7 @@ class QueryService:
                 keyword_terms=keyword_terms,
                 limit=limit,
                 threshold=threshold,
-                db=self.db,
+                session_factory=get_async_session_local(),
             )
 
             # Convert FusedResult to QueryResult format
@@ -2140,7 +2141,7 @@ class QueryService:
                     end_char = top_chunk.end_char
 
                 query_result = QueryResult(
-                    chunk_id=chunk_id or str(result.document_id),
+                    chunk_id=chunk_id,
                     document_id=str(result.document_id),
                     document_title=result.document_title,
                     content=content,
@@ -2151,7 +2152,7 @@ class QueryService:
                     file_type=result.file_type,
                     source_url=result.source_url,
                     source_id=result.source_id,
-                    created_at=result.created_at or datetime.now(UTC),
+                    created_at=result.created_at,
                 )
                 query_results.append(query_result)
 

--- a/backend/src/shu/services/query_service.py
+++ b/backend/src/shu/services/query_service.py
@@ -7,18 +7,23 @@ import functools
 import logging
 import re
 import time
-from datetime import UTC
+from datetime import UTC, datetime
 from typing import Any
+from uuid import UUID
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ..core.config import ConfigurationManager
+from ..core.embedding_service import get_embedding_service
 from ..core.exceptions import ShuException
+from ..core.vector_store import get_vector_store
 from ..models.document import Document
 from ..models.knowledge_base import KnowledgeBase
-from ..schemas.query import QueryRequest, SimilaritySearchRequest
+from ..schemas.query import QueryRequest, QueryResponse, QueryResult, QueryType, SimilaritySearchRequest
+from .retrieval import MultiSurfaceSearchService, ScoreFusionService
+from .retrieval.surfaces import ChunkVectorSurface, SynopsisMatchSurface
 
 logger = logging.getLogger(__name__)
 
@@ -990,6 +995,10 @@ class QueryService:
                 query_response = await self.keyword_search(knowledge_base_id, query, limit)
             elif search_type == "hybrid":
                 query_response = await self.hybrid_search(
+                    knowledge_base_id, query, limit, request.similarity_threshold or 0.0
+                )
+            elif search_type == "multi_surface":
+                query_response = await self._multi_surface_search(
                     knowledge_base_id, query, limit, request.similarity_threshold or 0.0
                 )
             else:
@@ -1969,3 +1978,157 @@ class QueryService:
         except Exception as e:
             logger.error(f"Failed to perform hybrid search: {e}", exc_info=True)
             raise ShuException(f"Failed to perform hybrid search: {e!s}", "HYBRID_SEARCH_ERROR")
+
+    @measure_execution_time
+    async def _multi_surface_search(
+        self, knowledge_base_id: str, query: str, limit: int = 10, threshold: float = 0.0
+    ) -> dict[str, Any]:
+        """Perform multi-surface search across multiple retrieval strategies.
+
+        Executes chunk vector and synopsis match surfaces in parallel,
+        fuses scores, and returns document-level results.
+
+        Args:
+            knowledge_base_id: ID of the knowledge base to search
+            query: Search query
+            limit: Maximum number of documents to return
+            threshold: Minimum score threshold for filtering results
+
+        Returns:
+            Dictionary with search results in QueryResponse format
+
+        """
+        try:
+            # Verify knowledge base exists
+            knowledge_base = await self._verify_knowledge_base(knowledge_base_id)
+
+            # Block vector search on stale or re-embedding KBs (same as similarity_search)
+            if knowledge_base.embedding_status not in ("current",):
+                from ..core.exceptions import KnowledgeBaseStaleEmbeddingsError
+
+                raise KnowledgeBaseStaleEmbeddingsError(knowledge_base_id, str(knowledge_base.embedding_status))
+
+            logger.info(
+                f"Multi-surface search: query='{query[:100]}...' kb_id={knowledge_base_id} "
+                f"limit={limit} threshold={threshold}"
+            )
+
+            # Preprocess query to extract keyword terms
+            preprocessed = self.preprocess_query(query)
+            keyword_terms = preprocessed["keyword_terms"]
+
+            # Get dependencies
+            vector_store = await get_vector_store()
+            embedding_service = await get_embedding_service()
+
+            # Get weights from config
+            settings = self.config_manager.settings
+            weights = {
+                "chunk_vector": settings.multi_surface_chunk_vector_weight,
+                "synopsis_match": settings.multi_surface_synopsis_match_weight,
+            }
+
+            # Create surfaces
+            surfaces = [
+                ChunkVectorSurface(vector_store),
+                SynopsisMatchSurface(vector_store),
+            ]
+
+            # Create fusion service with configured weights
+            fusion_service = ScoreFusionService(weights=weights)
+
+            # Create orchestrator
+            search_service = MultiSurfaceSearchService(
+                surfaces=surfaces,
+                embedding_service=embedding_service,
+                fusion_service=fusion_service,
+                surface_limit=settings.multi_surface_chunk_limit,
+                timeout_ms=settings.multi_surface_timeout_ms,
+            )
+
+            # Execute search
+            kb_uuid = UUID(knowledge_base_id)
+            fused_results = await search_service.search(
+                query=query,
+                kb_id=kb_uuid,
+                keyword_terms=keyword_terms,
+                limit=limit,
+                threshold=threshold,
+                db=self.db,
+            )
+
+            # Convert FusedResult to QueryResult format
+            query_results = []
+            for result in fused_results:
+                # Use first contributing chunk for content and chunk-level metadata if available
+                content = ""
+                chunk_id = None
+                chunk_index = 0
+                start_char = None
+                end_char = None
+                if result.contributing_chunks:
+                    top_chunk = result.contributing_chunks[0]
+                    content = top_chunk.snippet
+                    chunk_id = str(top_chunk.chunk_id)
+                    chunk_index = top_chunk.chunk_index
+                    start_char = top_chunk.start_char
+                    end_char = top_chunk.end_char
+
+                query_result = QueryResult(
+                    chunk_id=chunk_id or str(result.document_id),
+                    document_id=str(result.document_id),
+                    document_title=result.document_title,
+                    content=content,
+                    similarity_score=result.final_score,
+                    chunk_index=chunk_index,
+                    start_char=start_char,
+                    end_char=end_char,
+                    file_type=result.file_type,
+                    source_url=result.source_url,
+                    source_id=result.source_id,
+                    created_at=result.created_at or datetime.now(UTC),
+                )
+                query_results.append(query_result)
+
+            response = QueryResponse(
+                results=query_results,
+                total_results=len(query_results),
+                query=query,
+                query_type=QueryType.MULTI_SURFACE,
+                execution_time=0.0,  # Will be set by decorator
+                similarity_threshold=threshold,
+                embedding_model=str(knowledge_base.embedding_model),
+                processed_at=datetime.now(UTC),
+            )
+
+            # Add multi-surface metadata to response
+            response_dict = response.model_dump()
+            response_dict["multi_surface_results"] = [
+                {
+                    "document_id": str(r.document_id),
+                    "document_title": r.document_title,
+                    "final_score": r.final_score,
+                    "surface_scores": r.surface_scores,
+                    "contributing_chunks": [
+                        {
+                            "chunk_id": str(c.chunk_id),
+                            "chunk_index": c.chunk_index,
+                            "surface": c.surface,
+                            "score": c.score,
+                            "snippet": c.snippet,
+                            "summary": c.summary,
+                        }
+                        for c in r.contributing_chunks
+                    ],
+                }
+                for r in fused_results
+            ]
+
+            return response_dict
+
+        except ShuException:
+            # Re-raise ShuException without modification (preserves KnowledgeBaseNotFoundError, etc.)
+            raise
+        except Exception as e:
+            logger.error(f"Failed to perform multi-surface search: {e}", exc_info=True)
+            raise ShuException(f"Failed to perform multi-surface search: {e!s}", "MULTI_SURFACE_SEARCH_ERROR")

--- a/backend/src/shu/services/query_service.py
+++ b/backend/src/shu/services/query_service.py
@@ -992,14 +992,30 @@ class QueryService:
                     processed_at=datetime.now(UTC),
                 )
             elif search_type == "keyword":
-                query_response = await self.keyword_search(knowledge_base_id, query, limit)
+                query_response = await self.keyword_search(
+                    knowledge_base_id,
+                    query,
+                    limit,
+                    title_weighting_enabled=request.title_weighting_enabled,
+                    title_weight_multiplier=request.title_weight_multiplier,
+                )
             elif search_type == "hybrid":
                 query_response = await self.hybrid_search(
-                    knowledge_base_id, query, limit, request.similarity_threshold or 0.0
+                    knowledge_base_id,
+                    query,
+                    limit,
+                    request.similarity_threshold or 0.0,
+                    title_weighting_enabled=request.title_weighting_enabled,
+                    title_weight_multiplier=request.title_weight_multiplier,
                 )
             elif search_type == "multi_surface":
                 query_response = await self._multi_surface_search(
-                    knowledge_base_id, query, limit, request.similarity_threshold or 0.0
+                    knowledge_base_id,
+                    query,
+                    limit,
+                    request.similarity_threshold or 0.0,
+                    chunk_vector_weight=request.chunk_vector_weight,
+                    synopsis_match_weight=request.synopsis_match_weight,
                 )
             else:
                 raise ShuException(f"Unsupported search type: {search_type}", "UNSUPPORTED_SEARCH_TYPE")
@@ -1141,7 +1157,15 @@ class QueryService:
 
     # TODO: Refactor this function. It's too complex (number of branches and statements).
     @measure_execution_time
-    async def keyword_search(self, knowledge_base_id: str, query: str, limit: int = 10) -> dict[str, Any]:  # noqa: PLR0912, PLR0915
+    async def keyword_search(  # noqa: PLR0912, PLR0915
+        self,
+        knowledge_base_id: str,
+        query: str,
+        limit: int = 10,
+        *,
+        title_weighting_enabled: bool | None = None,
+        title_weight_multiplier: float | None = None,
+    ) -> dict[str, Any]:
         """Perform keyword search on document chunks with improved term extraction."""
         try:
             # Verify knowledge base exists
@@ -1263,13 +1287,23 @@ class QueryService:
 
             # Note: where_clauses used for building SQLAlchemy conditions below
 
-            # Get title weighting configuration
+            # Get title weighting configuration (request params override KB config)
             kb_config = knowledge_base.get_rag_config()
-            title_weighting_enabled = self.config_manager.get_title_weighting_enabled(kb_config=kb_config)
-            title_weight_multiplier = self.config_manager.get_title_weight_multiplier(kb_config=kb_config)
+            effective_title_weighting_enabled = (
+                title_weighting_enabled
+                if title_weighting_enabled is not None
+                else self.config_manager.get_title_weighting_enabled(kb_config=kb_config)
+            )
+            effective_title_weight_multiplier = (
+                title_weight_multiplier
+                if title_weight_multiplier is not None
+                else self.config_manager.get_title_weight_multiplier(kb_config=kb_config)
+            )
 
             logger.info(
-                f"Keyword search title weighting: enabled={title_weighting_enabled}, multiplier={title_weight_multiplier}, kb_config_title_weighting={kb_config.get('title_weighting_enabled')}"
+                f"Keyword search title weighting: enabled={effective_title_weighting_enabled}, "
+                f"multiplier={effective_title_weight_multiplier}, "
+                f"from_request={title_weighting_enabled is not None}"
             )
 
             # Build title match conditions for enhanced scoring (whole word matches only)
@@ -1374,7 +1408,7 @@ class QueryService:
             title_match_sql = " OR ".join(title_match_conditions) if title_match_conditions else "FALSE"
 
             # Check if title weighting is enabled and we have title matches
-            if title_weighting_enabled:
+            if effective_title_weighting_enabled:
                 # First, find documents with title matches
                 from sqlalchemy import text
 
@@ -1415,7 +1449,7 @@ class QueryService:
 
                         # Convert to the expected format and apply title boost
                         for chunk_data in doc_chunks:
-                            title_boost = (float(title_match.title_score) / 10.0) * title_weight_multiplier
+                            title_boost = (float(title_match.title_score) / 10.0) * effective_title_weight_multiplier
                             boosted_score = chunk_data["similarity_score"] + title_boost
 
                             # Create a chunk-like object for compatibility
@@ -1765,7 +1799,14 @@ class QueryService:
 
     @measure_execution_time
     async def hybrid_search(  # noqa: PLR0915
-        self, knowledge_base_id: str, query: str, limit: int = 10, threshold: float = 0.0
+        self,
+        knowledge_base_id: str,
+        query: str,
+        limit: int = 10,
+        threshold: float = 0.0,
+        *,
+        title_weighting_enabled: bool | None = None,
+        title_weight_multiplier: float | None = None,
     ) -> dict[str, Any]:
         """Perform hybrid search (combination of similarity and keyword).
 
@@ -1815,7 +1856,13 @@ class QueryService:
                     raise
 
             # Get keyword search results (this handles stop word filtering correctly)
-            keyword_response = await self.keyword_search(knowledge_base_id, query, limit)
+            keyword_response = await self.keyword_search(
+                knowledge_base_id,
+                query,
+                limit,
+                title_weighting_enabled=title_weighting_enabled,
+                title_weight_multiplier=title_weight_multiplier,
+            )
 
             # Log keyword search results for debugging
             logger.info(
@@ -1981,7 +2028,14 @@ class QueryService:
 
     @measure_execution_time
     async def _multi_surface_search(
-        self, knowledge_base_id: str, query: str, limit: int = 10, threshold: float = 0.0
+        self,
+        knowledge_base_id: str,
+        query: str,
+        limit: int = 10,
+        threshold: float = 0.0,
+        *,
+        chunk_vector_weight: float | None = None,
+        synopsis_match_weight: float | None = None,
     ) -> dict[str, Any]:
         """Perform multi-surface search across multiple retrieval strategies.
 
@@ -1993,6 +2047,8 @@ class QueryService:
             query: Search query
             limit: Maximum number of documents to return
             threshold: Minimum score threshold for filtering results
+            chunk_vector_weight: Weight for chunk vector surface (None = use config default)
+            synopsis_match_weight: Weight for synopsis match surface (None = use config default)
 
         Returns:
             Dictionary with search results in QueryResponse format
@@ -2021,12 +2077,21 @@ class QueryService:
             vector_store = await get_vector_store()
             embedding_service = await get_embedding_service()
 
-            # Get weights from config
+            # Get weights (request params override config defaults)
             settings = self.config_manager.settings
             weights = {
-                "chunk_vector": settings.multi_surface_chunk_vector_weight,
-                "synopsis_match": settings.multi_surface_synopsis_match_weight,
+                "chunk_vector": (
+                    chunk_vector_weight
+                    if chunk_vector_weight is not None
+                    else settings.multi_surface_chunk_vector_weight
+                ),
+                "synopsis_match": (
+                    synopsis_match_weight
+                    if synopsis_match_weight is not None
+                    else settings.multi_surface_synopsis_match_weight
+                ),
             }
+            logger.info(f"Multi-surface weights: {weights}")
 
             # Create surfaces
             surfaces = [

--- a/backend/src/shu/services/retrieval/__init__.py
+++ b/backend/src/shu/services/retrieval/__init__.py
@@ -1,0 +1,25 @@
+"""Multi-surface retrieval services.
+
+This package implements multi-surface search with parallel execution
+and score fusion across multiple retrieval strategies.
+"""
+
+from .multi_surface_search import MultiSurfaceSearchService
+from .protocol import (
+    ContributingChunk,
+    FusedResult,
+    RetrievalSurface,
+    SurfaceHit,
+    SurfaceResult,
+)
+from .score_fusion import ScoreFusionService
+
+__all__ = [
+    "ContributingChunk",
+    "FusedResult",
+    "MultiSurfaceSearchService",
+    "RetrievalSurface",
+    "ScoreFusionService",
+    "SurfaceHit",
+    "SurfaceResult",
+]

--- a/backend/src/shu/services/retrieval/multi_surface_search.py
+++ b/backend/src/shu/services/retrieval/multi_surface_search.py
@@ -88,7 +88,7 @@ class MultiSurfaceSearchService:
         # Step 1: Generate query embedding
         query_vector = await self._embedding_service.embed_query(query)
 
-        # Step 3: Execute all surfaces in parallel
+        # Step 2: Execute all surfaces in parallel
         tasks = [
             self._execute_surface(
                 surface,
@@ -103,7 +103,7 @@ class MultiSurfaceSearchService:
 
         surface_results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Step 4: Filter out exceptions and log warnings
+        # Step 3: Filter out exceptions and collect valid results
         valid_results: list[SurfaceResult] = []
         for i, result in enumerate(surface_results):
             if isinstance(result, Exception):

--- a/backend/src/shu/services/retrieval/multi_surface_search.py
+++ b/backend/src/shu/services/retrieval/multi_surface_search.py
@@ -11,13 +11,13 @@ import time
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
 from ...core.logging import get_logger
 from .protocol import FusedResult, RetrievalSurface, SurfaceResult
 from .score_fusion import ScoreFusionService
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
-
     from shu.core.embedding_service import EmbeddingService
 
 logger = get_logger(__name__)
@@ -67,7 +67,7 @@ class MultiSurfaceSearchService:
         keyword_terms: list[str],
         limit: int = 10,
         threshold: float = 0.0,
-        db: AsyncSession,
+        session_factory: async_sessionmaker,
     ) -> list[FusedResult]:
         """Execute multi-surface search and return fused results.
 
@@ -77,7 +77,8 @@ class MultiSurfaceSearchService:
             keyword_terms: Pre-extracted keyword terms from query preprocessing.
             limit: Maximum number of documents to return.
             threshold: Minimum final score threshold.
-            db: Async database session.
+            session_factory: Factory for creating database sessions. Each surface
+                gets its own session to allow safe parallel execution.
 
         Returns:
             List of FusedResult sorted by final_score descending.
@@ -88,7 +89,10 @@ class MultiSurfaceSearchService:
         # Step 1: Generate query embedding
         query_vector = await self._embedding_service.embed_query(query)
 
-        # Step 2: Execute all surfaces in parallel
+        # Step 2: Execute all surfaces in parallel (each gets its own session)
+        # NOTE: Each surface checks out a connection from the pool. With N surfaces + 1 fusion,
+        # that's N+1 connections per search. If pool pressure becomes an issue under load,
+        # add an asyncio.Semaphore here to limit concurrent surface execution.
         tasks = [
             self._execute_surface(
                 surface,
@@ -96,7 +100,7 @@ class MultiSurfaceSearchService:
                 query_vector=query_vector,
                 keyword_terms=keyword_terms,
                 kb_id=kb_id,
-                db=db,
+                session_factory=session_factory,
             )
             for surface in self._surfaces
         ]
@@ -126,13 +130,14 @@ class MultiSurfaceSearchService:
             )
             return []
 
-        # Step 5: Fuse results
-        fused_results = await self._fusion_service.fuse(
-            valid_results,
-            limit=limit,
-            threshold=threshold,
-            db=db,
-        )
+        # Step 5: Fuse results (fusion gets its own session)
+        async with session_factory() as db:
+            fused_results = await self._fusion_service.fuse(
+                valid_results,
+                limit=limit,
+                threshold=threshold,
+                db=db,
+            )
 
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         logger.info(
@@ -156,9 +161,12 @@ class MultiSurfaceSearchService:
         query_vector: list[float],
         keyword_terms: list[str],
         kb_id: UUID,
-        db: AsyncSession,
+        session_factory: async_sessionmaker,
     ) -> SurfaceResult:
         """Execute a single surface with timeout.
+
+        Each surface gets its own database session to allow safe parallel
+        execution without sharing AsyncSession across concurrent coroutines.
 
         Args:
             surface: The surface to execute.
@@ -166,7 +174,7 @@ class MultiSurfaceSearchService:
             query_vector: Pre-computed query embedding.
             keyword_terms: Extracted keyword terms.
             kb_id: Knowledge base ID.
-            db: Database session.
+            session_factory: Factory for creating database sessions.
 
         Returns:
             SurfaceResult from the surface.
@@ -177,15 +185,16 @@ class MultiSurfaceSearchService:
         """
         timeout_seconds = self._timeout_ms / 1000
 
-        return await asyncio.wait_for(
-            surface.search(
-                query_text,
-                query_vector,
-                keyword_terms,
-                kb_id=kb_id,
-                limit=self._surface_limit,
-                threshold=0.0,  # Let fusion handle threshold
-                db=db,
-            ),
-            timeout=timeout_seconds,
-        )
+        async with session_factory() as db:
+            return await asyncio.wait_for(
+                surface.search(
+                    query_text,
+                    query_vector,
+                    keyword_terms,
+                    kb_id=kb_id,
+                    limit=self._surface_limit,
+                    threshold=0.0,  # Let fusion handle threshold
+                    db=db,
+                ),
+                timeout=timeout_seconds,
+            )

--- a/backend/src/shu/services/retrieval/multi_surface_search.py
+++ b/backend/src/shu/services/retrieval/multi_surface_search.py
@@ -1,0 +1,191 @@
+"""MultiSurfaceSearchService - Orchestrator for multi-surface retrieval.
+
+Coordinates parallel execution of multiple retrieval surfaces and
+delegates score fusion to ScoreFusionService.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from ...core.logging import get_logger
+from .protocol import FusedResult, RetrievalSurface, SurfaceResult
+from .score_fusion import ScoreFusionService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from shu.core.embedding_service import EmbeddingService
+
+logger = get_logger(__name__)
+
+# Default configuration
+DEFAULT_SURFACE_LIMIT = 50
+DEFAULT_TIMEOUT_MS = 2000
+
+
+class MultiSurfaceSearchService:
+    """Orchestrator for multi-surface retrieval.
+
+    Executes multiple retrieval surfaces in parallel and fuses their
+    results into a ranked list of documents.
+    """
+
+    def __init__(
+        self,
+        surfaces: list[RetrievalSurface],
+        embedding_service: EmbeddingService,
+        fusion_service: ScoreFusionService | None = None,
+        *,
+        surface_limit: int = DEFAULT_SURFACE_LIMIT,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+    ) -> None:
+        """Initialize the multi-surface search service.
+
+        Args:
+            surfaces: List of retrieval surfaces to execute.
+            embedding_service: Service for generating query embeddings.
+            fusion_service: Service for fusing results. If None, creates default.
+            surface_limit: Max results per surface.
+            timeout_ms: Timeout for surface execution in milliseconds.
+
+        """
+        self._surfaces = surfaces
+        self._embedding_service = embedding_service
+        self._fusion_service = fusion_service or ScoreFusionService()
+        self._surface_limit = surface_limit
+        self._timeout_ms = timeout_ms
+
+    async def search(
+        self,
+        query: str,
+        kb_id: UUID,
+        *,
+        keyword_terms: list[str],
+        limit: int = 10,
+        threshold: float = 0.0,
+        db: AsyncSession,
+    ) -> list[FusedResult]:
+        """Execute multi-surface search and return fused results.
+
+        Args:
+            query: The search query text.
+            kb_id: Knowledge base ID to scope the search.
+            keyword_terms: Pre-extracted keyword terms from query preprocessing.
+            limit: Maximum number of documents to return.
+            threshold: Minimum final score threshold.
+            db: Async database session.
+
+        Returns:
+            List of FusedResult sorted by final_score descending.
+
+        """
+        start_time = time.perf_counter()
+
+        # Step 1: Generate query embedding
+        query_vector = await self._embedding_service.embed_query(query)
+
+        # Step 3: Execute all surfaces in parallel
+        tasks = [
+            self._execute_surface(
+                surface,
+                query_text=query,
+                query_vector=query_vector,
+                keyword_terms=keyword_terms,
+                kb_id=kb_id,
+                db=db,
+            )
+            for surface in self._surfaces
+        ]
+
+        surface_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Step 4: Filter out exceptions and log warnings
+        valid_results: list[SurfaceResult] = []
+        for i, result in enumerate(surface_results):
+            if isinstance(result, Exception):
+                surface_name = self._surfaces[i].name
+                logger.warning(
+                    "Surface execution failed",
+                    extra={
+                        "surface": surface_name,
+                        "error": str(result),
+                        "error_type": type(result).__name__,
+                    },
+                )
+            elif isinstance(result, SurfaceResult):
+                valid_results.append(result)
+
+        if not valid_results:
+            logger.warning(
+                "All surfaces failed or returned no results",
+                extra={"query": query[:100], "kb_id": str(kb_id)},
+            )
+            return []
+
+        # Step 5: Fuse results
+        fused_results = await self._fusion_service.fuse(
+            valid_results,
+            limit=limit,
+            threshold=threshold,
+            db=db,
+        )
+
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
+        logger.info(
+            "Multi-surface search completed",
+            extra={
+                "query": query[:100],
+                "kb_id": str(kb_id),
+                "surfaces_executed": len(valid_results),
+                "results_returned": len(fused_results),
+                "execution_time_ms": round(elapsed_ms, 2),
+            },
+        )
+
+        return fused_results
+
+    async def _execute_surface(
+        self,
+        surface: RetrievalSurface,
+        *,
+        query_text: str,
+        query_vector: list[float],
+        keyword_terms: list[str],
+        kb_id: UUID,
+        db: AsyncSession,
+    ) -> SurfaceResult:
+        """Execute a single surface with timeout.
+
+        Args:
+            surface: The surface to execute.
+            query_text: Original query text.
+            query_vector: Pre-computed query embedding.
+            keyword_terms: Extracted keyword terms.
+            kb_id: Knowledge base ID.
+            db: Database session.
+
+        Returns:
+            SurfaceResult from the surface.
+
+        Raises:
+            asyncio.TimeoutError: If surface execution exceeds timeout.
+
+        """
+        timeout_seconds = self._timeout_ms / 1000
+
+        return await asyncio.wait_for(
+            surface.search(
+                query_text,
+                query_vector,
+                keyword_terms,
+                kb_id=kb_id,
+                limit=self._surface_limit,
+                threshold=0.0,  # Let fusion handle threshold
+                db=db,
+            ),
+            timeout=timeout_seconds,
+        )

--- a/backend/src/shu/services/retrieval/protocol.py
+++ b/backend/src/shu/services/retrieval/protocol.py
@@ -1,0 +1,143 @@
+"""Protocol and types for multi-surface retrieval.
+
+Defines the RetrievalSurface protocol and associated dataclasses that
+all retrieval surfaces must implement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass(frozen=True)
+class SurfaceHit:
+    """A single hit from a retrieval surface.
+
+    Attributes:
+        id: The chunk_id or document_id depending on id_type.
+        id_type: Whether this hit refers to a chunk or document.
+        score: Normalized similarity score (0.0-1.0).
+        metadata: Surface-specific metadata (e.g., matched text, position).
+
+    """
+
+    id: UUID
+    id_type: Literal["chunk", "document"]
+    score: float
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SurfaceResult:
+    """Results from a single retrieval surface.
+
+    Attributes:
+        surface_name: Name of the surface that produced these results.
+        hits: List of hits sorted by score descending.
+        execution_time_ms: Time taken to execute the search.
+
+    """
+
+    surface_name: str
+    hits: list[SurfaceHit]
+    execution_time_ms: float
+
+
+@dataclass(frozen=True)
+class ContributingChunk:
+    """A chunk that contributed to a fused result.
+
+    Attributes:
+        chunk_id: The chunk's UUID.
+        chunk_index: Position of the chunk within its document.
+        surface: Name of the surface that found this chunk.
+        score: The chunk's score from that surface.
+        snippet: Text excerpt from the chunk.
+        summary: Optional chunk summary if available.
+        start_char: Start character offset in the source document.
+        end_char: End character offset in the source document.
+
+    """
+
+    chunk_id: UUID
+    chunk_index: int
+    surface: str
+    score: float
+    snippet: str
+    summary: str | None = None
+    start_char: int | None = None
+    end_char: int | None = None
+
+
+@dataclass
+class FusedResult:
+    """A document-level result after score fusion across surfaces.
+
+    Attributes:
+        document_id: The document's UUID.
+        document_title: Title of the document.
+        final_score: Weighted combined score from all surfaces.
+        surface_scores: Per-surface scores that contributed to final_score.
+        contributing_chunks: Chunks from this document across all surfaces.
+        file_type: Document file type (e.g., "pdf", "txt", "docx").
+        source_url: URL of the source document if available.
+        source_id: External source identifier if available.
+        created_at: Document creation timestamp.
+
+    """
+
+    document_id: UUID
+    document_title: str
+    final_score: float
+    surface_scores: dict[str, float]
+    contributing_chunks: list[ContributingChunk]
+    file_type: str = "txt"
+    source_url: str | None = None
+    source_id: str | None = None
+    created_at: datetime | None = None
+
+
+@runtime_checkable
+class RetrievalSurface(Protocol):
+    """Protocol for retrieval surfaces.
+
+    Each surface implements a different retrieval strategy (vector similarity,
+    keyword matching, synopsis matching, etc.) and returns normalized results
+    that can be fused together.
+    """
+
+    name: str
+
+    async def search(
+        self,
+        query_text: str,
+        query_vector: list[float],
+        keyword_terms: list[str],
+        *,
+        kb_id: UUID,
+        limit: int = 50,
+        threshold: float = 0.0,
+        db: AsyncSession,
+    ) -> SurfaceResult:
+        """Execute a search against this surface.
+
+        Args:
+            query_text: The original query text.
+            query_vector: Pre-computed embedding vector for the query.
+            keyword_terms: Extracted keyword terms for keyword-based surfaces.
+            kb_id: Knowledge base ID to scope the search.
+            limit: Maximum number of results to return.
+            threshold: Minimum score threshold (0.0-1.0).
+            db: Async database session.
+
+        Returns:
+            SurfaceResult with hits and execution time.
+
+        """
+        ...

--- a/backend/src/shu/services/retrieval/score_fusion.py
+++ b/backend/src/shu/services/retrieval/score_fusion.py
@@ -136,16 +136,23 @@ class ScoreFusionService:
             total_weight = 0.0
 
             for surface_name, hits in surface_hits.items():
+                weight = self._weights.get(surface_name, 0.1)
+                if weight <= 0:
+                    # Skip surfaces with non-positive weights
+                    continue
+
                 # Use max score from this surface for this document
                 max_score = max(h.score for h in hits)
                 surface_scores[surface_name] = max_score
-
-                weight = self._weights.get(surface_name, 0.1)
                 weighted_sum += max_score * weight
                 total_weight += weight
 
+            # Skip documents with no valid surface contributions
+            if total_weight == 0:
+                continue
+
             # Normalize by total weight used
-            final_score = weighted_sum / total_weight if total_weight > 0 else 0.0
+            final_score = weighted_sum / total_weight
             doc_scores[doc_id] = (final_score, surface_scores)
 
         # Step 5: Filter by threshold and sort

--- a/backend/src/shu/services/retrieval/score_fusion.py
+++ b/backend/src/shu/services/retrieval/score_fusion.py
@@ -1,0 +1,320 @@
+"""ScoreFusionService - Weighted score fusion across retrieval surfaces.
+
+Aggregates results from multiple retrieval surfaces, groups by document,
+applies weighted combination, and returns ranked FusedResults.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import select
+
+from ...core.logging import get_logger
+from ...models.document import Document, DocumentChunk
+from .protocol import ContributingChunk, FusedResult, SurfaceHit, SurfaceResult
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = get_logger(__name__)
+
+# Default surface weights (can be overridden via config)
+DEFAULT_SURFACE_WEIGHTS: dict[str, float] = {
+    "chunk_vector": 0.60,
+    "synopsis_match": 0.40,
+    # Future surfaces (PR 2+):
+    # "query_match": 0.25,
+    # "keyword_match": 0.15,
+    # "topic_match": 0.10,
+}
+
+# Maximum snippet length for contributing chunks
+MAX_SNIPPET_LENGTH = 200
+
+
+def _ensure_uuid(val: "UUID | str") -> UUID:
+    """Convert a value to UUID, handling both string and UUID inputs.
+
+    asyncpg returns UUID columns as uuid.UUID objects, while some test mocks
+    return strings. This helper handles both cases safely.
+    """
+    return val if isinstance(val, UUID) else UUID(val)
+
+
+class ScoreFusionService:
+    """Service for fusing scores from multiple retrieval surfaces.
+
+    Takes results from multiple surfaces, groups hits by document,
+    applies weighted combination, and produces ranked FusedResults.
+    """
+
+    def __init__(self, weights: dict[str, float] | None = None) -> None:
+        """Initialize with optional custom weights.
+
+        Args:
+            weights: Mapping of surface_name -> weight. If not provided,
+                     uses DEFAULT_SURFACE_WEIGHTS.
+
+        """
+        self._weights = weights or DEFAULT_SURFACE_WEIGHTS
+
+    async def fuse(  # noqa: PLR0912, PLR0915
+        self,
+        surface_results: list[SurfaceResult],
+        *,
+        query_type: str | None = None,
+        limit: int = 10,
+        threshold: float = 0.0,
+        db: AsyncSession,
+    ) -> list[FusedResult]:
+        """Fuse results from multiple surfaces into ranked document results.
+
+        Args:
+            surface_results: Results from each surface.
+            query_type: Optional query type for future weight adjustments.
+                Currently unused; reserved for query-type-specific weight
+                overrides (e.g., factual vs interpretive queries).
+            limit: Maximum number of documents to return.
+            threshold: Minimum final score threshold.
+            db: Async database session.
+
+        Returns:
+            List of FusedResult sorted by final_score descending.
+
+        """
+        # TODO: Use query_type to select weight overrides when implemented
+        _ = query_type  # Unused for now
+        if not surface_results:
+            return []
+
+        # Step 1: Collect all chunk IDs that need document_id lookup
+        chunk_ids_to_resolve: set[UUID] = set()
+        for result in surface_results:
+            for hit in result.hits:
+                if hit.id_type == "chunk":
+                    chunk_ids_to_resolve.add(hit.id)
+
+        # Step 2: Resolve chunk_id -> document_id mapping
+        chunk_to_doc: dict[UUID, UUID] = {}
+        if chunk_ids_to_resolve:
+            chunk_to_doc = await self._resolve_chunk_documents(list(chunk_ids_to_resolve), db)
+
+        # Step 3: Group hits by document_id
+        # doc_hits[document_id][surface_name] = list of (hit, chunk_id_or_none)
+        doc_hits: dict[UUID, dict[str, list[SurfaceHit]]] = defaultdict(lambda: defaultdict(list))
+
+        for result in surface_results:
+            surface_name = result.surface_name
+            for hit in result.hits:
+                if hit.id_type == "document":
+                    doc_id = hit.id
+                else:
+                    # Chunk hit - look up document
+                    doc_id = chunk_to_doc.get(hit.id)
+                    if doc_id is None:
+                        logger.warning(
+                            "Chunk not found in document mapping",
+                            extra={"chunk_id": str(hit.id)},
+                        )
+                        continue
+
+                doc_hits[doc_id][surface_name].append(hit)
+
+        if not doc_hits:
+            return []
+
+        # Step 4: Compute weighted scores per document
+        doc_scores: dict[UUID, tuple[float, dict[str, float]]] = {}
+        for doc_id, surface_hits in doc_hits.items():
+            surface_scores: dict[str, float] = {}
+            weighted_sum = 0.0
+            total_weight = 0.0
+
+            for surface_name, hits in surface_hits.items():
+                # Use max score from this surface for this document
+                max_score = max(h.score for h in hits)
+                surface_scores[surface_name] = max_score
+
+                weight = self._weights.get(surface_name, 0.1)
+                weighted_sum += max_score * weight
+                total_weight += weight
+
+            # Normalize by total weight used
+            final_score = weighted_sum / total_weight if total_weight > 0 else 0.0
+            doc_scores[doc_id] = (final_score, surface_scores)
+
+        # Step 5: Filter by threshold and sort
+        filtered_docs = [
+            (doc_id, score, surface_scores)
+            for doc_id, (score, surface_scores) in doc_scores.items()
+            if score >= threshold
+        ]
+        filtered_docs.sort(key=lambda x: x[1], reverse=True)
+        top_docs = filtered_docs[:limit]
+
+        if not top_docs:
+            return []
+
+        # Step 6: Load document metadata and chunk details
+        doc_ids = [d[0] for d in top_docs]
+        doc_metadata = await self._load_document_metadata(doc_ids, db)
+
+        # Collect all chunk IDs for contributing chunks
+        all_chunk_ids: set[UUID] = set()
+        for doc_id, surface_hits in doc_hits.items():
+            if doc_id in doc_ids:
+                for _, hits in surface_hits.items():
+                    for hit in hits:
+                        if hit.id_type == "chunk":
+                            all_chunk_ids.add(hit.id)
+
+        chunk_details = await self._load_chunk_details(list(all_chunk_ids), db)
+
+        # Step 7: Build FusedResults
+        results: list[FusedResult] = []
+        for doc_id, final_score, surface_scores in top_docs:
+            contributing_chunks: list[ContributingChunk] = []
+
+            # Collect contributing chunks from all surfaces
+            for surface_name, hits in doc_hits[doc_id].items():
+                for hit in hits:
+                    if hit.id_type == "chunk":
+                        details = chunk_details.get(hit.id)
+                        if details:
+                            chunk_index, content, summary, start_char, end_char = details
+                            snippet = self._make_snippet(content)
+                            contributing_chunks.append(
+                                ContributingChunk(
+                                    chunk_id=hit.id,
+                                    chunk_index=chunk_index,
+                                    surface=surface_name,
+                                    score=hit.score,
+                                    snippet=snippet,
+                                    summary=summary,
+                                    start_char=start_char,
+                                    end_char=end_char,
+                                )
+                            )
+
+            # Sort contributing chunks by score descending
+            contributing_chunks.sort(key=lambda c: c.score, reverse=True)
+
+            # Get document metadata (title, file_type, source_url, source_id, created_at)
+            title, file_type, source_url, source_id, created_at = doc_metadata.get(
+                doc_id, ("Unknown", "txt", None, None, None)
+            )
+
+            results.append(
+                FusedResult(
+                    document_id=doc_id,
+                    document_title=title,
+                    final_score=final_score,
+                    surface_scores=surface_scores,
+                    contributing_chunks=contributing_chunks,
+                    file_type=file_type,
+                    source_url=source_url,
+                    source_id=source_id,
+                    created_at=created_at,
+                )
+            )
+
+        return results
+
+    async def _resolve_chunk_documents(self, chunk_ids: list[UUID], db: AsyncSession) -> dict[UUID, UUID]:
+        """Look up document_id for each chunk_id.
+
+        Args:
+            chunk_ids: List of chunk IDs to resolve.
+            db: Async database session.
+
+        Returns:
+            Mapping of chunk_id -> document_id.
+
+        """
+        if not chunk_ids:
+            return {}
+
+        stmt = select(DocumentChunk.id, DocumentChunk.document_id).where(
+            DocumentChunk.id.in_([str(cid) for cid in chunk_ids])
+        )
+        result = await db.execute(stmt)
+        rows = result.fetchall()
+
+        return {_ensure_uuid(row[0]): _ensure_uuid(row[1]) for row in rows}
+
+    async def _load_document_metadata(
+        self, doc_ids: list[UUID], db: AsyncSession
+    ) -> dict[UUID, tuple[str, str, str | None, str | None, "datetime | None"]]:
+        """Load document metadata for a list of document IDs.
+
+        Args:
+            doc_ids: List of document IDs.
+            db: Async database session.
+
+        Returns:
+            Mapping of document_id -> (title, file_type, source_url, source_id, created_at).
+
+        """
+        if not doc_ids:
+            return {}
+
+        stmt = select(
+            Document.id,
+            Document.title,
+            Document.file_type,
+            Document.source_url,
+            Document.source_id,
+            Document.created_at,
+        ).where(Document.id.in_([str(did) for did in doc_ids]))
+        result = await db.execute(stmt)
+        rows = result.fetchall()
+
+        return {_ensure_uuid(row[0]): (row[1], row[2] or "txt", row[3], row[4], row[5]) for row in rows}
+
+    async def _load_chunk_details(
+        self, chunk_ids: list[UUID], db: AsyncSession
+    ) -> dict[UUID, tuple[int, str, str | None, int | None, int | None]]:
+        """Load chunk details for contributing chunks.
+
+        Args:
+            chunk_ids: List of chunk IDs.
+            db: Async database session.
+
+        Returns:
+            Mapping of chunk_id -> (chunk_index, content, summary, start_char, end_char).
+
+        """
+        if not chunk_ids:
+            return {}
+
+        stmt = select(
+            DocumentChunk.id,
+            DocumentChunk.chunk_index,
+            DocumentChunk.content,
+            DocumentChunk.summary,
+            DocumentChunk.start_char,
+            DocumentChunk.end_char,
+        ).where(DocumentChunk.id.in_([str(cid) for cid in chunk_ids]))
+        result = await db.execute(stmt)
+        rows = result.fetchall()
+
+        return {_ensure_uuid(row[0]): (row[1], row[2], row[3], row[4], row[5]) for row in rows}
+
+    def _make_snippet(self, content: str) -> str:
+        """Create a snippet from chunk content.
+
+        Args:
+            content: Full chunk content.
+
+        Returns:
+            Truncated snippet with ellipsis if needed.
+
+        """
+        if len(content) <= MAX_SNIPPET_LENGTH:
+            return content
+        return content[: MAX_SNIPPET_LENGTH - 3] + "..."

--- a/backend/src/shu/services/retrieval/score_fusion.py
+++ b/backend/src/shu/services/retrieval/score_fusion.py
@@ -37,7 +37,7 @@ DEFAULT_SURFACE_WEIGHTS: dict[str, float] = {
 MAX_SNIPPET_LENGTH = 200
 
 
-def _ensure_uuid(val: "UUID | str") -> UUID:
+def _ensure_uuid(val: UUID | str) -> UUID:
     """Convert a value to UUID, handling both string and UUID inputs.
 
     asyncpg returns UUID columns as uuid.UUID objects, while some test mocks
@@ -249,7 +249,7 @@ class ScoreFusionService:
 
     async def _load_document_metadata(
         self, doc_ids: list[UUID], db: AsyncSession
-    ) -> dict[UUID, tuple[str, str, str | None, str | None, "datetime | None"]]:
+    ) -> dict[UUID, tuple[str, str, str | None, str | None, datetime | None]]:
         """Load document metadata for a list of document IDs.
 
         Args:

--- a/backend/src/shu/services/retrieval/surfaces/__init__.py
+++ b/backend/src/shu/services/retrieval/surfaces/__init__.py
@@ -1,0 +1,13 @@
+"""Retrieval surface implementations.
+
+Each surface wraps a different retrieval strategy (vector search, keyword, etc.)
+and implements the RetrievalSurface protocol.
+"""
+
+from .chunk_vector import ChunkVectorSurface
+from .synopsis_match import SynopsisMatchSurface
+
+__all__ = [
+    "ChunkVectorSurface",
+    "SynopsisMatchSurface",
+]

--- a/backend/src/shu/services/retrieval/surfaces/chunk_vector.py
+++ b/backend/src/shu/services/retrieval/surfaces/chunk_vector.py
@@ -10,7 +10,7 @@ import time
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from ..protocol import SurfaceHit, SurfaceResult
+from ..protocol import RetrievalSurface, SurfaceHit, SurfaceResult
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from shu.core.vector_store import VectorStore
 
 
-class ChunkVectorSurface:
+class ChunkVectorSurface(RetrievalSurface):
     """Retrieval surface for vector similarity search on chunks.
 
     This is the primary retrieval surface, finding chunks whose embeddings

--- a/backend/src/shu/services/retrieval/surfaces/chunk_vector.py
+++ b/backend/src/shu/services/retrieval/surfaces/chunk_vector.py
@@ -1,0 +1,92 @@
+"""ChunkVectorSurface - Vector similarity search on document chunks.
+
+Wraps VectorStore.search("chunks") to find chunks with content that
+semantically matches the query.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from ..protocol import SurfaceHit, SurfaceResult
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from shu.core.vector_store import VectorStore
+
+
+class ChunkVectorSurface:
+    """Retrieval surface for vector similarity search on chunks.
+
+    This is the primary retrieval surface, finding chunks whose embeddings
+    are similar to the query embedding.
+    """
+
+    name = "chunk_vector"
+
+    def __init__(self, vector_store: VectorStore) -> None:
+        """Initialize with a VectorStore instance.
+
+        Args:
+            vector_store: The vector store to search against.
+
+        """
+        self._vector_store = vector_store
+
+    async def search(
+        self,
+        query_text: str,
+        query_vector: list[float],
+        keyword_terms: list[str],
+        *,
+        kb_id: UUID,
+        limit: int = 50,
+        threshold: float = 0.0,
+        db: AsyncSession,
+    ) -> SurfaceResult:
+        """Search for chunks similar to the query vector.
+
+        Args:
+            query_text: Original query text (unused by this surface).
+            query_vector: Pre-computed embedding vector.
+            keyword_terms: Keyword terms (unused by this surface).
+            kb_id: Knowledge base ID to scope the search.
+            limit: Maximum number of chunks to return.
+            threshold: Minimum similarity score (0.0-1.0).
+            db: Async database session.
+
+        Returns:
+            SurfaceResult with chunk hits and execution time.
+
+        """
+        start = time.perf_counter()
+
+        results = await self._vector_store.search(
+            collection="chunks",
+            query_vector=query_vector,
+            db=db,
+            limit=limit,
+            threshold=threshold,
+            filters={"knowledge_base_id": str(kb_id)},
+        )
+
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        hits = [
+            SurfaceHit(
+                id=UUID(r.id),
+                id_type="chunk",
+                score=r.score,
+                metadata={},
+            )
+            for r in results
+        ]
+
+        return SurfaceResult(
+            surface_name=self.name,
+            hits=hits,
+            execution_time_ms=elapsed_ms,
+        )

--- a/backend/src/shu/services/retrieval/surfaces/synopsis_match.py
+++ b/backend/src/shu/services/retrieval/surfaces/synopsis_match.py
@@ -1,0 +1,94 @@
+"""SynopsisMatchSurface - Vector similarity search on document synopses.
+
+Wraps VectorStore.search("synopses") to find documents whose synopsis
+semantically matches the query. Useful for interpretive queries.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from ..protocol import SurfaceHit, SurfaceResult
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from shu.core.vector_store import VectorStore
+
+
+class SynopsisMatchSurface:
+    """Retrieval surface for vector similarity search on document synopses.
+
+    This surface finds documents whose high-level synopsis (generated during
+    document profiling) matches the query. Particularly effective for
+    interpretive or thematic queries.
+    """
+
+    name = "synopsis_match"
+
+    def __init__(self, vector_store: VectorStore) -> None:
+        """Initialize with a VectorStore instance.
+
+        Args:
+            vector_store: The vector store to search against.
+
+        """
+        self._vector_store = vector_store
+
+    async def search(
+        self,
+        query_text: str,
+        query_vector: list[float],
+        keyword_terms: list[str],
+        *,
+        kb_id: UUID,
+        limit: int = 50,
+        threshold: float = 0.0,
+        db: AsyncSession,
+    ) -> SurfaceResult:
+        """Search for documents with synopses similar to the query vector.
+
+        Args:
+            query_text: Original query text (unused by this surface).
+            query_vector: Pre-computed embedding vector.
+            keyword_terms: Keyword terms (unused by this surface).
+            kb_id: Knowledge base ID to scope the search.
+            limit: Maximum number of documents to return.
+            threshold: Minimum similarity score (0.0-1.0).
+            db: Async database session.
+
+        Returns:
+            SurfaceResult with document hits and execution time.
+
+        """
+        start = time.perf_counter()
+
+        results = await self._vector_store.search(
+            collection="synopses",
+            query_vector=query_vector,
+            db=db,
+            limit=limit,
+            threshold=threshold,
+            filters={"knowledge_base_id": str(kb_id)},
+        )
+
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        # For synopses collection, the id is already the document_id
+        hits = [
+            SurfaceHit(
+                id=UUID(r.id),
+                id_type="document",
+                score=r.score,
+                metadata={},
+            )
+            for r in results
+        ]
+
+        return SurfaceResult(
+            surface_name=self.name,
+            hits=hits,
+            execution_time_ms=elapsed_ms,
+        )

--- a/backend/src/shu/services/retrieval/surfaces/synopsis_match.py
+++ b/backend/src/shu/services/retrieval/surfaces/synopsis_match.py
@@ -10,7 +10,7 @@ import time
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from ..protocol import SurfaceHit, SurfaceResult
+from ..protocol import RetrievalSurface, SurfaceHit, SurfaceResult
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from shu.core.vector_store import VectorStore
 
 
-class SynopsisMatchSurface:
+class SynopsisMatchSurface(RetrievalSurface):
     """Retrieval surface for vector similarity search on document synopses.
 
     This surface finds documents whose high-level synopsis (generated during

--- a/backend/src/shu/worker.py
+++ b/backend/src/shu/worker.py
@@ -878,6 +878,7 @@ async def _handle_profiling_job(job) -> None:
         result = await orchestrator.run_for_document(document_id)
 
         if result.skipped:
+            # skipped==True means the job had nothing to do (e.g. document not found). It is appropriate to bail without retrying.
             logger.info(
                 "Profiling job skipped - precondition not met",
                 extra={"job_id": job.id, "document_id": document_id, "reason": result.error},

--- a/backend/src/shu/worker.py
+++ b/backend/src/shu/worker.py
@@ -877,6 +877,13 @@ async def _handle_profiling_job(job) -> None:
 
         result = await orchestrator.run_for_document(document_id)
 
+        if result.skipped:
+            logger.info(
+                "Profiling job skipped - precondition not met",
+                extra={"job_id": job.id, "document_id": document_id, "reason": result.error},
+            )
+            return
+
         if result.success:
             # Set document pipeline status to PROCESSED (final state)
             # The orchestrator already updated profiling_status to "complete"

--- a/backend/src/tests/integ/test_query_integration.py
+++ b/backend/src/tests/integ/test_query_integration.py
@@ -127,6 +127,50 @@ async def test_query_hybrid_search(client, db, auth_headers):
     assert response.status_code in [200, 404]  # 404 if no documents found
 
 
+async def test_query_multi_surface_search(client, db, auth_headers):
+    """Test multi-surface search functionality.
+
+    Multi-surface search executes multiple retrieval surfaces in parallel
+    (chunk_vector, synopsis_match) and fuses their scores.
+    """
+    import uuid
+
+    unique_id = str(uuid.uuid4())[:8]
+
+    # Create knowledge base
+    kb_data = {
+        "name": f"Multi-Surface Search Test KB {unique_id}",
+        "description": "Knowledge base for multi-surface search testing",
+        "sync_enabled": True,
+    }
+
+    kb_response = await client.post("/api/v1/knowledge-bases", json=kb_data, headers=auth_headers)
+    assert kb_response.status_code == 201
+    kb_id = extract_data(kb_response)["id"]
+
+    # Test multi-surface search
+    multi_surface_data = {
+        "query": "machine learning algorithms",
+        "query_type": "multi_surface",
+        "limit": 10,
+        "similarity_threshold": 0.5,
+    }
+
+    response = await client.post(f"/api/v1/query/{kb_id}/search", json=multi_surface_data, headers=auth_headers)
+    # Should succeed even if no documents exist
+    assert response.status_code in [200, 404]
+
+    if response.status_code == 200:
+        data = extract_data(response)
+        assert "results" in data or "multi_surface_results" in data
+        # If multi_surface_results present, verify structure
+        if "multi_surface_results" in data:
+            for result in data["multi_surface_results"]:
+                assert "document_id" in result
+                assert "final_score" in result
+                assert "surface_scores" in result
+
+
 async def test_query_with_filters(client, db, auth_headers):
     """Test search with filters and metadata."""
     # Create knowledge base
@@ -315,6 +359,7 @@ class QueryIntegrationTestSuite(BaseIntegrationTestSuite):
             test_query_search_basic,
             test_query_similarity_search,
             test_query_hybrid_search,
+            test_query_multi_surface_search,
             test_query_with_filters,
             test_query_stats,
             test_query_invalid_knowledge_base,

--- a/backend/src/tests/integ/test_query_integration.py
+++ b/backend/src/tests/integ/test_query_integration.py
@@ -72,13 +72,6 @@ async def test_query_similarity_search(client, db, auth_headers):
     assert kb_response.status_code == 201
     kb_id = extract_data(kb_response)["id"]
 
-    # Test similarity search
-    similarity_data = {
-        "query": "artificial intelligence machine learning",
-        "limit": 10,
-        "threshold": 0.7,
-    }
-
     # Update to use unified search endpoint
     unified_similarity_data = {
         "query": "test similarity search",

--- a/backend/src/tests/unit/services/retrieval/__init__.py
+++ b/backend/src/tests/unit/services/retrieval/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for multi-surface retrieval services."""

--- a/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
+++ b/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
@@ -1,0 +1,200 @@
+"""Unit tests for MultiSurfaceSearchService."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from shu.services.retrieval.multi_surface_search import MultiSurfaceSearchService
+from shu.services.retrieval.protocol import FusedResult, SurfaceHit, SurfaceResult
+
+
+class TestMultiSurfaceSearchService:
+    """Tests for MultiSurfaceSearchService."""
+
+    def _make_mock_surface(self, name: str, hits: list[SurfaceHit] | None = None):
+        """Create a mock retrieval surface."""
+        surface = MagicMock()
+        surface.name = name
+        surface.search = AsyncMock(
+            return_value=SurfaceResult(
+                surface_name=name,
+                hits=hits or [],
+                execution_time_ms=10.0,
+            )
+        )
+        return surface
+
+    def _make_service(
+        self,
+        surfaces=None,
+        embedding_service=None,
+        fusion_service=None,
+    ):
+        """Create a MultiSurfaceSearchService with mocked dependencies."""
+        mock_embedding = embedding_service or MagicMock()
+        if not embedding_service:
+            mock_embedding.embed_query = AsyncMock(return_value=[0.1] * 1024)
+
+        mock_fusion = fusion_service or MagicMock()
+        if not fusion_service:
+            mock_fusion.fuse = AsyncMock(return_value=[])
+
+        return MultiSurfaceSearchService(
+            surfaces=surfaces or [],
+            embedding_service=mock_embedding,
+            fusion_service=mock_fusion,
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_executes_all_surfaces(self):
+        """search() should execute all configured surfaces."""
+        surface1 = self._make_mock_surface("surface1")
+        surface2 = self._make_mock_surface("surface2")
+        service = self._make_service(surfaces=[surface1, surface2])
+        mock_db = AsyncMock()
+
+        await service.search("test query", uuid4(), keyword_terms=["test"], db=mock_db)
+
+        surface1.search.assert_called_once()
+        surface2.search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_embeds_query(self):
+        """search() should embed the query once."""
+        mock_embedding = MagicMock()
+        mock_embedding.embed_query = AsyncMock(return_value=[0.1] * 1024)
+        service = self._make_service(embedding_service=mock_embedding)
+        mock_db = AsyncMock()
+
+        await service.search("test query", uuid4(), keyword_terms=["test"], db=mock_db)
+
+        mock_embedding.embed_query.assert_called_once_with("test query")
+
+    @pytest.mark.asyncio
+    async def test_search_passes_results_to_fusion(self):
+        """search() should pass surface results to fusion service."""
+        doc_id = uuid4()
+        surface = self._make_mock_surface(
+            "test_surface",
+            hits=[SurfaceHit(id=doc_id, id_type="document", score=0.9)],
+        )
+        mock_fusion = MagicMock()
+        mock_fusion.fuse = AsyncMock(
+            return_value=[
+                FusedResult(
+                    document_id=doc_id,
+                    document_title="Test",
+                    final_score=0.9,
+                    surface_scores={"test_surface": 0.9},
+                    contributing_chunks=[],
+                )
+            ]
+        )
+        service = self._make_service(surfaces=[surface], fusion_service=mock_fusion)
+        mock_db = AsyncMock()
+        kb_id = uuid4()
+
+        result = await service.search(
+            "test", kb_id, keyword_terms=["test"], limit=5, threshold=0.5, db=mock_db
+        )
+
+        mock_fusion.fuse.assert_called_once()
+        call_kwargs = mock_fusion.fuse.call_args.kwargs
+        assert call_kwargs["limit"] == 5
+        assert call_kwargs["threshold"] == 0.5
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_handles_surface_exceptions(self):
+        """search() should handle surface exceptions gracefully."""
+        good_surface = self._make_mock_surface("good_surface")
+        bad_surface = MagicMock()
+        bad_surface.name = "bad_surface"
+        bad_surface.search = AsyncMock(side_effect=Exception("Surface error"))
+
+        mock_fusion = MagicMock()
+        mock_fusion.fuse = AsyncMock(return_value=[])
+
+        service = self._make_service(
+            surfaces=[good_surface, bad_surface],
+            fusion_service=mock_fusion,
+        )
+        mock_db = AsyncMock()
+
+        # Should not raise, should log warning and continue
+        await service.search("test", uuid4(), keyword_terms=["test"], db=mock_db)
+
+        # Fusion should still be called with results from good surface
+        mock_fusion.fuse.assert_called_once()
+        call_args = mock_fusion.fuse.call_args[0][0]
+        assert len(call_args) == 1  # Only good surface result
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_when_all_surfaces_fail(self):
+        """search() should return empty list when all surfaces fail."""
+        bad_surface = MagicMock()
+        bad_surface.name = "bad_surface"
+        bad_surface.search = AsyncMock(side_effect=Exception("Fail"))
+
+        service = self._make_service(surfaces=[bad_surface])
+        mock_db = AsyncMock()
+
+        result = await service.search("test", uuid4(), keyword_terms=["test"], db=mock_db)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_search_passes_keyword_terms_to_surfaces(self):
+        """search() should pass keyword terms to surfaces."""
+        surface = self._make_mock_surface("test_surface")
+        service = self._make_service(surfaces=[surface])
+        mock_db = AsyncMock()
+
+        await service.search(
+            "test query",
+            uuid4(),
+            keyword_terms=["budget", "marketing"],
+            db=mock_db,
+        )
+
+        call_args = surface.search.call_args
+        keyword_terms = call_args[0][2]  # Third positional arg
+        assert "budget" in keyword_terms
+        assert "marketing" in keyword_terms
+
+    @pytest.mark.asyncio
+    async def test_search_respects_timeout(self):
+        """search() should timeout slow surfaces."""
+
+        async def slow_search(*args, **kwargs):
+            await asyncio.sleep(10)  # Longer than timeout
+            return SurfaceResult(
+                surface_name="slow", hits=[], execution_time_ms=10000
+            )
+
+        slow_surface = MagicMock()
+        slow_surface.name = "slow_surface"
+        slow_surface.search = slow_search
+
+        service = self._make_service(surfaces=[slow_surface])
+        service._timeout_ms = 100  # 100ms timeout
+        mock_db = AsyncMock()
+
+        # Should not hang, should handle timeout
+        result = await service.search("test", uuid4(), keyword_terms=["test"], db=mock_db)
+
+        # Result should be empty (surface timed out)
+        assert result == []
+
+    def test_default_configuration(self):
+        """Service should have sensible default configuration."""
+        mock_embedding = MagicMock()
+        service = MultiSurfaceSearchService(
+            surfaces=[],
+            embedding_service=mock_embedding,
+        )
+
+        assert service._surface_limit == 50
+        assert service._timeout_ms == 2000

--- a/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
+++ b/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
@@ -1,6 +1,7 @@
 """Unit tests for MultiSurfaceSearchService."""
 
 import asyncio
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -8,6 +9,21 @@ import pytest
 
 from shu.services.retrieval.multi_surface_search import MultiSurfaceSearchService
 from shu.services.retrieval.protocol import FusedResult, SurfaceHit, SurfaceResult
+
+
+def _make_mock_session_factory():
+    """Create a mock session factory that returns async context manager sessions."""
+    mock_session = AsyncMock()
+
+    @asynccontextmanager
+    async def session_context():
+        yield mock_session
+
+    factory = MagicMock()
+    factory.return_value = session_context()
+    # Make it callable multiple times by using side_effect
+    factory.side_effect = lambda: session_context()
+    return factory
 
 
 class TestMultiSurfaceSearchService:
@@ -53,9 +69,11 @@ class TestMultiSurfaceSearchService:
         surface1 = self._make_mock_surface("surface1")
         surface2 = self._make_mock_surface("surface2")
         service = self._make_service(surfaces=[surface1, surface2])
-        mock_db = AsyncMock()
+        mock_session_factory = _make_mock_session_factory()
 
-        await service.search("test query", uuid4(), keyword_terms=["test"], db=mock_db)
+        await service.search(
+            "test query", uuid4(), keyword_terms=["test"], session_factory=mock_session_factory
+        )
 
         surface1.search.assert_called_once()
         surface2.search.assert_called_once()
@@ -66,9 +84,11 @@ class TestMultiSurfaceSearchService:
         mock_embedding = MagicMock()
         mock_embedding.embed_query = AsyncMock(return_value=[0.1] * 1024)
         service = self._make_service(embedding_service=mock_embedding)
-        mock_db = AsyncMock()
+        mock_session_factory = _make_mock_session_factory()
 
-        await service.search("test query", uuid4(), keyword_terms=["test"], db=mock_db)
+        await service.search(
+            "test query", uuid4(), keyword_terms=["test"], session_factory=mock_session_factory
+        )
 
         mock_embedding.embed_query.assert_called_once_with("test query")
 
@@ -93,11 +113,16 @@ class TestMultiSurfaceSearchService:
             ]
         )
         service = self._make_service(surfaces=[surface], fusion_service=mock_fusion)
-        mock_db = AsyncMock()
+        mock_session_factory = _make_mock_session_factory()
         kb_id = uuid4()
 
         result = await service.search(
-            "test", kb_id, keyword_terms=["test"], limit=5, threshold=0.5, db=mock_db
+            "test",
+            kb_id,
+            keyword_terms=["test"],
+            limit=5,
+            threshold=0.5,
+            session_factory=mock_session_factory,
         )
 
         mock_fusion.fuse.assert_called_once()
@@ -121,10 +146,12 @@ class TestMultiSurfaceSearchService:
             surfaces=[good_surface, bad_surface],
             fusion_service=mock_fusion,
         )
-        mock_db = AsyncMock()
+        mock_session_factory = _make_mock_session_factory()
 
         # Should not raise, should log warning and continue
-        await service.search("test", uuid4(), keyword_terms=["test"], db=mock_db)
+        await service.search(
+            "test", uuid4(), keyword_terms=["test"], session_factory=mock_session_factory
+        )
 
         # Fusion should still be called with results from good surface
         mock_fusion.fuse.assert_called_once()
@@ -139,9 +166,11 @@ class TestMultiSurfaceSearchService:
         bad_surface.search = AsyncMock(side_effect=Exception("Fail"))
 
         service = self._make_service(surfaces=[bad_surface])
-        mock_db = AsyncMock()
+        mock_session_factory = _make_mock_session_factory()
 
-        result = await service.search("test", uuid4(), keyword_terms=["test"], db=mock_db)
+        result = await service.search(
+            "test", uuid4(), keyword_terms=["test"], session_factory=mock_session_factory
+        )
 
         assert result == []
 
@@ -150,13 +179,13 @@ class TestMultiSurfaceSearchService:
         """search() should pass keyword terms to surfaces."""
         surface = self._make_mock_surface("test_surface")
         service = self._make_service(surfaces=[surface])
-        mock_db = AsyncMock()
+        mock_session_factory = _make_mock_session_factory()
 
         await service.search(
             "test query",
             uuid4(),
             keyword_terms=["budget", "marketing"],
-            db=mock_db,
+            session_factory=mock_session_factory,
         )
 
         call_args = surface.search.call_args
@@ -180,10 +209,12 @@ class TestMultiSurfaceSearchService:
 
         service = self._make_service(surfaces=[slow_surface])
         service._timeout_ms = 100  # 100ms timeout
-        mock_db = AsyncMock()
+        mock_session_factory = _make_mock_session_factory()
 
         # Should not hang, should handle timeout
-        result = await service.search("test", uuid4(), keyword_terms=["test"], db=mock_db)
+        result = await service.search(
+            "test", uuid4(), keyword_terms=["test"], session_factory=mock_session_factory
+        )
 
         # Result should be empty (surface timed out)
         assert result == []

--- a/backend/src/tests/unit/services/retrieval/test_protocol.py
+++ b/backend/src/tests/unit/services/retrieval/test_protocol.py
@@ -1,0 +1,152 @@
+"""Unit tests for retrieval protocol and types."""
+
+from uuid import uuid4
+
+import pytest
+
+from shu.services.retrieval.protocol import (
+    ContributingChunk,
+    FusedResult,
+    SurfaceHit,
+    SurfaceResult,
+)
+
+
+class TestSurfaceHit:
+    """Tests for SurfaceHit dataclass."""
+
+    def test_create_chunk_hit(self):
+        """SurfaceHit can represent a chunk hit."""
+        chunk_id = uuid4()
+        hit = SurfaceHit(
+            id=chunk_id,
+            id_type="chunk",
+            score=0.85,
+            metadata={"matched_terms": ["test"]},
+        )
+
+        assert hit.id == chunk_id
+        assert hit.id_type == "chunk"
+        assert hit.score == 0.85
+        assert hit.metadata == {"matched_terms": ["test"]}
+
+    def test_create_document_hit(self):
+        """SurfaceHit can represent a document hit."""
+        doc_id = uuid4()
+        hit = SurfaceHit(
+            id=doc_id,
+            id_type="document",
+            score=0.72,
+        )
+
+        assert hit.id == doc_id
+        assert hit.id_type == "document"
+        assert hit.score == 0.72
+        assert hit.metadata == {}
+
+    def test_hit_is_frozen(self):
+        """SurfaceHit is immutable."""
+        hit = SurfaceHit(id=uuid4(), id_type="chunk", score=0.5)
+        with pytest.raises(AttributeError):
+            hit.score = 0.9
+
+
+class TestSurfaceResult:
+    """Tests for SurfaceResult dataclass."""
+
+    def test_create_result_with_hits(self):
+        """SurfaceResult holds hits and timing info."""
+        hits = [
+            SurfaceHit(id=uuid4(), id_type="chunk", score=0.9),
+            SurfaceHit(id=uuid4(), id_type="chunk", score=0.8),
+        ]
+        result = SurfaceResult(
+            surface_name="chunk_vector",
+            hits=hits,
+            execution_time_ms=45.2,
+        )
+
+        assert result.surface_name == "chunk_vector"
+        assert len(result.hits) == 2
+        assert result.execution_time_ms == 45.2
+
+    def test_create_empty_result(self):
+        """SurfaceResult can have empty hits."""
+        result = SurfaceResult(
+            surface_name="synopsis_match",
+            hits=[],
+            execution_time_ms=12.0,
+        )
+
+        assert result.surface_name == "synopsis_match"
+        assert len(result.hits) == 0
+
+
+class TestContributingChunk:
+    """Tests for ContributingChunk dataclass."""
+
+    def test_create_with_summary(self):
+        """ContributingChunk can include summary."""
+        chunk = ContributingChunk(
+            chunk_id=uuid4(),
+            chunk_index=3,
+            surface="chunk_vector",
+            score=0.88,
+            snippet="This is a test snippet...",
+            summary="Summary of the chunk content.",
+        )
+
+        assert chunk.chunk_index == 3
+        assert chunk.surface == "chunk_vector"
+        assert chunk.score == 0.88
+        assert chunk.summary == "Summary of the chunk content."
+
+    def test_create_without_summary(self):
+        """ContributingChunk works without summary."""
+        chunk = ContributingChunk(
+            chunk_id=uuid4(),
+            chunk_index=0,
+            surface="synopsis_match",
+            score=0.75,
+            snippet="Snippet text...",
+        )
+
+        assert chunk.summary is None
+
+
+class TestFusedResult:
+    """Tests for FusedResult dataclass."""
+
+    def test_create_fused_result(self):
+        """FusedResult aggregates document-level results."""
+        doc_id = uuid4()
+        chunks = [
+            ContributingChunk(
+                chunk_id=uuid4(),
+                chunk_index=1,
+                surface="chunk_vector",
+                score=0.9,
+                snippet="First chunk...",
+            ),
+            ContributingChunk(
+                chunk_id=uuid4(),
+                chunk_index=2,
+                surface="chunk_vector",
+                score=0.85,
+                snippet="Second chunk...",
+            ),
+        ]
+
+        result = FusedResult(
+            document_id=doc_id,
+            document_title="Test Document",
+            final_score=0.87,
+            surface_scores={"chunk_vector": 0.9, "synopsis_match": 0.75},
+            contributing_chunks=chunks,
+        )
+
+        assert result.document_id == doc_id
+        assert result.document_title == "Test Document"
+        assert result.final_score == 0.87
+        assert len(result.surface_scores) == 2
+        assert len(result.contributing_chunks) == 2

--- a/backend/src/tests/unit/services/retrieval/test_score_fusion.py
+++ b/backend/src/tests/unit/services/retrieval/test_score_fusion.py
@@ -1,0 +1,225 @@
+"""Unit tests for ScoreFusionService."""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from shu.services.retrieval.protocol import SurfaceHit, SurfaceResult
+from shu.services.retrieval.score_fusion import ScoreFusionService
+
+
+class TestScoreFusionService:
+    """Tests for ScoreFusionService."""
+
+    def _make_service(self, weights: dict[str, float] | None = None):
+        """Create a ScoreFusionService with optional custom weights."""
+        return ScoreFusionService(weights=weights)
+
+    @pytest.mark.asyncio
+    async def test_fuse_empty_results(self):
+        """fuse() should return empty list for no surface results."""
+        service = self._make_service()
+        mock_db = AsyncMock()
+
+        result = await service.fuse([], db=mock_db)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_fuse_single_surface_document_hits(self):
+        """fuse() should handle single surface with document hits."""
+        service = self._make_service({"synopsis_match": 1.0})
+        mock_db = AsyncMock()
+
+        doc_id = uuid4()
+        surface_result = SurfaceResult(
+            surface_name="synopsis_match",
+            hits=[
+                SurfaceHit(id=doc_id, id_type="document", score=0.85),
+            ],
+            execution_time_ms=10.0,
+        )
+
+        # Mock document metadata lookup
+        with patch.object(
+            service, "_load_document_metadata", return_value={doc_id: ("Test Doc", "pdf")}
+        ):
+            with patch.object(service, "_load_chunk_details", return_value={}):
+                result = await service.fuse([surface_result], db=mock_db)
+
+        assert len(result) == 1
+        assert result[0].document_id == doc_id
+        assert result[0].document_title == "Test Doc"
+        assert result[0].final_score == 0.85
+        assert "synopsis_match" in result[0].surface_scores
+
+    @pytest.mark.asyncio
+    async def test_fuse_combines_scores_from_multiple_surfaces(self):
+        """fuse() should combine scores from multiple surfaces with weights."""
+        weights = {"chunk_vector": 0.6, "synopsis_match": 0.4}
+        service = self._make_service(weights)
+        mock_db = AsyncMock()
+
+        doc_id = uuid4()
+        chunk_id = uuid4()
+
+        chunk_surface = SurfaceResult(
+            surface_name="chunk_vector",
+            hits=[SurfaceHit(id=chunk_id, id_type="chunk", score=0.9)],
+            execution_time_ms=20.0,
+        )
+        synopsis_surface = SurfaceResult(
+            surface_name="synopsis_match",
+            hits=[SurfaceHit(id=doc_id, id_type="document", score=0.8)],
+            execution_time_ms=15.0,
+        )
+
+        # Mock chunk -> document resolution
+        with patch.object(
+            service, "_resolve_chunk_documents", return_value={chunk_id: doc_id}
+        ):
+            with patch.object(
+                service, "_load_document_metadata", return_value={doc_id: ("Combined Doc", "txt")}
+            ):
+                with patch.object(
+                    service,
+                    "_load_chunk_details",
+                    return_value={chunk_id: (0, "Chunk content...", None)},
+                ):
+                    result = await service.fuse(
+                        [chunk_surface, synopsis_surface], db=mock_db
+                    )
+
+        assert len(result) == 1
+        assert result[0].document_id == doc_id
+        # Weighted score: (0.9 * 0.6 + 0.8 * 0.4) / (0.6 + 0.4) = 0.86
+        assert abs(result[0].final_score - 0.86) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_fuse_respects_threshold(self):
+        """fuse() should filter results below threshold."""
+        service = self._make_service({"synopsis_match": 1.0})
+        mock_db = AsyncMock()
+
+        doc_id = uuid4()
+        surface_result = SurfaceResult(
+            surface_name="synopsis_match",
+            hits=[SurfaceHit(id=doc_id, id_type="document", score=0.3)],
+            execution_time_ms=10.0,
+        )
+
+        with patch.object(
+            service, "_load_document_metadata", return_value={doc_id: ("Low Score Doc", "txt")}
+        ):
+            with patch.object(service, "_load_chunk_details", return_value={}):
+                result = await service.fuse(
+                    [surface_result], threshold=0.5, db=mock_db
+                )
+
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_fuse_respects_limit(self):
+        """fuse() should limit number of results."""
+        service = self._make_service({"synopsis_match": 1.0})
+        mock_db = AsyncMock()
+
+        # Create 5 document hits
+        doc_ids = [uuid4() for _ in range(5)]
+        hits = [
+            SurfaceHit(id=did, id_type="document", score=0.9 - i * 0.1)
+            for i, did in enumerate(doc_ids)
+        ]
+        surface_result = SurfaceResult(
+            surface_name="synopsis_match",
+            hits=hits,
+            execution_time_ms=10.0,
+        )
+
+        metadata = {did: (f"Doc {i}", "txt") for i, did in enumerate(doc_ids)}
+        with patch.object(service, "_load_document_metadata", return_value=metadata):
+            with patch.object(service, "_load_chunk_details", return_value={}):
+                result = await service.fuse(
+                    [surface_result], limit=3, db=mock_db
+                )
+
+        assert len(result) == 3
+        # Results should be sorted by score descending
+        assert result[0].final_score > result[1].final_score > result[2].final_score
+
+    @pytest.mark.asyncio
+    async def test_fuse_tracks_contributing_chunks(self):
+        """fuse() should track contributing chunks for each document."""
+        service = self._make_service({"chunk_vector": 1.0})
+        mock_db = AsyncMock()
+
+        doc_id = uuid4()
+        chunk1_id = uuid4()
+        chunk2_id = uuid4()
+
+        surface_result = SurfaceResult(
+            surface_name="chunk_vector",
+            hits=[
+                SurfaceHit(id=chunk1_id, id_type="chunk", score=0.9),
+                SurfaceHit(id=chunk2_id, id_type="chunk", score=0.85),
+            ],
+            execution_time_ms=20.0,
+        )
+
+        with patch.object(
+            service,
+            "_resolve_chunk_documents",
+            return_value={chunk1_id: doc_id, chunk2_id: doc_id},
+        ):
+            with patch.object(
+                service, "_load_document_metadata", return_value={doc_id: ("Test Doc", "txt")}
+            ):
+                with patch.object(
+                    service,
+                    "_load_chunk_details",
+                    return_value={
+                        chunk1_id: (0, "First chunk content...", "Summary 1"),
+                        chunk2_id: (1, "Second chunk content...", None),
+                    },
+                ):
+                    result = await service.fuse([surface_result], db=mock_db)
+
+        assert len(result) == 1
+        assert len(result[0].contributing_chunks) == 2
+        # Chunks should be sorted by score
+        assert result[0].contributing_chunks[0].score == 0.9
+        assert result[0].contributing_chunks[1].score == 0.85
+
+    def test_make_snippet_truncates_long_content(self):
+        """_make_snippet() should truncate content over 200 chars."""
+        service = self._make_service()
+        long_content = "x" * 300
+
+        snippet = service._make_snippet(long_content)
+
+        assert len(snippet) == 200
+        assert snippet.endswith("...")
+
+    def test_make_snippet_preserves_short_content(self):
+        """_make_snippet() should preserve short content."""
+        service = self._make_service()
+        short_content = "This is short."
+
+        snippet = service._make_snippet(short_content)
+
+        assert snippet == short_content
+
+    def test_default_weights_are_applied(self):
+        """Service should use default weights when none provided."""
+        service = self._make_service()
+
+        assert "chunk_vector" in service._weights
+        assert "synopsis_match" in service._weights
+
+    def test_custom_weights_override_defaults(self):
+        """Service should use custom weights when provided."""
+        custom_weights = {"custom_surface": 0.5}
+        service = self._make_service(custom_weights)
+
+        assert service._weights == custom_weights

--- a/backend/src/tests/unit/services/retrieval/test_score_fusion.py
+++ b/backend/src/tests/unit/services/retrieval/test_score_fusion.py
@@ -41,9 +41,9 @@ class TestScoreFusionService:
             execution_time_ms=10.0,
         )
 
-        # Mock document metadata lookup
+        # Mock document metadata lookup (title, file_type, source_url, source_id, created_at)
         with patch.object(
-            service, "_load_document_metadata", return_value={doc_id: ("Test Doc", "pdf")}
+            service, "_load_document_metadata", return_value={doc_id: ("Test Doc", "pdf", None, None, None)}
         ):
             with patch.object(service, "_load_chunk_details", return_value={}):
                 result = await service.fuse([surface_result], db=mock_db)
@@ -80,12 +80,12 @@ class TestScoreFusionService:
             service, "_resolve_chunk_documents", return_value={chunk_id: doc_id}
         ):
             with patch.object(
-                service, "_load_document_metadata", return_value={doc_id: ("Combined Doc", "txt")}
+                service, "_load_document_metadata", return_value={doc_id: ("Combined Doc", "txt", None, None, None)}
             ):
                 with patch.object(
                     service,
                     "_load_chunk_details",
-                    return_value={chunk_id: (0, "Chunk content...", None)},
+                    return_value={chunk_id: (0, "Chunk content...", None, None, None)},
                 ):
                     result = await service.fuse(
                         [chunk_surface, synopsis_surface], db=mock_db
@@ -110,7 +110,7 @@ class TestScoreFusionService:
         )
 
         with patch.object(
-            service, "_load_document_metadata", return_value={doc_id: ("Low Score Doc", "txt")}
+            service, "_load_document_metadata", return_value={doc_id: ("Low Score Doc", "txt", None, None, None)}
         ):
             with patch.object(service, "_load_chunk_details", return_value={}):
                 result = await service.fuse(
@@ -137,7 +137,7 @@ class TestScoreFusionService:
             execution_time_ms=10.0,
         )
 
-        metadata = {did: (f"Doc {i}", "txt") for i, did in enumerate(doc_ids)}
+        metadata = {did: (f"Doc {i}", "txt", None, None, None) for i, did in enumerate(doc_ids)}
         with patch.object(service, "_load_document_metadata", return_value=metadata):
             with patch.object(service, "_load_chunk_details", return_value={}):
                 result = await service.fuse(
@@ -173,14 +173,14 @@ class TestScoreFusionService:
             return_value={chunk1_id: doc_id, chunk2_id: doc_id},
         ):
             with patch.object(
-                service, "_load_document_metadata", return_value={doc_id: ("Test Doc", "txt")}
+                service, "_load_document_metadata", return_value={doc_id: ("Test Doc", "txt", None, None, None)}
             ):
                 with patch.object(
                     service,
                     "_load_chunk_details",
                     return_value={
-                        chunk1_id: (0, "First chunk content...", "Summary 1"),
-                        chunk2_id: (1, "Second chunk content...", None),
+                        chunk1_id: (0, "First chunk content...", "Summary 1", 0, 100),
+                        chunk2_id: (1, "Second chunk content...", None, 100, 200),
                     },
                 ):
                     result = await service.fuse([surface_result], db=mock_db)

--- a/backend/src/tests/unit/services/retrieval/test_surfaces.py
+++ b/backend/src/tests/unit/services/retrieval/test_surfaces.py
@@ -1,0 +1,148 @@
+"""Unit tests for retrieval surfaces."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from shu.core.vector_store import VectorSearchResult
+from shu.services.retrieval.surfaces import ChunkVectorSurface, SynopsisMatchSurface
+
+
+class TestChunkVectorSurface:
+    """Tests for ChunkVectorSurface."""
+
+    def _make_surface(self, mock_results: list[VectorSearchResult] | None = None):
+        """Create a ChunkVectorSurface with mocked VectorStore."""
+        mock_vector_store = MagicMock()
+        mock_vector_store.search = AsyncMock(return_value=mock_results or [])
+        return ChunkVectorSurface(mock_vector_store), mock_vector_store
+
+    @pytest.mark.asyncio
+    async def test_search_returns_chunk_hits(self):
+        """search() should return chunk hits with normalized scores."""
+        chunk_id = str(uuid4())
+        mock_results = [
+            VectorSearchResult(id=chunk_id, score=0.92),
+        ]
+        surface, mock_vs = self._make_surface(mock_results)
+        mock_db = AsyncMock()
+
+        result = await surface.search(
+            query_text="test query",
+            query_vector=[0.1] * 1024,
+            keyword_terms=["test"],
+            kb_id=uuid4(),
+            limit=10,
+            threshold=0.5,
+            db=mock_db,
+        )
+
+        assert result.surface_name == "chunk_vector"
+        assert len(result.hits) == 1
+        assert result.hits[0].id_type == "chunk"
+        assert result.hits[0].score == 0.92
+        assert result.execution_time_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_search_calls_vector_store_correctly(self):
+        """search() should call VectorStore with correct parameters."""
+        surface, mock_vs = self._make_surface([])
+        mock_db = AsyncMock()
+        kb_id = uuid4()
+
+        await surface.search(
+            query_text="test query",
+            query_vector=[0.5] * 1024,
+            keyword_terms=["test"],
+            kb_id=kb_id,
+            limit=20,
+            threshold=0.7,
+            db=mock_db,
+        )
+
+        mock_vs.search.assert_called_once()
+        call_kwargs = mock_vs.search.call_args.kwargs
+        assert call_kwargs["collection"] == "chunks"
+        assert call_kwargs["limit"] == 20
+        assert call_kwargs["threshold"] == 0.7
+        assert call_kwargs["filters"]["knowledge_base_id"] == str(kb_id)
+
+    @pytest.mark.asyncio
+    async def test_search_handles_empty_results(self):
+        """search() should handle empty results gracefully."""
+        surface, _ = self._make_surface([])
+        mock_db = AsyncMock()
+
+        result = await surface.search(
+            query_text="no matches",
+            query_vector=[0.1] * 1024,
+            keyword_terms=[],
+            kb_id=uuid4(),
+            db=mock_db,
+        )
+
+        assert result.surface_name == "chunk_vector"
+        assert len(result.hits) == 0
+
+    def test_surface_has_correct_name(self):
+        """ChunkVectorSurface has the expected name."""
+        surface, _ = self._make_surface()
+        assert surface.name == "chunk_vector"
+
+
+class TestSynopsisMatchSurface:
+    """Tests for SynopsisMatchSurface."""
+
+    def _make_surface(self, mock_results: list[VectorSearchResult] | None = None):
+        """Create a SynopsisMatchSurface with mocked VectorStore."""
+        mock_vector_store = MagicMock()
+        mock_vector_store.search = AsyncMock(return_value=mock_results or [])
+        return SynopsisMatchSurface(mock_vector_store), mock_vector_store
+
+    @pytest.mark.asyncio
+    async def test_search_returns_document_hits(self):
+        """search() should return document hits from synopsis collection."""
+        doc_id = str(uuid4())
+        mock_results = [
+            VectorSearchResult(id=doc_id, score=0.78),
+        ]
+        surface, _ = self._make_surface(mock_results)
+        mock_db = AsyncMock()
+
+        result = await surface.search(
+            query_text="test query",
+            query_vector=[0.1] * 1024,
+            keyword_terms=["test"],
+            kb_id=uuid4(),
+            limit=10,
+            threshold=0.5,
+            db=mock_db,
+        )
+
+        assert result.surface_name == "synopsis_match"
+        assert len(result.hits) == 1
+        assert result.hits[0].id_type == "document"
+        assert result.hits[0].score == 0.78
+
+    @pytest.mark.asyncio
+    async def test_search_uses_synopses_collection(self):
+        """search() should query the synopses collection."""
+        surface, mock_vs = self._make_surface([])
+        mock_db = AsyncMock()
+
+        await surface.search(
+            query_text="test",
+            query_vector=[0.1] * 1024,
+            keyword_terms=[],
+            kb_id=uuid4(),
+            db=mock_db,
+        )
+
+        call_kwargs = mock_vs.search.call_args.kwargs
+        assert call_kwargs["collection"] == "synopses"
+
+    def test_surface_has_correct_name(self):
+        """SynopsisMatchSurface has the expected name."""
+        surface, _ = self._make_surface()
+        assert surface.name == "synopsis_match"

--- a/frontend/src/components/QueryTester.js
+++ b/frontend/src/components/QueryTester.js
@@ -54,6 +54,9 @@ function QueryTester() {
   const [titleWeightMultiplier, setTitleWeightMultiplier] = useState(3.0);
   const [activeTab, setActiveTab] = useState(0);
   const [ragRewriteMode, setRagRewriteMode] = useState('raw_query');
+  // Multi-surface search weights
+  const [chunkVectorWeight, setChunkVectorWeight] = useState(0.6);
+  const [synopsisMatchWeight, setSynopsisMatchWeight] = useState(0.4);
 
   const { data: knowledgeBasesResponse, isLoading: kbLoading } = useQuery('knowledgeBases', knowledgeBaseAPI.list);
 
@@ -64,9 +67,10 @@ function QueryTester() {
   useQuery(['kb-config', selectedKB], () => (selectedKB ? knowledgeBaseAPI.getRAGConfig(selectedKB) : null), {
     enabled: !!selectedKB,
     onSuccess: (data) => {
-      if (data && threshold === null) {
+      if (data) {
         const config = extractDataFromResponse(data);
-        setThreshold(config.search_threshold || 0.7);
+        // Always update from KB config when KB changes
+        setThreshold(config.search_threshold || 0.3);
         setTitleWeightingEnabled(config.title_weighting_enabled ?? true);
         setTitleWeightMultiplier(config.title_weight_multiplier || 3.0);
       }
@@ -104,6 +108,8 @@ function QueryTester() {
           ...basePayload,
           query_type: 'multi_surface',
           similarity_threshold: params.threshold,
+          chunk_vector_weight: params.chunkVectorWeight,
+          synopsis_match_weight: params.synopsisMatchWeight,
         });
       }
 
@@ -136,6 +142,8 @@ function QueryTester() {
       titleWeightingEnabled: titleWeightingEnabled,
       titleWeightMultiplier: titleWeightMultiplier,
       ragRewriteMode,
+      chunkVectorWeight: chunkVectorWeight,
+      synopsisMatchWeight: synopsisMatchWeight,
     });
   };
 
@@ -165,6 +173,8 @@ function QueryTester() {
         ...baseRequest,
         query_type: 'multi_surface',
         similarity_threshold: parseFloat(threshold),
+        chunk_vector_weight: chunkVectorWeight,
+        synopsis_match_weight: synopsisMatchWeight,
       };
     } else {
       return {
@@ -282,7 +292,7 @@ function QueryTester() {
                   type="number"
                   value={threshold || ''}
                   onChange={(e) => setThreshold(e.target.value)}
-                  placeholder="Threshold (e.g., 0.7)"
+                  placeholder="Threshold (e.g., 0.3)"
                   sx={{ mb: 2 }}
                   inputProps={{ min: 0, max: 1, step: 0.1 }}
                   helperText={
@@ -372,6 +382,49 @@ function QueryTester() {
                 </Box>
               )}
 
+              {/* Multi-Surface Weight Controls */}
+              {searchType === 'multi_surface' && (
+                <Box sx={{ mb: 2 }}>
+                  <Divider sx={{ mb: 2 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      Surface Weights
+                    </Typography>
+                  </Divider>
+
+                  <Box sx={{ px: 1 }}>
+                    <Typography variant="body2" color="text.secondary" gutterBottom>
+                      Chunk Vector: {chunkVectorWeight.toFixed(2)}
+                    </Typography>
+                    <Slider
+                      value={chunkVectorWeight}
+                      onChange={(_, newValue) => setChunkVectorWeight(newValue)}
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      valueLabelDisplay="auto"
+                      sx={{ mb: 2 }}
+                    />
+
+                    <Typography variant="body2" color="text.secondary" gutterBottom>
+                      Synopsis Match: {synopsisMatchWeight.toFixed(2)}
+                    </Typography>
+                    <Slider
+                      value={synopsisMatchWeight}
+                      onChange={(_, newValue) => setSynopsisMatchWeight(newValue)}
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      valueLabelDisplay="auto"
+                      sx={{ mb: 1 }}
+                    />
+
+                    <Typography variant="caption" color="text.secondary">
+                      Adjust weights to control how much each surface contributes to the final score
+                    </Typography>
+                  </Box>
+                </Box>
+              )}
+
               <Button
                 fullWidth
                 variant="contained"
@@ -392,7 +445,11 @@ function QueryTester() {
               <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
                 <Typography variant="h6">Results</Typography>
                 {queryResults && (
-                  <Chip label={`${queryResults.results?.length || 0} results`} color="primary" size="small" />
+                  <Chip
+                    label={`${queryResults.multi_surface_results?.length || queryResults.results?.length || 0} results`}
+                    color="primary"
+                    size="small"
+                  />
                 )}
               </Box>
 
@@ -435,67 +492,11 @@ function QueryTester() {
                   {activeTab === 0 && (
                     <Box>
                       {queryResults.multi_surface_results && queryResults.multi_surface_results.length > 0 ? (
-                        <Box>
-                          {queryResults.multi_surface_results.map((result, idx) => (
-                            <Card key={result.document_id} variant="outlined" sx={{ mb: 2 }}>
-                              <CardContent>
-                                <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                                  <Typography variant="subtitle1" fontWeight="bold">
-                                    {idx + 1}. {result.document_title}
-                                  </Typography>
-                                  <Chip
-                                    label={`Score: ${(result.final_score * 100).toFixed(1)}%`}
-                                    color="primary"
-                                    size="small"
-                                  />
-                                </Box>
-                                <Box display="flex" gap={1} flexWrap="wrap" mb={2}>
-                                  {Object.entries(result.surface_scores).map(([surface, score]) => (
-                                    <Chip
-                                      key={surface}
-                                      label={`${surface}: ${(score * 100).toFixed(1)}%`}
-                                      variant="outlined"
-                                      size="small"
-                                      color={surface === 'chunk_vector' ? 'info' : 'secondary'}
-                                    />
-                                  ))}
-                                </Box>
-                                {result.contributing_chunks && result.contributing_chunks.length > 0 && (
-                                  <Box>
-                                    <Typography variant="body2" color="text.secondary" gutterBottom>
-                                      Contributing Chunks:
-                                    </Typography>
-                                    {result.contributing_chunks.slice(0, 3).map((chunk) => (
-                                      <Box
-                                        key={chunk.chunk_id}
-                                        sx={{
-                                          bgcolor: 'grey.100',
-                                          p: 1,
-                                          borderRadius: 1,
-                                          mb: 1,
-                                          fontSize: '0.875rem',
-                                        }}
-                                      >
-                                        <Typography variant="caption" color="text.secondary">
-                                          [{chunk.surface}] Chunk #{chunk.chunk_index} ({(chunk.score * 100).toFixed(1)}
-                                          %)
-                                        </Typography>
-                                        <Typography variant="body2" sx={{ mt: 0.5 }}>
-                                          {chunk.snippet}
-                                        </Typography>
-                                        {chunk.summary && (
-                                          <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
-                                            Summary: {chunk.summary}
-                                          </Typography>
-                                        )}
-                                      </Box>
-                                    ))}
-                                  </Box>
-                                )}
-                              </CardContent>
-                            </Card>
-                          ))}
-                        </Box>
+                        <SourcePreview
+                          sources={queryResults.multi_surface_results}
+                          title="Multi-Surface Results"
+                          searchQuery={queryText}
+                        />
                       ) : queryResults.results && queryResults.results.length > 0 ? (
                         <SourcePreview sources={queryResults.results} title="Query Results" searchQuery={queryText} />
                       ) : (
@@ -505,20 +506,36 @@ function QueryTester() {
                   )}
 
                   {activeTab === 1 && (
-                    <Box>
+                    <Box sx={{ width: '100%', overflow: 'hidden' }}>
                       <Typography variant="subtitle2" gutterBottom>
                         Query Request
                       </Typography>
-                      <JSONPretty data={formatQueryRequest()} theme="monokai" />
+                      <Box
+                        sx={{
+                          overflowX: 'auto',
+                          maxWidth: '100%',
+                          '& pre': { whiteSpace: 'pre-wrap', wordBreak: 'break-word' },
+                        }}
+                      >
+                        <JSONPretty data={formatQueryRequest()} theme="monokai" />
+                      </Box>
                     </Box>
                   )}
 
                   {activeTab === 2 && (
-                    <Box>
+                    <Box sx={{ width: '100%', overflow: 'hidden' }}>
                       <Typography variant="subtitle2" gutterBottom>
                         Full Response
                       </Typography>
-                      <JSONPretty data={queryResults} theme="monokai" />
+                      <Box
+                        sx={{
+                          overflowX: 'auto',
+                          maxWidth: '100%',
+                          '& pre': { whiteSpace: 'pre-wrap', wordBreak: 'break-word' },
+                        }}
+                      >
+                        <JSONPretty data={queryResults} theme="monokai" />
+                      </Box>
                     </Box>
                   )}
                 </Box>

--- a/frontend/src/components/QueryTester.js
+++ b/frontend/src/components/QueryTester.js
@@ -99,6 +99,14 @@ function QueryTester() {
         });
       }
 
+      if (params.searchType === 'multi_surface') {
+        return queryAPI.search(params.kbId, {
+          ...basePayload,
+          query_type: 'multi_surface',
+          similarity_threshold: params.threshold,
+        });
+      }
+
       return queryAPI.search(params.kbId, {
         ...basePayload,
         query_type: 'hybrid',
@@ -151,6 +159,12 @@ function QueryTester() {
         similarity_threshold: parseFloat(threshold),
         title_weighting_enabled: titleWeightingEnabled,
         title_weight_multiplier: titleWeightingEnabled ? titleWeightMultiplier : 1.0,
+      };
+    } else if (searchType === 'multi_surface') {
+      return {
+        ...baseRequest,
+        query_type: 'multi_surface',
+        similarity_threshold: parseFloat(threshold),
       };
     } else {
       return {
@@ -227,6 +241,7 @@ function QueryTester() {
                   <MenuItem value="similarity">Similarity Search</MenuItem>
                   <MenuItem value="keyword">Keyword Search</MenuItem>
                   <MenuItem value="hybrid">Hybrid Search</MenuItem>
+                  <MenuItem value="multi_surface">Multi-Surface Search</MenuItem>
                 </Select>
               </FormControl>
 
@@ -258,7 +273,10 @@ function QueryTester() {
                 inputProps={{ min: 1, max: 100 }}
               />
 
-              {(searchType === 'similarity' || searchType === 'keyword' || searchType === 'hybrid') && (
+              {(searchType === 'similarity' ||
+                searchType === 'keyword' ||
+                searchType === 'hybrid' ||
+                searchType === 'multi_surface') && (
                 <TextField
                   fullWidth
                   type="number"
@@ -416,7 +434,69 @@ function QueryTester() {
 
                   {activeTab === 0 && (
                     <Box>
-                      {queryResults.results && queryResults.results.length > 0 ? (
+                      {queryResults.multi_surface_results && queryResults.multi_surface_results.length > 0 ? (
+                        <Box>
+                          {queryResults.multi_surface_results.map((result, idx) => (
+                            <Card key={result.document_id} variant="outlined" sx={{ mb: 2 }}>
+                              <CardContent>
+                                <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                                  <Typography variant="subtitle1" fontWeight="bold">
+                                    {idx + 1}. {result.document_title}
+                                  </Typography>
+                                  <Chip
+                                    label={`Score: ${(result.final_score * 100).toFixed(1)}%`}
+                                    color="primary"
+                                    size="small"
+                                  />
+                                </Box>
+                                <Box display="flex" gap={1} flexWrap="wrap" mb={2}>
+                                  {Object.entries(result.surface_scores).map(([surface, score]) => (
+                                    <Chip
+                                      key={surface}
+                                      label={`${surface}: ${(score * 100).toFixed(1)}%`}
+                                      variant="outlined"
+                                      size="small"
+                                      color={surface === 'chunk_vector' ? 'info' : 'secondary'}
+                                    />
+                                  ))}
+                                </Box>
+                                {result.contributing_chunks && result.contributing_chunks.length > 0 && (
+                                  <Box>
+                                    <Typography variant="body2" color="text.secondary" gutterBottom>
+                                      Contributing Chunks:
+                                    </Typography>
+                                    {result.contributing_chunks.slice(0, 3).map((chunk) => (
+                                      <Box
+                                        key={chunk.chunk_id}
+                                        sx={{
+                                          bgcolor: 'grey.100',
+                                          p: 1,
+                                          borderRadius: 1,
+                                          mb: 1,
+                                          fontSize: '0.875rem',
+                                        }}
+                                      >
+                                        <Typography variant="caption" color="text.secondary">
+                                          [{chunk.surface}] Chunk #{chunk.chunk_index} ({(chunk.score * 100).toFixed(1)}
+                                          %)
+                                        </Typography>
+                                        <Typography variant="body2" sx={{ mt: 0.5 }}>
+                                          {chunk.snippet}
+                                        </Typography>
+                                        {chunk.summary && (
+                                          <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
+                                            Summary: {chunk.summary}
+                                          </Typography>
+                                        )}
+                                      </Box>
+                                    ))}
+                                  </Box>
+                                )}
+                              </CardContent>
+                            </Card>
+                          ))}
+                        </Box>
+                      ) : queryResults.results && queryResults.results.length > 0 ? (
                         <SourcePreview sources={queryResults.results} title="Query Results" searchQuery={queryText} />
                       ) : (
                         <Alert severity="info">No results found for this query.</Alert>

--- a/frontend/src/components/SourcePreview.js
+++ b/frontend/src/components/SourcePreview.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography, Paper, Chip, Divider } from '@mui/material';
+import { Box, Typography, Paper, Chip, Divider, Card, CardContent, Collapse, IconButton } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 function safeGet(obj, keys, fallback = '') {
   for (const k of keys) {
@@ -11,20 +12,228 @@ function safeGet(obj, keys, fallback = '') {
 }
 
 /**
- * Minimal source preview for KB query results.
+ * Detect if this is a multi-surface result (has surface_scores and final_score)
+ */
+function isMultiSurfaceResult(item) {
+  return item && typeof item.surface_scores === 'object' && typeof item.final_score === 'number';
+}
+
+/**
+ * Group regular chunk results by document for cleaner display
+ */
+function groupByDocument(items) {
+  const groups = new Map();
+  for (const item of items) {
+    const docId = item.document_id || 'unknown';
+    if (!groups.has(docId)) {
+      groups.set(docId, {
+        document_id: docId,
+        document_title: safeGet(item, ['document_title', 'title', 'name'], 'Unknown Document'),
+        chunks: [],
+        best_score: 0,
+      });
+    }
+    const group = groups.get(docId);
+    const score = safeGet(item, ['score', 'similarity_score', 'similarity', 'confidence'], 0);
+    group.chunks.push({ ...item, score });
+    if (score > group.best_score) {
+      group.best_score = score;
+    }
+  }
+  // Sort groups by best score descending
+  return Array.from(groups.values()).sort((a, b) => b.best_score - a.best_score);
+}
+
+/**
+ * Render a single multi-surface result (document with surface scores and contributing chunks)
+ */
+function MultiSurfaceItem({ result, rank }) {
+  const [expanded, setExpanded] = React.useState(true);
+  const chunks = result.contributing_chunks || [];
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2 }}>
+      <CardContent sx={{ pb: expanded ? 1 : 2 }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+          <Typography variant="subtitle1" fontWeight="bold">
+            {rank}. {result.document_title}
+          </Typography>
+          <Chip label={`Score: ${(result.final_score * 100).toFixed(1)}%`} color="primary" size="small" />
+        </Box>
+        <Box display="flex" gap={1} flexWrap="wrap" mb={1}>
+          {Object.entries(result.surface_scores || {}).map(([surface, score]) => (
+            <Chip
+              key={surface}
+              label={`${surface}: ${(score * 100).toFixed(1)}%`}
+              variant="outlined"
+              size="small"
+              color={surface === 'chunk_vector' ? 'info' : 'secondary'}
+            />
+          ))}
+        </Box>
+        {chunks.length > 0 && (
+          <Box>
+            <Box display="flex" alignItems="center" sx={{ cursor: 'pointer' }} onClick={() => setExpanded(!expanded)}>
+              <Typography variant="body2" color="text.secondary">
+                {chunks.length} Contributing Chunk{chunks.length !== 1 ? 's' : ''}
+              </Typography>
+              <IconButton
+                size="small"
+                sx={{ transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: '0.2s' }}
+              >
+                <ExpandMoreIcon fontSize="small" />
+              </IconButton>
+            </Box>
+            <Collapse in={expanded}>
+              <Box sx={{ mt: 1 }}>
+                {chunks.slice(0, 5).map((chunk) => (
+                  <Box
+                    key={chunk.chunk_id}
+                    sx={{
+                      bgcolor: 'grey.100',
+                      p: 1,
+                      borderRadius: 1,
+                      mb: 1,
+                      fontSize: '0.875rem',
+                    }}
+                  >
+                    <Box display="flex" alignItems="center" gap={1} mb={0.5}>
+                      <Chip
+                        label={`#${chunk.chunk_index}`}
+                        size="small"
+                        color="default"
+                        sx={{ fontWeight: 'bold', minWidth: 45 }}
+                      />
+                      <Chip
+                        label={chunk.surface}
+                        size="small"
+                        variant="outlined"
+                        color={chunk.surface === 'chunk_vector' ? 'info' : 'secondary'}
+                      />
+                      <Chip label={`${(chunk.score * 100).toFixed(1)}%`} size="small" variant="outlined" />
+                    </Box>
+                    <Typography variant="body2" sx={{ mt: 0.5 }}>
+                      {chunk.snippet}
+                    </Typography>
+                    {chunk.summary && (
+                      <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
+                        Summary: {chunk.summary}
+                      </Typography>
+                    )}
+                  </Box>
+                ))}
+                {chunks.length > 5 && (
+                  <Typography variant="caption" color="text.secondary">
+                    +{chunks.length - 5} more chunks
+                  </Typography>
+                )}
+              </Box>
+            </Collapse>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Render grouped regular results (chunks grouped by document)
+ */
+function GroupedDocumentItem({ group, rank }) {
+  const [expanded, setExpanded] = React.useState(true);
+  const chunks = group.chunks.sort((a, b) => b.score - a.score);
+
+  return (
+    <Card variant="outlined" sx={{ mb: 2 }}>
+      <CardContent sx={{ pb: expanded ? 1 : 2 }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+          <Typography variant="subtitle1" fontWeight="bold">
+            {rank}. {group.document_title}
+          </Typography>
+          <Chip label={`Best: ${(group.best_score * 100).toFixed(1)}%`} color="primary" size="small" />
+        </Box>
+        <Box display="flex" alignItems="center" sx={{ cursor: 'pointer' }} onClick={() => setExpanded(!expanded)}>
+          <Typography variant="body2" color="text.secondary">
+            {chunks.length} Chunk{chunks.length !== 1 ? 's' : ''}
+          </Typography>
+          <IconButton size="small" sx={{ transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: '0.2s' }}>
+            <ExpandMoreIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <Collapse in={expanded}>
+          <Box sx={{ mt: 1 }}>
+            {chunks.slice(0, 5).map((chunk, idx) => {
+              const chunkIndex = safeGet(chunk, ['chunk_index', 'index'], idx);
+              const snippet = safeGet(chunk, ['snippet', 'content_snippet', 'content_preview', 'content'], '');
+              const url = safeGet(chunk, ['source_url', 'url', 'link'], '');
+
+              return (
+                <Box
+                  key={chunk.id || idx}
+                  sx={{
+                    bgcolor: 'grey.100',
+                    p: 1,
+                    borderRadius: 1,
+                    mb: 1,
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  <Box display="flex" alignItems="center" gap={1} mb={0.5}>
+                    <Chip
+                      label={`#${chunkIndex}`}
+                      size="small"
+                      color="default"
+                      sx={{ fontWeight: 'bold', minWidth: 45 }}
+                    />
+                    <Chip label={`${(chunk.score * 100).toFixed(1)}%`} size="small" variant="outlined" />
+                    {chunk.source_type && <Chip label={chunk.source_type} size="small" variant="outlined" />}
+                  </Box>
+                  {url && (
+                    <Typography variant="caption" color="primary" sx={{ display: 'block', mb: 0.5 }}>
+                      {url}
+                    </Typography>
+                  )}
+                  {snippet && (
+                    <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                      {snippet.length > 300 ? `${snippet.slice(0, 300)}...` : snippet}
+                    </Typography>
+                  )}
+                </Box>
+              );
+            })}
+            {chunks.length > 5 && (
+              <Typography variant="caption" color="text.secondary">
+                +{chunks.length - 5} more chunks
+              </Typography>
+            )}
+          </Box>
+        </Collapse>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Source preview for KB query results - supports both multi-surface and regular results.
  * Props:
  * - title?: string
- * - sources: Array<any>
+ * - sources: Array<any> - regular chunk results or multi-surface results
  * - searchQuery?: string
+ * - groupByDoc?: boolean - group regular results by document (default: true)
  */
-export default function SourcePreview({ title = 'Sources', sources = [], searchQuery = '' }) {
+export default function SourcePreview({ title = 'Sources', sources = [], searchQuery = '', groupByDoc = true }) {
   const items = Array.isArray(sources) ? sources : [];
+  const isMultiSurface = items.length > 0 && isMultiSurfaceResult(items[0]);
+
+  // Count documents vs chunks for display
+  const docCount = isMultiSurface ? items.length : groupByDoc ? groupByDocument(items).length : items.length;
+  const itemLabel = isMultiSurface || groupByDoc ? 'document' : 'chunk';
 
   return (
     <Box>
       <Box display="flex" alignItems="center" justifyContent="space-between" mb={1}>
         <Typography variant="subtitle1">{title}</Typography>
-        <Chip label={`${items.length} item${items.length === 1 ? '' : 's'}`} size="small" color="primary" />
+        <Chip label={`${docCount} ${itemLabel}${docCount === 1 ? '' : 's'}`} size="small" color="primary" />
       </Box>
       {searchQuery && (
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
@@ -36,18 +245,35 @@ export default function SourcePreview({ title = 'Sources', sources = [], searchQ
         <Typography variant="body2" color="text.secondary">
           No sources to display.
         </Typography>
+      ) : isMultiSurface ? (
+        // Multi-surface results - already grouped by document
+        <Box>
+          {items.slice(0, 20).map((result, idx) => (
+            <MultiSurfaceItem key={result.document_id} result={result} rank={idx + 1} />
+          ))}
+        </Box>
+      ) : groupByDoc ? (
+        // Regular results grouped by document
+        <Box>
+          {groupByDocument(items)
+            .slice(0, 20)
+            .map((group, idx) => (
+              <GroupedDocumentItem key={group.document_id} group={group} rank={idx + 1} />
+            ))}
+        </Box>
       ) : (
+        // Flat list (legacy mode)
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
           {items.slice(0, 20).map((src, idx) => {
-            const title = safeGet(src, ['document_title', 'title', 'name'], `Result ${idx + 1}`);
+            const itemTitle = safeGet(src, ['document_title', 'title', 'name'], `Result ${idx + 1}`);
             const snippet = safeGet(src, ['snippet', 'content_snippet', 'content_preview', 'content'], '');
             const url = safeGet(src, ['source_url', 'url', 'link'], '');
-            const score = safeGet(src, ['score', 'similarity', 'confidence'], null);
+            const score = safeGet(src, ['score', 'similarity_score', 'similarity', 'confidence'], null);
 
             return (
               <Paper key={idx} sx={{ p: 1.5, backgroundColor: 'grey.50' }}>
                 <Typography variant="subtitle2" gutterBottom>
-                  {title}
+                  {itemTitle}
                 </Typography>
                 {url && (
                   <Typography variant="caption" color="primary" sx={{ display: 'block', mb: 0.5 }}>

--- a/frontend/src/components/SourcePreview.js
+++ b/frontend/src/components/SourcePreview.js
@@ -15,7 +15,12 @@ function safeGet(obj, keys, fallback = '') {
  * Detect if this is a multi-surface result (has surface_scores and final_score)
  */
 function isMultiSurfaceResult(item) {
-  return item && typeof item.surface_scores === 'object' && typeof item.final_score === 'number';
+  return (
+    item &&
+    item.surface_scores !== null &&
+    typeof item.surface_scores === 'object' &&
+    typeof item.final_score === 'number'
+  );
 }
 
 /**
@@ -86,9 +91,9 @@ function MultiSurfaceItem({ result, rank }) {
             </Box>
             <Collapse in={expanded}>
               <Box sx={{ mt: 1 }}>
-                {chunks.slice(0, 5).map((chunk) => (
+                {chunks.slice(0, 5).map((chunk, index) => (
                   <Box
-                    key={chunk.chunk_id}
+                    key={chunk.chunk_id || `chunk-${chunk.chunk_index ?? index}`}
                     sx={{
                       bgcolor: 'grey.100',
                       p: 1,
@@ -99,18 +104,22 @@ function MultiSurfaceItem({ result, rank }) {
                   >
                     <Box display="flex" alignItems="center" gap={1} mb={0.5}>
                       <Chip
-                        label={`#${chunk.chunk_index}`}
+                        label={`#${chunk.chunk_index ?? '?'}`}
                         size="small"
                         color="default"
                         sx={{ fontWeight: 'bold', minWidth: 45 }}
                       />
                       <Chip
-                        label={chunk.surface}
+                        label={chunk.surface || 'unknown'}
                         size="small"
                         variant="outlined"
                         color={chunk.surface === 'chunk_vector' ? 'info' : 'secondary'}
                       />
-                      <Chip label={`${(chunk.score * 100).toFixed(1)}%`} size="small" variant="outlined" />
+                      <Chip
+                        label={typeof chunk.score === 'number' ? `${(chunk.score * 100).toFixed(1)}%` : 'N/A'}
+                        size="small"
+                        variant="outlined"
+                      />
                     </Box>
                     <Typography variant="body2" sx={{ mt: 0.5 }}>
                       {chunk.snippet}
@@ -141,7 +150,7 @@ function MultiSurfaceItem({ result, rank }) {
  */
 function GroupedDocumentItem({ group, rank }) {
   const [expanded, setExpanded] = React.useState(true);
-  const chunks = group.chunks.sort((a, b) => b.score - a.score);
+  const chunks = [...group.chunks].sort((a, b) => b.score - a.score);
 
   return (
     <Card variant="outlined" sx={{ mb: 2 }}>


### PR DESCRIPTION
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-surface search that fuses chunk-vector and synopsis-match results with per-request weight controls.
  * Title-weighting controls for keyword searches.
  * UI: query tester sliders for multi-surface weights, relaxed threshold handling, grouped document view with collapsible chunk details.
  * Profiling now marks and skips no-op jobs to avoid unnecessary retries.

* **Bug Fixes**
  * Lowered default RAG/hybrid similarity thresholds from 0.7 to 0.3 for broader matching.

* **Tests**
  * Added integration and unit coverage for multi-surface retrieval and fusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->