### PR TITLE
[SHU-657] Per op schema changes

### DIFF
--- a/backend/src/shu/api/chat_plugins.py
+++ b/backend/src/shu/api/chat_plugins.py
@@ -21,6 +21,7 @@ from ..plugins.base import Plugin
 from ..plugins.executor import EXECUTOR
 from ..plugins.loader import PluginRecord
 from ..plugins.registry import REGISTRY
+from ..plugins.schema import resolve_all_ops
 from ..schemas.envelope import SuccessResponse
 from ..services.plugin_execution import get_allowed_plugin_names
 from ..services.plugin_identity import (
@@ -62,25 +63,9 @@ def get_chat_ops(rec: PluginRecord) -> list:
         return []
 
 
-async def get_plugin_and_schema(name: str, db: AsyncSession) -> tuple[Plugin | None, dict[str, Any] | None]:
-    plugin = None
+async def resolve_plugin(name: str, db: AsyncSession) -> Plugin | None:
     try:
-        plugin = await REGISTRY.resolve(name, db)
-    except Exception:
-        pass
-
-    schema = None
-    try:
-        schema = plugin.get_schema()
-    except Exception:
-        pass
-
-    return plugin, schema
-
-
-def get_enum_labels(schema: dict[str, Any] | None) -> dict[str, str] | None:
-    try:
-        return ((((schema or {}).get("properties") or {}).get("op") or {}).get("x-ui", {})).get("enum_labels")
+        return await REGISTRY.resolve(name, db)
     except Exception:
         return None
 
@@ -110,33 +95,19 @@ async def list_chat_plugins(
         if not chat_ops:
             continue
 
-        # Load plugin to get schema and optional labels/help
-        plugin, schema = await get_plugin_and_schema(name, db)
+        plugin = await resolve_plugin(name, db)
         if not plugin:
             continue
 
-        # Derive enum labels/help for title/description when available
-        enum_labels = get_enum_labels(schema)
-
-        for op in chat_ops:
-            title = None
-            description = None
-            if isinstance(enum_labels, dict):
-                label = enum_labels.get(str(op))
-                if label:
-                    title = label
-            # Fallback titles
-            if not title:
-                title = f"{name}:{op}"
-            base_schema = schema or {
+        for op, resolved in resolve_all_ops(plugin, chat_ops).items():
+            base_schema = resolved.schema or {
                 "type": "object",
                 "properties": {},
                 "additionalProperties": True,
             }
-            # Deep-copy the base schema so we can pin the `op` field per chat-callable operation
-            # without mutating the plugin's original schema (shared across ops/endpoints). This limits
-            # the available operations to the chat-callable subset declared in the manifest, which prevents
-            # op injection attacks or LLM accidental execution of non-chat-callable ops.
+            # Deep-copy so we can pin the `op` field per chat-callable operation without
+            # mutating the plugin's original schema. This limits available operations to
+            # the chat-callable subset, preventing op injection or accidental execution.
             op_schema = copy.deepcopy(base_schema)
             props = op_schema.setdefault("properties", {})
             props["op"] = {
@@ -154,8 +125,8 @@ async def list_chat_plugins(
                 ChatPluginOpDescriptor(
                     name=name,
                     op=op,
-                    title=title,
-                    description=description,
+                    title=resolved.title or f"{name}:{op}",
+                    description=resolved.description,
                     input_schema=op_schema,
                     required_identities=list(getattr(rec, "required_identities", []) or []),
                     chat_callable=True,

--- a/backend/src/shu/api/plugins_admin.py
+++ b/backend/src/shu/api/plugins_admin.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, Field
@@ -47,11 +46,6 @@ class PluginEnableRequest(BaseModel):
     enabled: bool
 
 
-class PluginSchemaRequest(BaseModel):
-    input_schema: dict[str, Any] | None = None
-    output_schema: dict[str, Any] | None = None
-
-
 @router.patch("/admin/{name}/enable", response_model=SuccessResponse[dict])
 async def admin_set_plugin_enabled(
     name: str,
@@ -71,36 +65,6 @@ async def admin_set_plugin_enabled(
             "name": row.name,
             "version": getattr(row, "version", None),
             "enabled": bool(row.enabled),
-            "input_schema": getattr(row, "input_schema", None),
-            "output_schema": getattr(row, "output_schema", None),
-        }
-    )
-
-
-@router.put("/admin/{name}/schema", response_model=SuccessResponse[dict])
-async def admin_set_plugin_schema(
-    name: str,
-    body: PluginSchemaRequest,
-    db: AsyncSession = Depends(get_db),
-    admin: User = Depends(require_power_user),
-):
-    res = await db.execute(select(PluginDefinition).where(PluginDefinition.name == name))
-    row = res.scalars().first()
-    if not row:
-        raise HTTPException(status_code=404, detail=f"Plugin '{name}' not found")
-    if body.input_schema is not None:
-        row.input_schema = body.input_schema
-    if body.output_schema is not None:
-        row.output_schema = body.output_schema
-    await db.commit()
-    await db.refresh(row)
-    return ShuResponse.success(
-        {
-            "name": row.name,
-            "version": getattr(row, "version", None),
-            "enabled": bool(row.enabled),
-            "input_schema": getattr(row, "input_schema", None),
-            "output_schema": getattr(row, "output_schema", None),
         }
     )
 

--- a/backend/src/shu/api/plugins_public.py
+++ b/backend/src/shu/api/plugins_public.py
@@ -24,6 +24,7 @@ from ..models.plugin_execution import PluginExecution, PluginExecutionStatus
 from ..models.plugin_registry import PluginDefinition
 from ..plugins.executor import EXECUTOR
 from ..plugins.registry import REGISTRY
+from ..plugins.schema import resolve_all_ops
 from ..schemas.envelope import SuccessResponse
 from ..services.plugin_identity import get_provider_identities_map, resolve_user_email_for_execution
 from ..services.plugin_validation import enforce_input_limit, enforce_output_limit
@@ -39,18 +40,47 @@ class PluginExecuteRequest(BaseModel):
     agent_key: str | None = None
 
 
+class OpSchemaResponse(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    input_schema: dict[str, Any] | None = None
+
+
 class PluginInfoResponse(BaseModel):
     name: str
     version: str | None = None
     enabled: bool
     display_name: str | None = None
-    input_schema: dict[str, Any] | None = None
+    ops: dict[str, OpSchemaResponse] = Field(default_factory=dict)
     output_schema: dict[str, Any] | None = None
     capabilities: list[str] | None = None
     required_identities: list[dict[str, Any]] | None = None
     op_auth: dict[str, Any] | None = None
     default_feed_op: str | None = None
     allowed_feed_ops: list[str] | None = None
+
+
+async def _resolve_ops(
+    plugin_name: str,
+    rec: Any,
+    enabled: bool,
+    db: AsyncSession,
+) -> dict[str, OpSchemaResponse]:
+    """Resolve per-op schemas for a plugin from the live instance."""
+    declared_ops = list(rec.chat_callable_ops or []) + list(rec.allowed_feed_ops or [])
+    if not declared_ops or not enabled:
+        return {}
+    plugin = await REGISTRY.resolve(plugin_name, db)
+    if not plugin:
+        return {}
+    return {
+        op_name: OpSchemaResponse(
+            title=resolved.title,
+            description=resolved.description,
+            input_schema=resolved.schema,
+        )
+        for op_name, resolved in resolve_all_ops(plugin, declared_ops).items()
+    }
 
 
 @router.get("/", response_model=SuccessResponse[list[PluginInfoResponse]])
@@ -77,29 +107,31 @@ async def list_plugins(
             req_ids = (
                 list(rec.required_identities or []) if getattr(rec, "required_identities", None) is not None else None
             )
-            op_auth = dict(rec.op_auth or {}) if getattr(rec, "op_auth", None) is not None else None
+            op_auth_val = dict(rec.op_auth or {}) if getattr(rec, "op_auth", None) is not None else None
             default_feed_op = rec.default_feed_op if getattr(rec, "default_feed_op", None) is not None else None
             allowed_feed_ops = (
                 list(rec.allowed_feed_ops or []) if getattr(rec, "allowed_feed_ops", None) is not None else None
             )
             display_name = getattr(rec, "display_name", None) or getattr(rec, "name", None) or name
-            input_schema = getattr(r, "input_schema", None) if r is not None else None
             output_schema = getattr(r, "output_schema", None) if r is not None else None
             version = getattr(r, "version", None) or getattr(rec, "version", None)
             enabled = bool(getattr(r, "enabled", False))
+
+            ops = await _resolve_ops(name, rec, enabled, db)
         except Exception as e:
             logger.warning("Failed to process plugin manifest entry %s: %s", name, e)
+            continue
         out.append(
             PluginInfoResponse(
                 name=name,
                 version=version,
                 enabled=enabled,
                 display_name=display_name,
-                input_schema=input_schema,
+                ops=ops,
                 output_schema=output_schema,
                 capabilities=caps,
                 required_identities=req_ids,
-                op_auth=op_auth,
+                op_auth=op_auth_val,
                 default_feed_op=default_feed_op,
                 allowed_feed_ops=allowed_feed_ops,
             )
@@ -128,7 +160,7 @@ async def get_plugin(
     req_ids = (
         list(rec.required_identities or []) if rec and getattr(rec, "required_identities", None) is not None else None
     )
-    op_auth = dict(rec.op_auth or {}) if rec and getattr(rec, "op_auth", None) is not None else None
+    op_auth_val = dict(rec.op_auth or {}) if rec and getattr(rec, "op_auth", None) is not None else None
     default_feed_op = rec.default_feed_op if rec and getattr(rec, "default_feed_op", None) is not None else None
     allowed_feed_ops = (
         list(rec.allowed_feed_ops or []) if rec and getattr(rec, "allowed_feed_ops", None) is not None else None
@@ -137,17 +169,19 @@ async def get_plugin(
         (getattr(rec, "display_name", None) if rec else None) or (getattr(rec, "name", None) if rec else None) or name
     )
 
+    ops = await _resolve_ops(name, rec, bool(row.enabled), db) if rec else {}
+
     return ShuResponse.success(
         PluginInfoResponse(
             name=row.name,
             version=getattr(row, "version", None),
             enabled=bool(row.enabled),
             display_name=display_name,
-            input_schema=getattr(row, "input_schema", None),
+            ops=ops,
             output_schema=getattr(row, "output_schema", None),
             capabilities=caps,
             required_identities=req_ids,
-            op_auth=op_auth,
+            op_auth=op_auth_val,
             default_feed_op=default_feed_op,
             allowed_feed_ops=allowed_feed_ops,
         )

--- a/backend/src/shu/api/plugins_public.py
+++ b/backend/src/shu/api/plugins_public.py
@@ -67,12 +67,12 @@ async def _resolve_ops(
     db: AsyncSession,
 ) -> dict[str, OpSchemaResponse]:
     """Resolve per-op schemas for a plugin from the live instance."""
-    declared_ops = list(rec.chat_callable_ops or []) + list(rec.allowed_feed_ops or [])
-    if not declared_ops or not enabled:
+    declared_ops = list(dict.fromkeys(list(rec.chat_callable_ops or []) + list(rec.allowed_feed_ops or [])))
+    if not declared_ops:
         return {}
-    plugin = await REGISTRY.resolve(plugin_name, db)
+    plugin = await REGISTRY.resolve(plugin_name, db) if enabled else None
     if not plugin:
-        return {}
+        return {op: OpSchemaResponse() for op in declared_ops}
     return {
         op_name: OpSchemaResponse(
             title=resolved.title,
@@ -169,7 +169,11 @@ async def get_plugin(
         (getattr(rec, "display_name", None) if rec else None) or (getattr(rec, "name", None) if rec else None) or name
     )
 
-    ops = await _resolve_ops(name, rec, bool(row.enabled), db) if rec else {}
+    try:
+        ops = await _resolve_ops(name, rec, bool(row.enabled), db) if rec else {}
+    except Exception:
+        logger.warning("Failed to resolve ops for plugin %s", name)
+        ops = {}
 
     return ShuResponse.success(
         PluginInfoResponse(

--- a/backend/src/shu/models/plugin_execution.py
+++ b/backend/src/shu/models/plugin_execution.py
@@ -61,4 +61,4 @@ class CallableTool:
     op: str
     plugin: Plugin | None
     schema: dict[str, Any] | None
-    enum_labels: dict[str, Any] | None
+    title: str | None

--- a/backend/src/shu/plugins/base.py
+++ b/backend/src/shu/plugins/base.py
@@ -42,7 +42,19 @@ class Plugin(Protocol):
     version: str
 
     def get_schema(self) -> dict[str, Any] | None:
-        """Return a JSON schema for parameters if available."""
+        """Return a combined JSON schema for all operations.
+
+        Deprecated: Implement ``get_schema_for_op`` instead to provide
+        accurate per-operation schemas.
+        """
+        ...
+
+    def get_schema_for_op(self, op: str) -> dict[str, Any] | None:
+        """Return the JSON schema for a specific operation.
+
+        Returns ``None`` if the plugin cannot provide a schema for *op*.
+        Preferred over the deprecated ``get_schema`` method.
+        """
         ...
 
     def get_output_schema(self) -> dict[str, Any] | None:

--- a/backend/src/shu/plugins/executor.py
+++ b/backend/src/shu/plugins/executor.py
@@ -30,6 +30,7 @@ from ..core.cache_backend import CacheBackend, get_cache_backend
 from ..core.config import get_settings_instance  # type: ignore
 from ..services.policy_engine import POLICY_CACHE
 from .base import ExecuteContext, Plugin, PluginResult
+from .schema import resolve_op_schema
 
 logger = logging.getLogger(__name__)
 
@@ -233,39 +234,19 @@ class Executor:
             self._limiter = None
             self._provider_limiter = None
 
-    def _validate(self, plugin: Plugin, params: dict[str, Any]) -> dict[str, Any]:
-        """Validate the provided params against the plugin's input schema and return the params if validation succeeds.
+    def _validate(self, plugin: Plugin, params: dict[str, Any], op: str) -> dict[str, Any]:
+        """Validate params against the plugin's per-op input schema.
 
-        If the plugin exposes no schema, the params are returned unchanged (with stripped None values). If jsonschema
-        is available, perform full schema validation and raise an HTTPException with status 422 and a structured detail
-        on validation failure. If jsonschema is not available, ensure all keys listed under the schema's "required"
-        field are present and raise an HTTPException 422 identifying a missing key if not.
-
-        Parameters
-        ----------
-            plugin (Plugin): Plugin instance whose schema will be used (via plugin.get_schema()).
-            params (Dict[str, Any]): Input parameters to validate.
-
-        Returns
-        -------
-            Dict[str, Any]: The same `params` dictionary if validation passes.
+        If the plugin exposes no schema for *op*, params are returned unchanged
+        (with stripped None values). Uses ``resolve_op_schema`` to try the per-op
+        interface first and fall back to the deprecated combined schema.
 
         Raises
         ------
-            HTTPException: Raised with status code 422 and a structured detail when validation fails or required keys are missing.
+            HTTPException: 422 when validation fails or required keys are missing.
 
         """
-        schema = None
-        try:
-            # Call the more precise `get_schema_for_op` function, with fallback to the legacy `get_schema` function
-            op = params.get("op") if isinstance(params, dict) else None
-            get_schema_for_op = getattr(plugin, "get_schema_for_op", None)
-            if op and get_schema_for_op:
-                schema = get_schema_for_op(op)
-            if not schema:
-                schema = plugin.get_schema()
-        except Exception:
-            logger.exception("Plugin.get_schema failed for %s", getattr(plugin, "name", "?"))
+        schema = resolve_op_schema(plugin, op)
         if not schema:
             return params
 
@@ -587,7 +568,7 @@ class Executor:
                     )
 
             # Validate
-            vparams = self._validate(plugin, raw_params)
+            vparams = self._validate(plugin, raw_params, str(raw_params.get("op") or ""))
 
             # Derive op_auth scopes into host overlay for host.auth resolution (AUTH-REF-001)
             try:

--- a/backend/src/shu/plugins/executor.py
+++ b/backend/src/shu/plugins/executor.py
@@ -250,6 +250,18 @@ class Executor:
         if not schema:
             return params
 
+        # Ensure the host-injected "op" field is declared in the schema so
+        # validation catches callers that forget to inject it.
+        schema = dict(schema)
+        props = dict(schema.get("properties") or {})
+        if "op" not in props:
+            props["op"] = {"type": "string"}
+            schema["properties"] = props
+        req = list(schema.get("required") or [])
+        if "op" not in req:
+            req.append("op")
+            schema["required"] = req
+
         # Strip None values so optional params sent as null by OLLAMA don't fail schema validation.
         # Models sometimes call {..., "param": None, ...} which fails validation, so we strip them.
         clean_params = {k: v for k, v in params.items() if v is not None}

--- a/backend/src/shu/plugins/loader.py
+++ b/backend/src/shu/plugins/loader.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from ..core.config import get_settings_instance
 from .base import Plugin
+from .schema import validate_legacy_schema, validate_per_op_schemas
 
 logger = logging.getLogger(__name__)
 
@@ -243,16 +244,13 @@ class PluginLoader:
             mod = importlib.import_module(module_path)
         cls = getattr(mod, class_name)
         plugin = cls()  # type: ignore[call-arg]
-        # Validate op requirement: schema must declare properties.op.enum with at least one value
+        # Validate op requirement: plugin must produce schemas for its declared ops.
         try:
-            in_schema = None
-            if hasattr(plugin, "get_schema"):
-                in_schema = plugin.get_schema()
-            props = (in_schema or {}).get("properties") if isinstance(in_schema, dict) else None
-            op_def = (props or {}).get("op") if isinstance(props, dict) else None
-            enum_vals = (op_def or {}).get("enum") if isinstance(op_def, dict) else None
-            if not (isinstance(enum_vals, (list, tuple)) and len(enum_vals) >= 1):
-                raise ImportError(f"Plugin '{record.name}' missing op enum in input schema")
+            declared_ops = list(record.chat_callable_ops or []) + list(record.allowed_feed_ops or [])
+            if callable(getattr(plugin, "get_schema_for_op", None)):
+                validate_per_op_schemas(plugin, declared_ops)
+            else:
+                validate_legacy_schema(plugin)
         except ImportError:
             raise
         except Exception as e:

--- a/backend/src/shu/plugins/mcp_adapter.py
+++ b/backend/src/shu/plugins/mcp_adapter.py
@@ -263,7 +263,7 @@ class McpPluginAdapter:
         warnings: list[str] = []
         last_cursor: str | None = None
 
-        for page in range(self._max_pagination_pages):
+        for _ in range(self._max_pagination_pages):
             outcome = await self._call_tool(op, call_params)
             if isinstance(outcome, PluginResult):
                 if cursor_field and cursor_param and last_cursor:

--- a/backend/src/shu/plugins/mcp_adapter.py
+++ b/backend/src/shu/plugins/mcp_adapter.py
@@ -6,6 +6,7 @@ import json
 import time
 from typing import Any
 
+from shu.core.config import get_settings_instance
 from shu.core.logging import get_logger
 from shu.models.mcp_server_connection import McpServerConnection
 from shu.plugins.base import ExecuteContext, PluginResult
@@ -33,6 +34,8 @@ class McpPluginAdapter:
     def __init__(self, connection: McpServerConnection, client: McpClient | None = None) -> None:
         self._connection = connection
         self._client = client
+        settings = get_settings_instance()
+        self._max_pagination_pages = getattr(settings, "max_pagination_limit", 1000)
         self.name: str = f"mcp:{connection.name}"
         server_info = connection.server_info or {}
         self.version: str = server_info.get("version", "1.0")
@@ -129,20 +132,17 @@ class McpPluginAdapter:
         discovered = self._discovered_tools_by_name()
         tool_info = discovered.get(op, {})
         input_schema = tool_info.get("inputSchema")
-
-        properties: dict[str, Any] = {}
-        required: list[str] = ["op"]
+        description = tool_info.get("description")
 
         if input_schema and isinstance(input_schema, dict):
-            properties.update(input_schema.get("properties", {}))
-            required.extend(input_schema.get("required", []))
+            schema = dict(input_schema)
+        else:
+            schema = {"type": "object", "properties": {}, "additionalProperties": True}
 
-        return {
-            "type": "object",
-            "properties": properties,
-            "required": required,
-            "additionalProperties": True,
-        }
+        schema["title"] = op.replace("_", " ").replace("-", " ").title()
+        if description:
+            schema["description"] = description
+        return schema
 
     def get_output_schema(self) -> dict[str, Any] | None:
         """MCP output schemas are ephemeral — return None."""
@@ -263,7 +263,7 @@ class McpPluginAdapter:
         warnings: list[str] = []
         last_cursor: str | None = None
 
-        while True:
+        for page in range(self._max_pagination_pages):
             outcome = await self._call_tool(op, call_params)
             if isinstance(outcome, PluginResult):
                 if cursor_field and cursor_param and last_cursor:
@@ -299,6 +299,12 @@ class McpPluginAdapter:
 
             last_cursor = str(next_cursor)
             call_params[cursor_param] = last_cursor
+        else:
+            logger.warning(
+                "mcp.pagination_limit_reached [%s/%s] after %d pages, ingested=%d",
+                self.name, op, self._max_pagination_pages, ingested_count,
+            )
+            warnings.append(f"Pagination stopped after {self._max_pagination_pages} pages")
 
         if cursor_field and cursor_param and last_cursor and not await self._save_cursor(host, kb_id, last_cursor):
             warnings.append("Cursor save failed; next run may re-process items")
@@ -376,7 +382,8 @@ class McpPluginAdapter:
             return None
         try:
             return await host.cursor.get(kb_id)
-        except Exception:
+        except Exception as e:
+            logger.warning("Could not load cursor: %s", e)
             return None
 
     async def _save_cursor(self, host: Any, kb_id: str, cursor: str) -> bool:

--- a/backend/src/shu/plugins/mcp_adapter.py
+++ b/backend/src/shu/plugins/mcp_adapter.py
@@ -302,7 +302,10 @@ class McpPluginAdapter:
         else:
             logger.warning(
                 "mcp.pagination_limit_reached [%s/%s] after %d pages, ingested=%d",
-                self.name, op, self._max_pagination_pages, ingested_count,
+                self.name,
+                op,
+                self._max_pagination_pages,
+                ingested_count,
             )
             warnings.append(f"Pagination stopped after {self._max_pagination_pages} pages")
 

--- a/backend/src/shu/plugins/registry.py
+++ b/backend/src/shu/plugins/registry.py
@@ -55,7 +55,7 @@ class PluginRegistry:
             return {}
 
     # TODO: Refactor this function. It's too complex (number of branches and statements).
-    async def sync(self, session: AsyncSession) -> dict:  # noqa: PLR0912, PLR0915
+    async def sync(self, session: AsyncSession) -> dict:  # noqa: PLR0915
         """Auto-register discovered plugins into PluginDefinition.
         - Creates a row if missing (enabled=False by default)
         - Updates output_schema if provided by plugin (input_schema is resolved live)

--- a/backend/src/shu/plugins/registry.py
+++ b/backend/src/shu/plugins/registry.py
@@ -58,7 +58,7 @@ class PluginRegistry:
     async def sync(self, session: AsyncSession) -> dict:  # noqa: PLR0912, PLR0915
         """Auto-register discovered plugins into PluginDefinition.
         - Creates a row if missing (enabled=False by default)
-        - Updates input_schema/output_schema if provided by plugin
+        - Updates output_schema if provided by plugin (input_schema is resolved live)
         - Purges DB rows for plugins no longer present on disk
         - Does not flip enabled state automatically.
         """
@@ -84,19 +84,12 @@ class PluginRegistry:
                     continue
                 row = PluginDefinition(name=name, version=getattr(record, "version", "1"), enabled=False)
                 try:
-                    in_schema = None
                     out_schema = None
-                    try:
-                        in_schema = plugin.get_schema()
-                    except Exception:
-                        in_schema = None
                     try:
                         get_out = getattr(plugin, "get_output_schema", None)
                         out_schema = get_out() if callable(get_out) else None
                     except Exception:
                         out_schema = None
-                    if in_schema:
-                        row.input_schema = in_schema
                     if out_schema:
                         row.output_schema = out_schema
                 finally:
@@ -104,28 +97,17 @@ class PluginRegistry:
                     await session.commit()
                     created += 1
             else:
-                # update schema if available
+                # update output_schema if available
                 try:
                     plugin = self._loader.load(record)
-                    in_schema = None
                     out_schema = None
-                    try:
-                        in_schema = plugin.get_schema()
-                    except Exception:
-                        in_schema = None
                     try:
                         get_out = getattr(plugin, "get_output_schema", None)
                         out_schema = get_out() if callable(get_out) else None
                     except Exception:
                         out_schema = None
-                    changed = False
-                    if in_schema and row.input_schema != in_schema:
-                        row.input_schema = in_schema
-                        changed = True
                     if out_schema and row.output_schema != out_schema:
                         row.output_schema = out_schema
-                        changed = True
-                    if changed:
                         await session.commit()
                         updated += 1
                 except Exception:

--- a/backend/src/shu/plugins/schema.py
+++ b/backend/src/shu/plugins/schema.py
@@ -1,0 +1,124 @@
+"""Shared schema resolution helper for plugin operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from shu.core.logging import get_logger
+from shu.plugins.base import Plugin
+
+logger = get_logger(__name__)
+
+
+def resolve_op_schema(plugin: Plugin, op: str) -> dict[str, Any] | None:
+    """Resolve the JSON Schema for a specific plugin operation.
+
+    Tries the per-op interface first (``get_schema_for_op``), then falls back
+    to the legacy ``get_schema()`` with a deprecation warning.  Returns
+    ``None`` when no schema can be obtained.
+    """
+    get_schema_for_op = getattr(plugin, "get_schema_for_op", None)
+    if callable(get_schema_for_op):
+        try:
+            schema = get_schema_for_op(op)
+            if schema is not None:
+                return schema
+        except Exception:
+            logger.exception(
+                "resolve_op_schema.get_schema_for_op_failed plugin=%s op=%s",
+                plugin.name,
+                op,
+            )
+
+    try:
+        schema = plugin.get_schema()
+    except Exception:
+        logger.exception(
+            "resolve_op_schema.get_schema_fallback_failed plugin=%s op=%s",
+            plugin.name,
+            op,
+        )
+        return None
+
+    if schema is not None:
+        logger.warning(
+            "resolve_op_schema.deprecated_get_schema plugin=%s op=%s; implement get_schema_for_op()",
+            plugin.name,
+            op,
+        )
+
+    return schema
+
+
+def validate_per_op_schemas(plugin: Plugin, declared_ops: list[str]) -> None:
+    """Validate that a per-op plugin produces a schema for each declared op.
+
+    Raises ``ImportError`` if any declared op returns ``None`` from
+    ``get_schema_for_op``.
+    """
+    missing = [op for op in declared_ops if plugin.get_schema_for_op(op) is None]
+    if missing:
+        raise ImportError(f"Plugin '{plugin.name}' get_schema_for_op returned None for ops: {missing}")
+
+
+def validate_legacy_schema(plugin: Plugin) -> None:
+    """Validate that a legacy plugin's combined schema declares at least one op.
+
+    Checks ``properties.op.enum`` has at least one value.
+    Raises ``ImportError`` if the schema is missing or invalid.
+    """
+    in_schema = None
+    if hasattr(plugin, "get_schema"):
+        in_schema = plugin.get_schema()
+    props = (in_schema or {}).get("properties") if isinstance(in_schema, dict) else None
+    op_def = (props or {}).get("op") if isinstance(props, dict) else None
+    enum_vals = (op_def or {}).get("enum") if isinstance(op_def, dict) else None
+    if not (isinstance(enum_vals, (list, tuple)) and len(enum_vals) >= 1):
+        raise ImportError(f"Plugin '{plugin.name}' missing op enum in input schema")
+
+
+@dataclass
+class ResolvedOp:
+    """A resolved operation with its schema, title, and description."""
+
+    op: str
+    schema: dict[str, Any] | None
+    title: str | None
+    description: str | None
+
+
+def resolve_all_ops(plugin: Plugin, ops: list[str]) -> dict[str, ResolvedOp]:
+    """Resolve schemas for all declared ops on a plugin.
+
+    Returns a dict keyed by op name with resolved schema, title, and description.
+    Deduplicates ops while preserving order.
+    """
+    result: dict[str, ResolvedOp] = {}
+    for op in dict.fromkeys(ops):
+        schema = resolve_op_schema(plugin, op)
+        result[op] = ResolvedOp(
+            op=op,
+            schema=schema,
+            title=extract_op_title(schema, op),
+            description=(schema or {}).get("description"),
+        )
+    return result
+
+
+def extract_op_title(schema: dict[str, Any] | None, op: str) -> str | None:
+    """Extract a display title for *op* from a schema dict.
+
+    Checks the standard JSON Schema ``title`` field first (per-op schemas),
+    then falls back to ``properties.op.x-ui.enum_labels`` (combined schemas
+    from the deprecated ``get_schema()`` path).
+    """
+    if not schema:
+        return None
+    title = schema.get("title")
+    if title:
+        return title
+    try:
+        return ((schema.get("properties") or {}).get("op") or {}).get("x-ui", {}).get("enum_labels", {}).get(str(op))
+    except Exception:
+        return None

--- a/backend/src/shu/plugins/schema.py
+++ b/backend/src/shu/plugins/schema.py
@@ -54,12 +54,27 @@ def resolve_op_schema(plugin: Plugin, op: str) -> dict[str, Any] | None:
 def validate_per_op_schemas(plugin: Plugin, declared_ops: list[str]) -> None:
     """Validate that a per-op plugin produces a schema for each declared op.
 
-    Raises ``ImportError`` if any declared op returns ``None`` from
-    ``get_schema_for_op``.
+    Each schema must be non-None and include ``title`` and ``description``.
+    Raises ``ImportError`` on violations.
     """
-    missing = [op for op in declared_ops if plugin.get_schema_for_op(op) is None]
+    missing: list[str] = []
+    missing_title: list[str] = []
+    missing_description: list[str] = []
+    for op in declared_ops:
+        schema = plugin.get_schema_for_op(op)
+        if schema is None:
+            missing.append(op)
+            continue
+        if not schema.get("title"):
+            missing_title.append(op)
+        if not schema.get("description"):
+            missing_description.append(op)
     if missing:
         raise ImportError(f"Plugin '{plugin.name}' get_schema_for_op returned None for ops: {missing}")
+    if missing_title:
+        raise ImportError(f"Plugin '{plugin.name}' per-op schema missing 'title' for ops: {missing_title}")
+    if missing_description:
+        raise ImportError(f"Plugin '{plugin.name}' per-op schema missing 'description' for ops: {missing_description}")
 
 
 def validate_legacy_schema(plugin: Plugin) -> None:

--- a/backend/src/shu/schemas/mcp_admin.py
+++ b/backend/src/shu/schemas/mcp_admin.py
@@ -97,6 +97,14 @@ class McpConnectionCreate(BaseModel):
     )
     enabled: bool = Field(default=True, description="Whether the connection is enabled")
 
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        """Reject names containing __ which conflicts with the tool name delimiter."""
+        if "__" in v:
+            raise ValueError("Connection name must not contain '__' (reserved as tool name delimiter)")
+        return v
+
     @field_validator("url")
     @classmethod
     def validate_url(cls, v: str) -> str:

--- a/backend/src/shu/services/plugin_execution.py
+++ b/backend/src/shu/services/plugin_execution.py
@@ -12,6 +12,7 @@ from shu.plugins.base import Plugin
 from shu.plugins.executor import EXECUTOR
 from shu.plugins.loader import PluginRecord
 from shu.plugins.registry import REGISTRY
+from shu.plugins.schema import extract_op_title, resolve_op_schema
 from shu.services.plugin_identity import PluginIdentityError, ensure_user_identity_for_plugin
 from shu.services.policy_engine import POLICY_CACHE
 
@@ -86,50 +87,25 @@ async def build_agent_tools(db_session: AsyncSession, user_id: str) -> list[Call
         if not plugin:
             continue
 
-        schema: dict[str, Any] | None = None
-        try:
-            schema = plugin.get_schema()
-        except Exception:
-            pass
-
-        enum_labels: dict[str, Any] | None = None
-        try:
-            enum_labels = ((((schema or {}).get("properties") or {}).get("op") or {}).get("x-ui", {})).get(
-                "enum_labels"
-            )
-        except Exception:
-            pass
-
         for op in chat_ops:
-            # Use a per-op schema when the plugin provides get_schema_for_op().
-            # Falls back to the shared schema for plugins that don't implement it.
-            op_schema = schema
-            try:
-                get_op_schema = getattr(plugin, "get_schema_for_op", None)
-                if callable(get_op_schema):
-                    per_op = get_op_schema(op)
-                    if per_op is not None:
-                        op_schema = per_op
-            except Exception:
-                pass
-
+            op_schema = resolve_op_schema(plugin, op)
             tools.append(
                 CallableTool(
                     name=_sanitize_plugin_name(name),
                     op=op,
                     plugin=plugin,
                     schema=op_schema,
-                    enum_labels=enum_labels,
+                    title=extract_op_title(op_schema, op),
                 )
             )
 
     return tools
 
 
-def _coerce_params(plugin: Plugin, params: dict[str, Any]) -> dict[str, Any]:
+def _coerce_params(plugin: Plugin, params: dict[str, Any], op: str) -> dict[str, Any]:
     """Coerce parameter types based on plugin schema."""
     try:
-        schema = plugin.get_schema()
+        schema = resolve_op_schema(plugin, op)
         if not schema:
             return params
 
@@ -262,8 +238,8 @@ async def execute_plugin(
         user_email_val = None
 
     params = dict(args_dict or {})
-    params = _coerce_params(plugin, params)
     params["op"] = operation
+    params = _coerce_params(plugin, params, operation)
 
     try:
         await ensure_user_identity_for_plugin(

--- a/backend/src/shu/services/plugin_execution.py
+++ b/backend/src/shu/services/plugin_execution.py
@@ -88,16 +88,19 @@ async def build_agent_tools(db_session: AsyncSession, user_id: str) -> list[Call
             continue
 
         for op in chat_ops:
-            op_schema = resolve_op_schema(plugin, op)
-            tools.append(
-                CallableTool(
-                    name=_sanitize_plugin_name(name),
-                    op=op,
-                    plugin=plugin,
-                    schema=op_schema,
-                    title=extract_op_title(op_schema, op),
+            try:
+                op_schema = resolve_op_schema(plugin, op)
+                tools.append(
+                    CallableTool(
+                        name=_sanitize_plugin_name(name),
+                        op=op,
+                        plugin=plugin,
+                        schema=op_schema,
+                        title=extract_op_title(op_schema, op),
+                    )
                 )
-            )
+            except Exception:
+                logger.warning("Failed to resolve schema for %s op=%s", name, op, exc_info=True)
 
     return tools
 

--- a/backend/src/shu/services/plugin_execution_runner.py
+++ b/backend/src/shu/services/plugin_execution_runner.py
@@ -254,6 +254,8 @@ async def execute_plugin_record(  # noqa: PLR0912, PLR0915
 
     _apply_to_record(rec, status=status, error=error_str, result=payload, completed_at=now)
 
+    await _maybe_update_mcp_health(session, rec.plugin_name, status, _err_val, error_str)
+
     # Step 13: Diagnostics logging
     try:
         from ..plugins.utils import log_plugin_diagnostics as _log_diags
@@ -411,3 +413,63 @@ async def _check_subscription(
         )
         return _preflight_failure(rec, "subscription_check_error")
     return None
+
+
+_MCP_CONNECTIVITY_ERROR_CODES = frozenset(
+    {
+        "mcp_connection_error",
+        "mcp_timeout",
+        "mcp_server_error",
+        "mcp_protocol_error",
+        "mcp_response_too_large",
+    }
+)
+
+
+async def _maybe_update_mcp_health(
+    session: AsyncSession,
+    plugin_name: str,
+    status: PluginExecutionStatus,
+    err_val: Any,
+    error_str: str | None,
+) -> None:
+    """Update MCP connection health only for success or actual connectivity failures."""
+    if not plugin_name or not plugin_name.startswith("mcp:"):
+        return
+    error_code = err_val.get("code") if isinstance(err_val, dict) else None
+    is_mcp_error = error_code in _MCP_CONNECTIVITY_ERROR_CODES
+    if status == PluginExecutionStatus.COMPLETED or is_mcp_error:
+        await _update_mcp_health(session, plugin_name, not is_mcp_error, error_str)
+
+
+async def _update_mcp_health(session: AsyncSession, plugin_name: str, success: bool, error: str | None) -> None:
+    """Update MCP connection health tracking after feed execution."""
+    from sqlalchemy import update
+
+    from ..models.mcp_server_connection import McpServerConnection
+
+    connection_name = plugin_name.removeprefix("mcp:").strip()
+    if not connection_name:
+        return
+    try:
+        if success:
+            await session.execute(
+                update(McpServerConnection)
+                .where(McpServerConnection.name == connection_name)
+                .values(consecutive_failures=0, last_error=None, last_connected_at=datetime.now(UTC))
+            )
+        else:
+            await session.execute(
+                update(McpServerConnection)
+                .where(McpServerConnection.name == connection_name)
+                .values(
+                    consecutive_failures=McpServerConnection.consecutive_failures + 1,
+                    last_error=(error or "feed execution failed")[:500],
+                )
+            )
+    except Exception:
+        logger.warning(
+            "Failed to update MCP health after feed execution | plugin=%s",
+            plugin_name,
+            exc_info=True,
+        )

--- a/backend/src/shu/services/plugins_feed_policy.py
+++ b/backend/src/shu/services/plugins_feed_policy.py
@@ -24,7 +24,13 @@ def enforce_feed_op(plugin_name: str, params: dict[str, Any] | None) -> dict[str
         default_op = None
 
     if not allowed:
-        return p
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_feed_op",
+                "message": f"Plugin '{plugin_name}' does not declare any allowed_feed_ops",
+            },
+        )
 
     op = p.get("op")
     if not op:

--- a/backend/src/shu/services/providers/adapters/anthropic_adapter.py
+++ b/backend/src/shu/services/providers/adapters/anthropic_adapter.py
@@ -529,9 +529,7 @@ class AnthropicAdapter(BaseProviderAdapter):
     async def inject_tool_payload(self, tools: list[CallableTool], payload: dict[str, Any]) -> dict[str, Any]:
         anthropic_tools = []
         for tool in tools:
-            title = None
-            if isinstance(tool.enum_labels, dict):
-                title = tool.enum_labels.get(str(tool.op))
+            title = tool.title
             tool_name = f"{tool.name}__{tool.op}"
             input_schema = tool.schema or {
                 "type": "object",

--- a/backend/src/shu/services/providers/adapters/completions_adapter.py
+++ b/backend/src/shu/services/providers/adapters/completions_adapter.py
@@ -251,9 +251,7 @@ class CompletionsAdapter(BaseProviderAdapter):
     async def inject_tool_payload(self, tools: list[CallableTool], payload: dict[str, Any]) -> dict[str, Any]:
         res: list[dict[str, Any]] = []
         for tool in tools:
-            title = None
-            if isinstance(tool.enum_labels, dict):
-                title = tool.enum_labels.get(str(tool.op))
+            title = tool.title
             fname = f"{tool.name}__{tool.op}"
             op_schema = (
                 copy.deepcopy(tool.schema)

--- a/backend/src/shu/services/providers/adapters/gemini_adapter.py
+++ b/backend/src/shu/services/providers/adapters/gemini_adapter.py
@@ -454,9 +454,7 @@ class GeminiAdapter(BaseProviderAdapter):
     async def inject_tool_payload(self, tools: list[CallableTool], payload: dict[str, Any]) -> dict[str, Any]:
         res: list[dict[str, Any]] = []
         for tool in tools:
-            title = None
-            if isinstance(tool.enum_labels, dict):
-                title = tool.enum_labels.get(str(tool.op))
+            title = tool.title
             fname = f"{tool.name}__{tool.op}"
             op_schema = copy.deepcopy(tool.schema) if tool.schema else {"type": "object", "properties": {}}
             props = op_schema.setdefault("properties", {})

--- a/backend/src/shu/services/providers/adapters/responses_adapter.py
+++ b/backend/src/shu/services/providers/adapters/responses_adapter.py
@@ -341,9 +341,7 @@ class ResponsesAdapter(BaseProviderAdapter):
     async def inject_tool_payload(self, tools: list[CallableTool], payload: dict[str, Any]) -> dict[str, Any]:
         res: list[dict[str, Any]] = []
         for tool in tools:
-            title = None
-            if isinstance(tool.enum_labels, dict):
-                title = tool.enum_labels.get(str(tool.op))
+            title = tool.title
             fname = f"{tool.name}__{tool.op}"
             op_schema = (
                 copy.deepcopy(tool.schema)

--- a/backend/src/shu/services/providers/adapters/xai_adapter.py
+++ b/backend/src/shu/services/providers/adapters/xai_adapter.py
@@ -46,9 +46,7 @@ class XAIAdapter(ResponsesAdapter):
     async def inject_tool_payload(self, tools: list[CallableTool], payload: dict[str, Any]) -> dict[str, Any]:
         res: list[dict[str, Any]] = []
         for tool in tools:
-            title = None
-            if isinstance(tool.enum_labels, dict):
-                title = tool.enum_labels.get(str(tool.op))
+            title = tool.title
             fname = f"{tool.name}__{tool.op}"
             op_schema = (
                 copy.deepcopy(tool.schema)

--- a/backend/src/tests/integ/test_outlook_mail_plugin_registration.py
+++ b/backend/src/tests/integ/test_outlook_mail_plugin_registration.py
@@ -192,8 +192,7 @@ async def test_outlook_mail_plugin_registry_sync(client, db, auth_headers):
     assert plugin_def is not None, "outlook_mail plugin not found in database after sync"
     assert plugin_def.name == "outlook_mail", f"Expected name 'outlook_mail', got '{plugin_def.name}'"
 
-    # Verify plugin has schemas
-    assert plugin_def.input_schema is not None, "Plugin should have input_schema"
+    # Verify plugin has output_schema (input_schema is now resolved live, not stored in DB)
     assert plugin_def.output_schema is not None, "Plugin should have output_schema"
 
     # Note: Plugin is created with enabled=False by default (admin must enable)

--- a/backend/src/tests/integ/test_tool_registry_integration.py
+++ b/backend/src/tests/integ/test_tool_registry_integration.py
@@ -77,49 +77,12 @@ async def test_registry_enable_gates_execution(client, db, auth_headers):
     assert payload["data"]["echo"] == "hello"
 
 
-async def test_registry_get_and_update_schema(client, db, auth_headers):
-    """Admin can set schema fields; GET should reflect updates."""
-    # Ensure synced and enabled
-    await client.post("/api/v1/plugins/admin/sync", headers=auth_headers)
-    await client.patch(
-        "/api/v1/plugins/admin/test_schema/enable",
-        json={"enabled": True},
-        headers=auth_headers,
-    )
-
-    # Update schema via admin
-    new_in_schema: dict[str, Any] = {
-        "type": "object",
-        "properties": {"q": {"type": "string"}},
-        "required": ["q"],
-    }
-    new_out_schema: dict[str, Any] = {
-        "type": "object",
-        "properties": {"echo": {"type": "string"}},
-        "required": ["echo"],
-    }
-    resp = await client.put(
-        "/api/v1/plugins/admin/test_schema/schema",
-        json={"input_schema": new_in_schema, "output_schema": new_out_schema},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 200, resp.text
-
-    # GET should reflect changes
-    resp = await client.get("/api/v1/plugins/test_schema", headers=auth_headers)
-    assert resp.status_code == 200, resp.text
-    tool = resp.json()["data"]
-    assert tool["input_schema"] == new_in_schema
-    assert tool["output_schema"] == new_out_schema
-
-
 # --- Suite wrapper ---
 class ToolsRegistryTestSuite(BaseIntegrationTestSuite):
     def get_test_functions(self):
         return [
             test_registry_sync_creates_entries,
             test_registry_enable_gates_execution,
-            test_registry_get_and_update_schema,
         ]
 
     def get_suite_name(self) -> str:

--- a/backend/src/tests/unit/plugins/test_executor.py
+++ b/backend/src/tests/unit/plugins/test_executor.py
@@ -47,6 +47,13 @@ if "shu.plugins.host" not in sys.modules:
     _host_mod = MagicMock()
     sys.modules["shu.plugins.host"] = _host_mod
 
+# Also mock the services.policy_engine path which creates a second circular
+# import chain: executor -> policy_engine -> services/__init__ -> chat_service
+# -> llm -> plugin_execution -> executor.
+if "shu.services.policy_engine" not in sys.modules:
+    _pe_mod = MagicMock()
+    sys.modules["shu.services.policy_engine"] = _pe_mod
+
 from fastapi import HTTPException
 
 from shu.plugins.executor import Executor
@@ -57,10 +64,10 @@ from shu.plugins.executor import Executor
 # ---------------------------------------------------------------------------
 
 def _make_plugin(schema: dict) -> MagicMock:
-    """Return a minimal plugin stub whose get_schema() returns *schema*."""
+    """Return a minimal plugin stub whose get_schema_for_op() returns *schema*."""
     plugin = MagicMock()
-    plugin.get_schema.return_value = schema
-    plugin.get_schema_for_op = None
+    plugin.name = "test-plugin"
+    plugin.get_schema_for_op.return_value = schema
     return plugin
 
 
@@ -93,7 +100,7 @@ def test_validate_strips_none_params():
     executor = _make_executor()
     plugin = _make_plugin(_SCHEMA)
 
-    result = executor._validate(plugin, {"op": "list", "query_filter": None})
+    result = executor._validate(plugin, {"op": "list", "query_filter": None}, "list")
 
     assert result == {"op": "list"}, (
         "query_filter=None should be stripped; returned dict must not contain it"
@@ -106,7 +113,7 @@ def test_validate_required_field_still_enforced():
     plugin = _make_plugin(_SCHEMA)
 
     with pytest.raises(HTTPException) as exc_info:
-        executor._validate(plugin, {"query_filter": None})
+        executor._validate(plugin, {"query_filter": None}, "list")
 
     assert exc_info.value.status_code == 422, (
         "Missing required field 'op' must raise HTTP 422"

--- a/backend/src/tests/unit/plugins/test_schema.py
+++ b/backend/src/tests/unit/plugins/test_schema.py
@@ -174,12 +174,23 @@ class TestExtractOpTitle:
 
 class TestValidatePerOpSchemas:
     def test_passes_when_all_ops_have_schemas(self):
-        plugin = _make_plugin(per_op_schema={"type": "object"})
+        schema = {"type": "object", "title": "Test Op", "description": "A test operation."}
+        plugin = _make_plugin(per_op_schema=schema)
         validate_per_op_schemas(plugin, ["op1", "op2"])
 
     def test_raises_when_op_returns_none(self):
         plugin = _make_plugin(per_op_schema=None)
         with pytest.raises(ImportError, match="returned None for ops"):
+            validate_per_op_schemas(plugin, ["op1"])
+
+    def test_raises_when_title_missing(self):
+        plugin = _make_plugin(per_op_schema={"type": "object", "description": "Has description."})
+        with pytest.raises(ImportError, match="missing 'title'"):
+            validate_per_op_schemas(plugin, ["op1"])
+
+    def test_raises_when_description_missing(self):
+        plugin = _make_plugin(per_op_schema={"type": "object", "title": "Has Title"})
+        with pytest.raises(ImportError, match="missing 'description'"):
             validate_per_op_schemas(plugin, ["op1"])
 
 class TestValidateLegacySchema:

--- a/backend/src/tests/unit/plugins/test_schema.py
+++ b/backend/src/tests/unit/plugins/test_schema.py
@@ -1,0 +1,244 @@
+"""Unit tests for resolve_op_schema helper."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("SHU_DATABASE_URL", "test_db_url")
+os.environ.setdefault("JWT_SECRET_KEY", "test_secret")
+
+from shu.plugins.schema import (
+    extract_op_title,
+    resolve_all_ops,
+    resolve_op_schema,
+    validate_legacy_schema,
+    validate_per_op_schemas,
+)
+
+
+def _make_plugin(
+    name: str = "test-plugin",
+    *,
+    per_op_schema: dict[str, Any] | None | Exception = None,
+    legacy_schema: dict[str, Any] | None | Exception = None,
+    has_per_op: bool = True,
+    has_legacy: bool = True,
+) -> MagicMock:
+    """Build a mock plugin with configurable schema methods."""
+    plugin = MagicMock()
+    plugin.name = name
+    plugin.version = "1.0.0"
+
+    if has_per_op:
+        if isinstance(per_op_schema, Exception):
+            plugin.get_schema_for_op.side_effect = per_op_schema
+        else:
+            plugin.get_schema_for_op.return_value = per_op_schema
+    else:
+        del plugin.get_schema_for_op
+
+    if has_legacy:
+        if isinstance(legacy_schema, Exception):
+            plugin.get_schema.side_effect = legacy_schema
+        else:
+            plugin.get_schema.return_value = legacy_schema
+    else:
+        del plugin.get_schema
+
+    return plugin
+
+
+class TestResolveOpSchema:
+    def test_returns_per_op_schema_when_available(self):
+        expected = {"type": "object", "properties": {"repo": {"type": "string"}}}
+        plugin = _make_plugin(per_op_schema=expected)
+
+        result = resolve_op_schema(plugin, "fetch_activity")
+
+        assert result == expected
+        plugin.get_schema_for_op.assert_called_once_with("fetch_activity")
+        plugin.get_schema.assert_not_called()
+
+    def test_falls_back_to_legacy_when_per_op_returns_none(self):
+        legacy = {"type": "object"}
+        plugin = _make_plugin(per_op_schema=None, legacy_schema=legacy)
+
+        result = resolve_op_schema(plugin, "some_op")
+
+        assert result == legacy
+
+    def test_falls_back_to_legacy_when_per_op_raises(self):
+        legacy = {"type": "object"}
+        plugin = _make_plugin(
+            per_op_schema=RuntimeError("boom"),
+            legacy_schema=legacy,
+        )
+
+        result = resolve_op_schema(plugin, "some_op")
+
+        assert result == legacy
+
+    def test_falls_back_to_legacy_when_per_op_missing(self):
+        legacy = {"type": "object"}
+        plugin = _make_plugin(has_per_op=False, legacy_schema=legacy)
+
+        result = resolve_op_schema(plugin, "some_op")
+
+        assert result == legacy
+
+    def test_returns_none_when_both_unavailable(self):
+        plugin = _make_plugin(has_per_op=False, legacy_schema=None)
+
+        result = resolve_op_schema(plugin, "some_op")
+
+        assert result is None
+
+    def test_returns_none_when_legacy_raises(self):
+        plugin = _make_plugin(
+            per_op_schema=None,
+            legacy_schema=ValueError("bad"),
+        )
+
+        result = resolve_op_schema(plugin, "some_op")
+
+        assert result is None
+
+    def test_returns_none_when_both_raise(self):
+        plugin = _make_plugin(
+            per_op_schema=RuntimeError("boom"),
+            legacy_schema=ValueError("bad"),
+        )
+
+        result = resolve_op_schema(plugin, "some_op")
+
+        assert result is None
+
+    def test_no_legacy_call_when_per_op_succeeds(self):
+        plugin = _make_plugin(
+            per_op_schema={"type": "object"},
+            legacy_schema={"type": "object"},
+        )
+
+        resolve_op_schema(plugin, "op1")
+
+        plugin.get_schema.assert_not_called()
+
+
+class TestExtractOpTitle:
+    def test_returns_none_for_none_schema(self):
+        assert extract_op_title(None, "op") is None
+
+    def test_returns_title_field_from_per_op_schema(self):
+        schema = {"title": "Check Availability", "type": "object"}
+        assert extract_op_title(schema, "check") == "Check Availability"
+
+    def test_returns_enum_label_from_combined_schema(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "op": {
+                    "type": "string",
+                    "x-ui": {"enum_labels": {"book": "Book Service", "cancel": "Cancel"}},
+                }
+            },
+        }
+        assert extract_op_title(schema, "book") == "Book Service"
+
+    def test_title_field_takes_precedence_over_enum_labels(self):
+        schema = {
+            "title": "Per-Op Title",
+            "type": "object",
+            "properties": {
+                "op": {"x-ui": {"enum_labels": {"op1": "Combined Title"}}},
+            },
+        }
+        assert extract_op_title(schema, "op1") == "Per-Op Title"
+
+    def test_returns_none_when_no_title_or_labels(self):
+        schema = {"type": "object", "properties": {}}
+        assert extract_op_title(schema, "op") is None
+
+    def test_returns_none_for_unknown_op_in_enum_labels(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "op": {"x-ui": {"enum_labels": {"known": "Known Op"}}},
+            },
+        }
+        assert extract_op_title(schema, "unknown") is None
+
+
+class TestValidatePerOpSchemas:
+    def test_passes_when_all_ops_have_schemas(self):
+        plugin = _make_plugin(per_op_schema={"type": "object"})
+        validate_per_op_schemas(plugin, ["op1", "op2"])
+
+    def test_raises_when_op_returns_none(self):
+        plugin = _make_plugin(per_op_schema=None)
+        with pytest.raises(ImportError, match="returned None for ops"):
+            validate_per_op_schemas(plugin, ["op1"])
+
+class TestValidateLegacySchema:
+    def test_passes_with_valid_op_enum(self):
+        plugin = _make_plugin(
+            has_per_op=False,
+            legacy_schema={
+                "type": "object",
+                "properties": {"op": {"type": "string", "enum": ["list", "get"]}},
+            },
+        )
+        validate_legacy_schema(plugin)
+
+    def test_raises_when_no_op_enum(self):
+        plugin = _make_plugin(
+            has_per_op=False,
+            legacy_schema={"type": "object", "properties": {}},
+        )
+        with pytest.raises(ImportError, match="missing op enum"):
+            validate_legacy_schema(plugin)
+
+    def test_raises_when_schema_is_none(self):
+        plugin = _make_plugin(has_per_op=False, legacy_schema=None)
+        with pytest.raises(ImportError, match="missing op enum"):
+            validate_legacy_schema(plugin)
+
+
+class TestResolveAllOps:
+    def test_resolves_all_declared_ops(self):
+        schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+        plugin = _make_plugin(per_op_schema=schema)
+
+        result = resolve_all_ops(plugin, ["search", "list"])
+
+        assert set(result.keys()) == {"search", "list"}
+        assert result["search"].schema == schema
+        assert result["list"].schema == schema
+
+    def test_deduplicates_ops(self):
+        plugin = _make_plugin(per_op_schema={"type": "object"})
+
+        result = resolve_all_ops(plugin, ["op1", "op1", "op2"])
+
+        assert list(result.keys()) == ["op1", "op2"]
+
+    def test_populates_title_and_description(self):
+        schema = {"type": "object", "title": "Search", "description": "Full-text search"}
+        plugin = _make_plugin(per_op_schema=schema)
+
+        result = resolve_all_ops(plugin, ["search"])
+
+        assert result["search"].title == "Search"
+        assert result["search"].description == "Full-text search"
+
+    def test_none_schema_when_unresolvable(self):
+        plugin = _make_plugin(per_op_schema=None, legacy_schema=None)
+
+        result = resolve_all_ops(plugin, ["unknown"])
+
+        assert result["unknown"].schema is None
+        assert result["unknown"].title is None
+        assert result["unknown"].description is None

--- a/backend/src/tests/unit/services/providers/adapters/shared.py
+++ b/backend/src/tests/unit/services/providers/adapters/shared.py
@@ -2085,13 +2085,7 @@ TOOLS = [
             "required": [],
             "additionalProperties": True,
         },
-        enum_labels={
-            "list": "List emails",
-            "mark_read": "Mark read",
-            "archive": "Archive",
-            "digest": "Digest summary",
-            "ingest": "Ingest to KB",
-        },
+        title="List emails",
     ),
     CallableTool(
         name="calendar_events",
@@ -2138,6 +2132,6 @@ TOOLS = [
             "required": [],
             "additionalProperties": True,
         },
-        enum_labels=None,
+        title=None,
     ),
 ]

--- a/backend/src/tests/unit/services/test_plugin_execution.py
+++ b/backend/src/tests/unit/services/test_plugin_execution.py
@@ -9,8 +9,7 @@ from shu.services.plugin_execution import _coerce_params
 
 class TestParamCoercion:
     def test_coerce_params(self):
-        mock_plugin = MagicMock()
-        mock_plugin.get_schema.return_value = {
+        schema = {
             "properties": {
                 "limit": {"type": "integer"},
                 "threshold": {"type": "number"},
@@ -18,6 +17,9 @@ class TestParamCoercion:
                 "name": {"type": "string"},
             }
         }
+        mock_plugin = MagicMock()
+        mock_plugin.name = "test-plugin"
+        mock_plugin.get_schema_for_op.return_value = schema
 
         params = {
             "limit": "48",
@@ -27,7 +29,7 @@ class TestParamCoercion:
             "other": "ignore",
         }
 
-        result = _coerce_params(mock_plugin, params)
+        result = _coerce_params(mock_plugin, params, "some_op")
 
         assert result["limit"] == 48
         assert result["threshold"] == 0.5
@@ -37,14 +39,17 @@ class TestParamCoercion:
 
     def test_coerce_params_no_schema(self):
         mock_plugin = MagicMock()
+        mock_plugin.name = "test-plugin"
+        mock_plugin.get_schema_for_op.return_value = None
         mock_plugin.get_schema.return_value = None
         params = {"limit": "48"}
-        result = _coerce_params(mock_plugin, params)
+        result = _coerce_params(mock_plugin, params, "some_op")
         assert result == params
 
     def test_coerce_params_invalid_types(self):
         mock_plugin = MagicMock()
-        mock_plugin.get_schema.return_value = {"properties": {"limit": {"type": "integer"}}}
+        mock_plugin.name = "test-plugin"
+        mock_plugin.get_schema_for_op.return_value = {"properties": {"limit": {"type": "integer"}}}
         params = {"limit": "abc"}
-        result = _coerce_params(mock_plugin, params)
+        result = _coerce_params(mock_plugin, params, "some_op")
         assert result["limit"] == "abc"  # Should remain string if not coercible

--- a/backend/src/tests/unit/services/test_plugin_execution_pbac.py
+++ b/backend/src/tests/unit/services/test_plugin_execution_pbac.py
@@ -134,6 +134,7 @@ class TestExecutorPbac:
         executor = Executor(settings=settings)
         plugin = MagicMock()
         plugin.name = "gmail"
+        plugin.get_schema_for_op.return_value = None
         plugin.get_schema.return_value = None
         plugin.get_output_schema.return_value = None
         mock_result = MagicMock()

--- a/docs/contracts/PLUGIN_CONTRACT.md
+++ b/docs/contracts/PLUGIN_CONTRACT.md
@@ -25,9 +25,39 @@ Do not treat schemas as UI‑only; they are the foundation for plugin interopera
 ## Base Interface (Conceptual)
 - BaseTool
   - execute(parameters: JSON, user_context)
-  - get_schema(): JSON Schema for parameters
+  - get_schema_for_op(op: str): JSON Schema for a specific operation's parameters (preferred)
+  - get_schema(): JSON Schema for parameters (deprecated — use get_schema_for_op)
   - get_output_schema(): JSON Schema for ToolResult.data when status == "success" (recommended)
   - requires_permission(): permission key(s)
+
+### Per-Op Schema Contract
+
+Plugins SHOULD implement `get_schema_for_op(op)` instead of `get_schema()`. Each per-op schema MUST include:
+
+- `title`: Human-readable display name for the operation (shown in UI and LLM tool descriptions)
+- `description`: One-sentence explanation of what the operation does (shown as tooltip/help text)
+- `type`: Always `"object"`
+- `properties`: The operation's parameters (do NOT include an `op` property — the host pins it automatically)
+
+Example:
+```python
+def get_schema_for_op(self, op: str) -> dict | None:
+    schemas = {
+        "fetch_activity": {
+            "title": "Fetch GitHub Activity",
+            "description": "Retrieve commits, PRs, and reviews for a repository.",
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string", "description": "Repository in owner/repo format"},
+                "date": {"type": "string", "description": "Start date (YYYY-MM-DD)"},
+            },
+            "required": ["repo"],
+        },
+    }
+    return schemas.get(op)
+```
+
+Plugins that only implement `get_schema()` still work via the fallback path, but the host logs a deprecation warning. The combined schema cannot provide accurate per-op parameter sets and will be removed in a future version.
 
 ## Result Contract
 - ToolResult

--- a/frontend/src/components/ExperienceStepBuilder.js
+++ b/frontend/src/components/ExperienceStepBuilder.js
@@ -146,13 +146,13 @@ const PluginStepConfig = ({
       </FormControl>
     )}
 
-    {step.plugin_op && selectedPlugin?.input_schema && (
+    {step.plugin_op && selectedPlugin?.ops?.[step.plugin_op]?.input_schema && (
       <Box sx={{ mt: 1 }}>
         <Typography variant="subtitle2" color="text.secondary" gutterBottom>
           Parameters (only set values you want to override)
         </Typography>
         <SchemaForm
-          schema={selectedPlugin.input_schema}
+          schema={selectedPlugin.ops[step.plugin_op].input_schema}
           values={step.params_template || {}}
           onChangeField={(key, type, value) => {
             const newParams = { ...(step.params_template || {}) };
@@ -165,7 +165,7 @@ const PluginStepConfig = ({
               params_template: Object.keys(newParams).length > 0 ? newParams : null,
             });
           }}
-          hideKeys={new Set(['op', 'kb_id'])}
+          hideKeys={new Set(['kb_id'])}
         />
       </Box>
     )}
@@ -210,12 +210,10 @@ const StepCard = ({
     if (!selectedPlugin) {
       return [];
     }
-    // Get operations from input_schema.properties.op.enum
-    const enumOps = selectedPlugin?.input_schema?.properties?.op?.enum;
-    if (Array.isArray(enumOps) && enumOps.length > 0) {
-      return enumOps;
+    const opKeys = Object.keys(selectedPlugin?.ops || {});
+    if (opKeys.length > 0) {
+      return opKeys;
     }
-    // Fallback to allowed_feed_ops if no enum
     if (Array.isArray(selectedPlugin?.allowed_feed_ops)) {
       return selectedPlugin.allowed_feed_ops;
     }

--- a/frontend/src/components/FeedDialog.js
+++ b/frontend/src/components/FeedDialog.js
@@ -167,71 +167,49 @@ export default function FeedDialog({
     }
   }, [open, isEdit, pluginName, plugins]);
 
-  // Identity gating derived from op_auth (provider-agnostic)
+  const [selectedOp, setSelectedOp] = useState('');
+
+  const feedOps = useMemo(() => {
+    const allOps = Object.keys(selectedPlugin?.ops || {});
+    const allowed = Array.isArray(selectedPlugin?.allowed_feed_ops) ? selectedPlugin.allowed_feed_ops : [];
+    return allowed.length > 0 ? allOps.filter((op) => allowed.includes(op)) : allOps;
+  }, [selectedPlugin]);
+
   const currentOp = useMemo(
-    () => String(values?.op || selectedPlugin?.default_feed_op || '').toLowerCase(),
-    [values, selectedPlugin]
+    () => String(selectedOp || selectedPlugin?.default_feed_op || '').toLowerCase(),
+    [selectedOp, selectedPlugin]
   );
 
-  // Schema + defaults merge
+  const opSchema = useMemo(() => selectedPlugin?.ops?.[selectedOp]?.input_schema || null, [selectedPlugin, selectedOp]);
+
   useEffect(() => {
     if (!selectedPlugin) {
       return;
     }
-    if (selectedPlugin.input_schema) {
-      const defaults = buildDefaultValues(selectedPlugin.input_schema) || {};
-      let merged = isEdit ? { ...defaults, ...(schedule?.params || {}) } : defaults;
-      const allowedFeedOps = Array.isArray(selectedPlugin?.allowed_feed_ops) ? selectedPlugin.allowed_feed_ops : [];
-      try {
-        const defaultFeedOp = selectedPlugin?.default_feed_op || null;
-        if (allowedFeedOps.length > 0 && !merged.op && defaultFeedOp) {
-          merged = { ...merged, op: defaultFeedOp };
-        }
-      } catch (_) {
-        // Ignore error
-      }
-      // Filter op enum to only show feed-eligible ops
-      const rawSchema = selectedPlugin.input_schema;
-      if (allowedFeedOps.length > 0 && rawSchema?.properties?.op?.enum) {
-        const filtered = rawSchema.properties.op.enum.filter((v) => allowedFeedOps.includes(v));
-        if (filtered.length === 0) {
-          setSchema(rawSchema);
-          setValues(merged);
-          return;
-        }
-        const filteredLabels = rawSchema.properties.op['x-ui']?.enum_labels
-          ? Object.fromEntries(
-              Object.entries(rawSchema.properties.op['x-ui'].enum_labels).filter(([k]) => allowedFeedOps.includes(k))
-            )
-          : undefined;
-        const filteredHelp = rawSchema.properties.op['x-ui']?.enum_help
-          ? Object.fromEntries(
-              Object.entries(rawSchema.properties.op['x-ui'].enum_help).filter(([k]) => allowedFeedOps.includes(k))
-            )
-          : undefined;
-        setSchema({
-          ...rawSchema,
-          properties: {
-            ...rawSchema.properties,
-            op: {
-              ...rawSchema.properties.op,
-              enum: filtered,
-              'x-ui': { ...rawSchema.properties.op['x-ui'], enum_labels: filteredLabels, enum_help: filteredHelp },
-            },
-          },
-        });
-      } else {
-        setSchema(rawSchema);
-      }
-      setValues(merged);
-    } else {
-      setSchema(null);
-      setValues(isEdit ? schedule?.params || {} : {});
-    }
+    const defaultFeedOp = selectedPlugin?.default_feed_op || null;
+    const editOp = isEdit ? schedule?.params?.op : null;
+    const initialOp = editOp || defaultFeedOp || (feedOps.length > 0 ? feedOps[0] : '');
+    setSelectedOp(initialOp);
+
+    const initialSchema = selectedPlugin?.ops?.[initialOp]?.input_schema || null;
+    const defaults = buildDefaultValues(initialSchema) || {};
+    const merged = isEdit ? { ...defaults, ...(schedule?.params || {}) } : defaults;
+    setSchema(initialSchema);
+    setValues(merged);
     setIdentitiesOk(
       !(Array.isArray(selectedPlugin?.required_identities) && selectedPlugin.required_identities.length > 0)
     );
-  }, [selectedPlugin, isEdit, schedule]);
+  }, [selectedPlugin, isEdit, schedule, feedOps]);
+
+  useEffect(() => {
+    if (!selectedPlugin) {
+      return;
+    }
+    setSchema(opSchema);
+    const defaults = buildDefaultValues(opSchema) || {};
+    const merged = isEdit ? { ...defaults, ...(schedule?.params || {}) } : defaults;
+    setValues(merged);
+  }, [opSchema]);
 
   // OCR section visibility
   const defaultFeedOp = selectedPlugin?.default_feed_op || null;
@@ -292,6 +270,7 @@ export default function FeedDialog({
 
     const baseParams = {
       ...(values || {}),
+      op: selectedOp,
       ...(isEdit ? (kbId ? { kb_id: kbId } : {}) : { kb_id: effectiveKb }),
     };
     // Merge host overlays: OCR + auth overlay
@@ -408,6 +387,26 @@ export default function FeedDialog({
                         {pluginPrimaryLabel(t)}
                       </MenuItem>
                     ))}
+                </Select>
+              </FormControl>
+            </Grid>
+          )}
+
+          {feedOps.length > 1 && (
+            <Grid item xs={12} md={6}>
+              <FormControl fullWidth>
+                <InputLabel id="feed-op-label">Operation</InputLabel>
+                <Select
+                  labelId="feed-op-label"
+                  label="Operation"
+                  value={selectedOp}
+                  onChange={(e) => setSelectedOp(e.target.value)}
+                >
+                  {feedOps.map((op) => (
+                    <MenuItem key={op} value={op}>
+                      {selectedPlugin?.ops?.[op]?.title || op}
+                    </MenuItem>
+                  ))}
                 </Select>
               </FormControl>
             </Grid>

--- a/frontend/src/components/FeedDialog.js
+++ b/frontend/src/components/FeedDialog.js
@@ -172,7 +172,7 @@ export default function FeedDialog({
   const feedOps = useMemo(() => {
     const allOps = Object.keys(selectedPlugin?.ops || {});
     const allowed = Array.isArray(selectedPlugin?.allowed_feed_ops) ? selectedPlugin.allowed_feed_ops : [];
-    return allowed.length > 0 ? allOps.filter((op) => allowed.includes(op)) : allOps;
+    return allowed.length > 0 ? allOps.filter((op) => allowed.includes(op)) : [];
   }, [selectedPlugin]);
 
   const currentOp = useMemo(
@@ -188,7 +188,8 @@ export default function FeedDialog({
     }
     const defaultFeedOp = selectedPlugin?.default_feed_op || null;
     const editOp = isEdit ? schedule?.params?.op : null;
-    const initialOp = editOp || defaultFeedOp || (feedOps.length > 0 ? feedOps[0] : '');
+    const validDefault = defaultFeedOp && feedOps.includes(defaultFeedOp) ? defaultFeedOp : null;
+    const initialOp = editOp || validDefault || (feedOps.length > 0 ? feedOps[0] : '');
     setSelectedOp(initialOp);
 
     const initialSchema = selectedPlugin?.ops?.[initialOp]?.input_schema || null;
@@ -207,13 +208,13 @@ export default function FeedDialog({
     }
     setSchema(opSchema);
     const defaults = buildDefaultValues(opSchema) || {};
-    const merged = isEdit ? { ...defaults, ...(schedule?.params || {}) } : defaults;
+    const isOriginalOp = isEdit && schedule?.params?.op === selectedOp;
+    const merged = isOriginalOp ? { ...defaults, ...(schedule?.params || {}) } : defaults;
     setValues(merged);
-  }, [opSchema]);
+  }, [opSchema, selectedPlugin, isEdit, schedule, selectedOp]);
 
   // OCR section visibility
-  const defaultFeedOp = selectedPlugin?.default_feed_op || null;
-  const opForOcr = useMemo(() => String(values?.op || defaultFeedOp || '').toLowerCase(), [values, defaultFeedOp]);
+  const opForOcr = useMemo(() => String(selectedOp || '').toLowerCase(), [selectedOp]);
   const hasOcrCap = useMemo(
     () => Array.isArray(selectedPlugin?.capabilities) && selectedPlugin.capabilities.includes('ocr'),
     [selectedPlugin]

--- a/frontend/src/components/PluginExecutionModal.js
+++ b/frontend/src/components/PluginExecutionModal.js
@@ -27,8 +27,11 @@ import { pluginDisplayName } from '../utils/plugins';
 
 export default function PluginExecutionModal({ open, onClose, plugin, onStart = null, onResult = null }) {
   const pluginDef = plugin;
-  const [schema, setSchema] = useState(pluginDef?.input_schema || null);
-  const [values, setValues] = useState(() => buildDefaultValues(pluginDef?.input_schema));
+  const availableOps = useMemo(() => Object.keys(pluginDef?.ops || {}), [pluginDef]);
+  const [selectedOp, setSelectedOp] = useState('');
+  const opSchema = useMemo(() => pluginDef?.ops?.[selectedOp]?.input_schema || null, [pluginDef, selectedOp]);
+  const [schema, setSchema] = useState(null);
+  const [values, setValues] = useState({});
   const [agentKey, setAgentKey] = useState('');
   const [rawMode, setRawMode] = useState(false);
   const [rawJson, setRawJson] = useState('');
@@ -39,18 +42,17 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
   const [identitiesOk, setIdentitiesOk] = useState(true);
   const [authOverlay, setAuthOverlay] = useState({});
 
-  // Current operation used to derive auth spec (op_auth)
   const currentOp = useMemo(() => {
     if (rawMode) {
       try {
         const obj = JSON.parse(rawJson || '{}');
-        return String(obj?.op || '').toLowerCase();
+        return String(obj?.op || selectedOp || '').toLowerCase();
       } catch (_) {
         // Ignore error
       }
     }
-    return String(values?.op || '').toLowerCase();
-  }, [rawMode, rawJson, values]);
+    return String(selectedOp || '').toLowerCase();
+  }, [rawMode, rawJson, selectedOp]);
 
   const hasKbId = useMemo(() => Boolean(schema?.properties?.kb_id), [schema]);
   const kbsQ = useQuery(['kbs', 'list'], () => knowledgeBaseAPI.list().then(extractItemsFromResponse), {
@@ -59,17 +61,25 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
   });
 
   useEffect(() => {
-    setSchema(pluginDef?.input_schema || null);
-    const defaults = buildDefaultValues(pluginDef?.input_schema);
+    const firstOp = availableOps.length > 0 ? availableOps[0] : '';
+    setSelectedOp(firstOp);
+    const firstSchema = pluginDef?.ops?.[firstOp]?.input_schema || null;
+    setSchema(firstSchema);
+    const defaults = buildDefaultValues(firstSchema);
     setValues(defaults);
     setRawJson(JSON.stringify(defaults, null, 2));
     setResult(null);
     setErrorEnvelope(null);
     setShowErrorDetails(false);
-    // Default to allowed until IdentityGate reports otherwise (based on selected mode)
     setIdentitiesOk(true);
-    // Auth UI state managed inside ProviderAuthPanel
-  }, [pluginDef]);
+  }, [pluginDef, availableOps]);
+
+  useEffect(() => {
+    setSchema(opSchema);
+    const defaults = buildDefaultValues(opSchema);
+    setValues(defaults);
+    setRawJson(JSON.stringify(defaults, null, 2));
+  }, [opSchema]);
 
   const execMut = useMutation(
     ({ name, params, agentKey }) => pluginsAPI.execute(name, params, agentKey).then(extractDataFromResponse),
@@ -162,7 +172,7 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
   }, [schema, values, rawMode]);
 
   const handleRun = () => {
-    let params = values;
+    let params = rawMode ? null : { ...values, op: selectedOp };
     if (rawMode) {
       try {
         params = JSON.parse(rawJson || '{}');
@@ -171,7 +181,6 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
         return;
       }
     }
-    // Merge auth overlay under reserved __host key
     if (authOverlay && Object.keys(authOverlay).length > 0) {
       params = {
         ...params,
@@ -196,7 +205,7 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
   };
 
   const handlePreview = () => {
-    let params = values;
+    let params = rawMode ? null : { ...values, op: selectedOp };
     if (rawMode) {
       try {
         params = JSON.parse(rawJson || '{}');
@@ -205,7 +214,6 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
         return;
       }
     }
-    // Merge auth overlay
     if (authOverlay && Object.keys(authOverlay).length > 0) {
       params = {
         ...params,
@@ -231,7 +239,7 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
   };
 
   const handleApproveRun = () => {
-    let params = values;
+    let params = rawMode ? null : { ...values, op: selectedOp };
     if (rawMode) {
       try {
         params = JSON.parse(rawJson || '{}');
@@ -240,7 +248,6 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
         return;
       }
     }
-    // Merge auth overlay
     if (authOverlay && Object.keys(authOverlay).length > 0) {
       params = {
         ...params,
@@ -269,14 +276,32 @@ export default function PluginExecutionModal({ open, onClose, plugin, onStart = 
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>Execute Plugin: {pluginDisplayName(pluginDef) || pluginDef?.name}</DialogTitle>
       <DialogContent dividers>
-        {pluginDef?.input_schema ? (
+        {availableOps.length > 0 ? (
           <Typography variant="body2" color="text.secondary" mb={2}>
             Schema-based form. Toggle Raw JSON if needed.
           </Typography>
         ) : (
           <Alert severity="info" sx={{ mb: 2 }}>
-            This plugin does not declare an input schema. Use Raw JSON mode to provide params.
+            This plugin does not declare any operations. Use Raw JSON mode to provide params.
           </Alert>
+        )}
+
+        {availableOps.length > 1 && (
+          <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+            <InputLabel id="exec-op-label">Operation</InputLabel>
+            <Select
+              labelId="exec-op-label"
+              label="Operation"
+              value={selectedOp}
+              onChange={(e) => setSelectedOp(e.target.value)}
+            >
+              {availableOps.map((op) => (
+                <MenuItem key={op} value={op}>
+                  {pluginDef?.ops?.[op]?.title || op}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         )}
 
         <Box display="flex" alignItems="center" justifyContent="space-between" mb={2}>

--- a/frontend/src/components/PluginsAdmin.js
+++ b/frontend/src/components/PluginsAdmin.js
@@ -110,12 +110,11 @@ const PluginCard = ({
     };
   };
 
-  const enumOps = Array.isArray(plugin?.input_schema?.properties?.op?.enum)
-    ? plugin.input_schema.properties.op.enum
-    : [];
+  const opsMap = plugin.ops || {};
+  const opKeys = Object.keys(opsMap);
   const allowed = Array.isArray(plugin.allowed_feed_ops) ? plugin.allowed_feed_ops : [];
   const defaultOp = plugin.default_feed_op || null;
-  const ops = enumOps && enumOps.length ? enumOps : allowed;
+  const ops = opKeys.length > 0 ? opKeys : allowed;
 
   return (
     <Card
@@ -251,12 +250,8 @@ const PluginCard = ({
                   {ops.slice(0, 3).map((op) => {
                     const feedSafe = allowed.includes(op);
                     const isDefault = defaultOp === op;
-                    const opDef = plugin?.input_schema?.properties?.op || {};
-                    const xui = opDef['x-ui'] || opDef['x_ui'] || {};
-                    const enumLabels = xui.enum_labels || {};
-                    const enumHelp = xui.enum_help || {};
-                    const label = enumLabels[String(op)] || String(op);
-                    const help = enumHelp[String(op)];
+                    const label = opsMap[op]?.title || String(op);
+                    const help = opsMap[op]?.description;
                     const chip = (
                       <Chip
                         key={op}
@@ -283,12 +278,8 @@ const PluginCard = ({
                             Additional Operations:
                           </Typography>
                           {ops.slice(3).map((op) => {
-                            const opDef = plugin?.input_schema?.properties?.op || {};
-                            const xui = opDef['x-ui'] || opDef['x_ui'] || {};
-                            const enumLabels = xui.enum_labels || {};
-                            const enumHelp = xui.enum_help || {};
-                            const label = enumLabels[String(op)] || String(op);
-                            const help = enumHelp[String(op)] || 'No description available';
+                            const label = opsMap[op]?.title || String(op);
+                            const help = opsMap[op]?.description || 'No description available';
                             return (
                               <Box key={op}>
                                 <Typography variant="body2" sx={{ fontWeight: 500 }}>
@@ -333,7 +324,7 @@ const PluginCard = ({
             <Stack direction="row" spacing={1} alignItems="center" justifyContent="flex-end">
               {/* Schema indicators */}
               <Stack direction="row" spacing={0.5} alignItems="center">
-                {plugin.input_schema && (
+                {plugin.ops && Object.keys(plugin.ops).length > 0 && (
                   <Tooltip title="Has input schema">
                     <Chip
                       size="small"
@@ -402,7 +393,7 @@ const PluginCard = ({
           <Divider sx={{ my: 2 }} />
           <Box>
             <Typography variant="subtitle2" gutterBottom>
-              Input Schema
+              Operations
             </Typography>
             <Box
               sx={{
@@ -414,7 +405,7 @@ const PluginCard = ({
                 mb: 2,
               }}
             >
-              <JSONPretty data={plugin.input_schema || {}} />
+              <JSONPretty data={plugin.ops || {}} />
             </Box>
             <Typography variant="subtitle2" gutterBottom>
               Output Schema

--- a/frontend/src/components/ProviderAuthPanel.js
+++ b/frontend/src/components/ProviderAuthPanel.js
@@ -284,6 +284,10 @@ export default function ProviderAuthPanel({
   const showProbe = effMode === 'domain_delegate' && provider === 'google';
   const showSaProbe = effMode === 'service_account' && provider === 'google';
 
+  if (!provider) {
+    return null;
+  }
+
   return (
     <Box>
       <Typography variant="subtitle1" gutterBottom>

--- a/frontend/src/services/pluginsApi.js
+++ b/frontend/src/services/pluginsApi.js
@@ -9,11 +9,6 @@ export const pluginsAPI = {
       agent_key: agentKey,
     }),
   setEnabled: (name, enabled) => api.patch(`/plugins/admin/${encodeURIComponent(name)}/enable`, { enabled }),
-  setSchema: (name, input_schema = null, output_schema = null) =>
-    api.put(`/plugins/admin/${encodeURIComponent(name)}/schema`, {
-      input_schema,
-      output_schema,
-    }),
   sync: () => api.post('/plugins/admin/sync'),
   upload: (file, force = false) => {
     const form = new FormData();

--- a/plugins/github/plugin.py
+++ b/plugins/github/plugin.py
@@ -99,9 +99,10 @@ async def _resolve_pat(host: Any) -> tuple[str, PluginResult | None]:
 
 _OP_SCHEMAS: dict[str, dict[str, Any]] = {
     "fetch_activity": {
+        "title": "Fetch Activity",
+        "description": "Retrieve commits, PRs, and reviews for a repository.",
         "type": "object",
         "properties": {
-            "op": {"type": "string", "enum": ["fetch_activity"]},
             "repo": {
                 "type": "string",
                 "description": "Repository in owner/repo format",
@@ -117,7 +118,7 @@ _OP_SCHEMAS: dict[str, dict[str, Any]] = {
                 "description": "End date (ISO 8601 YYYY-MM-DD); defaults to today (UTC)",
             },
         },
-        "required": ["op", "repo"],
+        "required": ["repo"],
         "additionalProperties": False,
     },
 }

--- a/plugins/shu_kb_search/plugin.py
+++ b/plugins/shu_kb_search/plugin.py
@@ -256,6 +256,8 @@ class KbSearchPlugin:
 
         if op == "search_chunks":
             return {
+                "title": "Search Chunks",
+                "description": "Search document chunks by field, operator, and value.",
                 "type": "object",
                 "properties": {
                     "field": {
@@ -296,6 +298,8 @@ class KbSearchPlugin:
 
         if op == "search_documents":
             return {
+                "title": "Search Documents",
+                "description": "Search documents by field, operator, and value.",
                 "type": "object",
                 "properties": {
                     "field": {
@@ -345,6 +349,8 @@ class KbSearchPlugin:
 
         if op == "get_document":
             return {
+                "title": "Get Document",
+                "description": "Retrieve a document by its ID.",
                 "type": "object",
                 "properties": {
                     "document_id": {


### PR DESCRIPTION
## DEPENDS ON: https://github.com/Open-Shu/shu/pull/110

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
- [x] New feature (MCP integration, per-op schemas)
- [x] Refactoring (schema resolution moved from DB to live, removed dead endpoints)

## Related Issues
Closes SHU-657, SHU-87

## Changes Made
- Per-op schema system (`get_schema_for_op`) replacing combined `get_schema`
- MCP server connections: client, adapter, service, admin API, frontend management UI
- Experiences scheduler service
- Removed dead admin schema endpoint and `pluginsApi.setSchema`
- Refined MCP health tracking (only update on connectivity errors, not business logic failures)
- Schema validation requires `title` and `description` on per-op schemas

## Testing
- [x] Unit tests added/updated (mcp_service, mcp_adapter, mcp_client, schema, mcp_admin, experiences_scheduler, registry)
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests passing locally

## Code Quality Checklist

### Backend (Python)

- [x] Type hints
- [x] Docstrings added to all public functions/classes
- [x] Unit tests written for new code
- [x] ConfigurationManager used
- [x] Dependency injection
- [x] Timezone-aware datetimes used
- [x] No breaking migration changes
- [x] Files end with trailing newlines
- [x] Logger convention

### Frontend (React/JavaScript)

- [x] Functional components with hooks used
- [x] log.js used instead of console.*
- [x] React Query used for server state
- [x] Envelope utilities used (extractDataFromResponse)
- [x] Material-UI components used
- [ ] Components < 500 LOC
- [x] aria-label on icon-only buttons
- [x] Custom hooks for complex logic

### API

- [x] ShuResponse helper used
- [x] Envelope format followed
- [x] Proper HTTP status codes
- [x] Pydantic schemas defined in schemas/

### Linting

- [ ] Pre-commit hooks pass
- [ ] CI linting checks pass
- [ ] No linting warnings ignored without justification

### Documentation

- [x] Code comments added where needed
- [ ] README updated (if applicable)
- [x] API docs updated (if applicable)
- [ ] Migration guide provided (if breaking change)

### Security

- [x] No hardcoded secrets or credentials
- [x] No sensitive data in logs
- [x] Input validation added
- [x] Authentication/authorization checked

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Deployment Notes
<!-- Any special deployment considerations? -->
- [ ] Database migrations required
- [ ] Environment variables added/changed
- [ ] Dependencies added/updated
- [ ] Configuration changes needed

## Reviewer Notes
<!-- Anything specific you want reviewers to focus on? -->

## Post-Merge Tasks
<!-- Tasks to complete after merging -->
- [ ] Update documentation
- [ ] Notify stakeholders
- [ ] Monitor logs/metrics
- [ ] Update related issues

---

**By submitting this PR, I confirm that:**

- [ ] I have run `make lint-fix` and all linting checks pass
- [ ] I have tested my changes locally
- [ ] I have followed the coding standards in `docs/policies/DEVELOPMENT_STANDARDS.md`
- [ ] I have read and followed the linting policy in `docs/policies/LINTING_POLICY.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-operation schemas with titles/descriptions for each plugin operation
  * MCP connectivity health tracking and automatic health updates

* **Removed Features**
  * Admin API endpoint to set plugin input/output schemas removed
  * Client-side exported setSchema function removed

* **Bug Fixes**
  * Fail-fast on invalid/empty feed-op declarations
  * Better handling when plugin ops cannot be resolved

* **Improvements**
  * UI updated to show per-op metadata and operation selector
  * Bounded pagination for feeds and clearer pagination warnings
* **Tests**
  * Added unit tests for per-op schema resolution and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->