### PR TITLE
Fix MCP basic auth header issue

### DIFF
--- a/backend/src/shu/plugins/mcp_client.py
+++ b/backend/src/shu/plugins/mcp_client.py
@@ -7,6 +7,7 @@ JSON-RPC based MCP protocol for tool discovery and invocation.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import urllib.parse
 from dataclasses import dataclass, field
@@ -73,6 +74,39 @@ MCP_PROTOCOL_VERSION = "2025-03-26"
 MCP_SUPPORTED_VERSIONS = {"2024-11-05", "2025-03-26"}
 
 
+def _extract_auth(headers: dict[str, str]) -> httpx.Auth | None:
+    """Extract an Authorization header into an httpx.Auth instance.
+
+    httpx.Auth re-attaches credentials on redirects, unlike raw headers
+    which get stripped on cross-origin redirects.
+    """
+    auth_value = next((v for k, v in headers.items() if k.lower() == "authorization"), None)
+    if not auth_value:
+        return None
+    lower = auth_value.lower()
+
+    # For basic headers we need to use "httpx.BasicAuth" so the headers are preserved across redirects
+    if lower.startswith("basic "):
+        decoded = base64.b64decode(auth_value[6:]).decode("utf-8")
+        username, _, password = decoded.partition(":")
+        return httpx.BasicAuth(username, password)
+
+    if lower.startswith("bearer "):
+        token = auth_value[7:]
+        return _BearerAuth(token)
+
+    return None
+
+
+class _BearerAuth(httpx.Auth):
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def auth_flow(self, request: httpx.Request):
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        yield request
+
+
 class McpClient:
     """Async MCP client using Streamable HTTP transport.
 
@@ -91,7 +125,9 @@ class McpClient:
     ) -> None:
         settings = get_settings_instance()
         self._url = url
-        self._headers = headers or {}
+        raw_headers = headers or {}
+        self._auth = _extract_auth(raw_headers)
+        self._headers = {k: v for k, v in raw_headers.items() if k.lower() != "authorization"}
 
         allowlist = getattr(settings, "http_egress_allowlist", None)
         if allowlist:
@@ -128,6 +164,7 @@ class McpClient:
                 "Accept": "application/json, text/event-stream",
                 **self._headers,
             },
+            auth=self._auth,
             follow_redirects=False,
         )
 

--- a/backend/src/shu/plugins/mcp_client.py
+++ b/backend/src/shu/plugins/mcp_client.py
@@ -87,7 +87,11 @@ def _extract_auth(headers: dict[str, str]) -> httpx.Auth | None:
 
     # For basic headers we need to use "httpx.BasicAuth" so the headers are preserved across redirects
     if lower.startswith("basic "):
-        decoded = base64.b64decode(auth_value[6:]).decode("utf-8")
+        try:
+            decoded = base64.b64decode(auth_value[6:]).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            logger.warning("mcp.auth.invalid_basic_credentials: malformed base64 or encoding in plugin secret Authorization header")
+            return None
         username, _, password = decoded.partition(":")
         return httpx.BasicAuth(username, password)
 
@@ -95,6 +99,8 @@ def _extract_auth(headers: dict[str, str]) -> httpx.Auth | None:
         token = auth_value[7:]
         return _BearerAuth(token)
 
+    scheme = auth_value.split()[0] if auth_value else "empty"
+    logger.warning("mcp.auth.unsupported_scheme scheme=%s (from plugin secret Authorization header)", scheme)
     return None
 
 

--- a/backend/src/shu/plugins/mcp_client.py
+++ b/backend/src/shu/plugins/mcp_client.py
@@ -90,7 +90,9 @@ def _extract_auth(headers: dict[str, str]) -> httpx.Auth | None:
         try:
             decoded = base64.b64decode(auth_value[6:]).decode("utf-8")
         except (ValueError, UnicodeDecodeError):
-            logger.warning("mcp.auth.invalid_basic_credentials: malformed base64 or encoding in plugin secret Authorization header")
+            logger.warning(
+                "mcp.auth.invalid_basic_credentials: malformed base64 or encoding in plugin secret Authorization header"
+            )
             return None
         username, _, password = decoded.partition(":")
         return httpx.BasicAuth(username, password)

--- a/backend/src/tests/unit/plugins/test_mcp_client.py
+++ b/backend/src/tests/unit/plugins/test_mcp_client.py
@@ -22,6 +22,8 @@ from shu.plugins.mcp_client import (
     McpTimeoutError,
     McpToolInfo,
     McpToolResult,
+    _BearerAuth,
+    _extract_auth,
 )
 
 SERVER_URL = "http://mcp.test/rpc"
@@ -426,3 +428,97 @@ async def test_non_dict_json_response(client: McpClient) -> None:
 
     with pytest.raises(McpProtocolError, match="not a JSON object"):
         await client._send_jsonrpc("test/method")
+
+
+class TestExtractAuth:
+    """Tests for _extract_auth and _BearerAuth."""
+
+    def test_basic_auth_extracted(self) -> None:
+        """Basic auth header is decoded and returned as httpx.BasicAuth."""
+        import base64
+
+        encoded = base64.b64encode(b"user@example.com:api-token").decode()
+        headers = {"Authorization": f"Basic {encoded}"}
+
+        auth = _extract_auth(headers)
+
+        assert isinstance(auth, httpx.BasicAuth)
+        assert auth._auth_header == httpx.BasicAuth("user@example.com", "api-token")._auth_header
+
+    def test_bearer_auth_extracted(self) -> None:
+        """Bearer auth header is returned as _BearerAuth."""
+        headers = {"Authorization": "Bearer ghp_abc123"}
+
+        auth = _extract_auth(headers)
+
+        assert isinstance(auth, _BearerAuth)
+        assert auth._token == "ghp_abc123"
+
+    def test_no_authorization_header(self) -> None:
+        """Returns None when no Authorization header is present."""
+        assert _extract_auth({}) is None
+        assert _extract_auth({"Content-Type": "application/json"}) is None
+
+    def test_unknown_scheme_returns_none(self) -> None:
+        """Returns None for unrecognized auth schemes."""
+        assert _extract_auth({"Authorization": "Digest abc123"}) is None
+
+    def test_case_insensitive_header_key(self) -> None:
+        """Authorization header key matching is case-insensitive."""
+        import base64
+
+        encoded = base64.b64encode(b"user:pass").decode()
+        auth = _extract_auth({"authorization": f"Basic {encoded}"})
+        assert isinstance(auth, httpx.BasicAuth)
+
+    def test_case_insensitive_scheme(self) -> None:
+        """Auth scheme matching is case-insensitive."""
+        auth = _extract_auth({"Authorization": "BEARER my-token"})
+        assert isinstance(auth, _BearerAuth)
+        assert auth._token == "my-token"
+
+    def test_basic_auth_with_colon_in_password(self) -> None:
+        """Basic auth correctly handles passwords containing colons."""
+        import base64
+
+        encoded = base64.b64encode(b"user:pass:with:colons").decode()
+        auth = _extract_auth({"Authorization": f"Basic {encoded}"})
+
+        assert isinstance(auth, httpx.BasicAuth)
+        assert auth._auth_header == httpx.BasicAuth("user", "pass:with:colons")._auth_header
+
+    def test_bearer_auth_flow_sets_header(self) -> None:
+        """_BearerAuth.auth_flow sets the Authorization header on the request."""
+        auth = _BearerAuth("my-token")
+        request = httpx.Request("GET", "http://example.com")
+
+        flow = auth.auth_flow(request)
+        yielded = next(flow)
+
+        assert yielded.headers["Authorization"] == "Bearer my-token"
+
+    def test_client_with_basic_auth_uses_httpx_auth(self) -> None:
+        """McpClient constructed with Basic auth uses httpx.Auth, not raw header."""
+        import base64
+
+        encoded = base64.b64encode(b"user:pass").decode()
+        with patch("shu.plugins.mcp_client.get_settings_instance", return_value=_mock_settings()):
+            c = McpClient(url=SERVER_URL, headers={"Authorization": f"Basic {encoded}"})
+
+        assert isinstance(c._auth, httpx.BasicAuth)
+        assert "authorization" not in {k.lower() for k in c._client.headers}
+
+    def test_client_with_bearer_auth_uses_httpx_auth(self) -> None:
+        """McpClient constructed with Bearer auth uses httpx.Auth, not raw header."""
+        with patch("shu.plugins.mcp_client.get_settings_instance", return_value=_mock_settings()):
+            c = McpClient(url=SERVER_URL, headers={"Authorization": "Bearer ghp_abc"})
+
+        assert isinstance(c._auth, _BearerAuth)
+        assert "authorization" not in {k.lower() for k in c._client.headers}
+
+    def test_client_without_auth_has_none(self) -> None:
+        """McpClient constructed without auth headers has _auth=None."""
+        with patch("shu.plugins.mcp_client.get_settings_instance", return_value=_mock_settings()):
+            c = McpClient(url=SERVER_URL)
+
+        assert c._auth is None


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Basic auth needs to be done differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved redirect behavior by ensuring authentication credentials are properly re-attached across HTTP requests.
  * Enhanced support for both Basic and Bearer authentication schemes with case-insensitive header matching.

* **Tests**
  * Added comprehensive test coverage for authentication header parsing and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->