### PR TITLE
[SHU-680] Accomodate external embedding models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,20 @@ SHU_OCR_PAGE_TIMEOUT=180
 
 
 # =============================================================================
+# SERVICE BACKEND CONFIGURATION
+# =============================================================================
+
+# Controls whether local OCR/embedding models are loaded into memory.
+# Set to false for hosted deployments that use external API providers
+# (e.g., OpenRouter), avoiding memory overhead per model.
+# When false, an external model must be registered in llm_models with the
+# appropriate model_type ("ocr" or "embedding"), otherwise startup fails.
+# Default: true (backward-compatible — local models loaded as before)
+SHU_LOCAL_OCR_ENABLED=true
+SHU_LOCAL_EMBEDDING_ENABLED=true
+
+
+# =============================================================================
 # TEXT PROCESSING CONFIGURATION
 # =============================================================================
 

--- a/backend/src/shu/api/llm.py
+++ b/backend/src/shu/api/llm.py
@@ -8,7 +8,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,7 +18,7 @@ from ..auth.rbac import get_current_user, require_admin
 from ..core.exceptions import LLMProviderError
 from ..core.response import ShuResponse
 from ..llm.service import LLMService
-from ..models.llm_provider import LLMProvider
+from ..models.llm_provider import LLMProvider, ModelType
 from ..schemas.envelope import SuccessResponse
 from ..schemas.llm_provider_type import (
     ProviderTypeDefinitionListItem,
@@ -122,7 +122,7 @@ class LLMModelCreate(BaseModel):
 
     model_name: str = Field(..., description="Model name")
     display_name: str | None = Field(None, description="Display name")
-    model_type: str = Field("chat", description="Model type (chat, completion, embedding)")
+    model_type: str = Field("chat", description="Model type (chat, embedding, ocr)")
     supports_streaming: bool = Field(True, description="Supports streaming")
     supports_functions: bool = Field(False, description="Supports function calling")
     supports_vision: bool = Field(False, description="Supports vision/image inputs")
@@ -312,14 +312,30 @@ async def test_provider(
 @router.get("/models", response_model=SuccessResponse[list[LLMModelResponse]])
 async def list_models(
     provider_id: str | None = None,
+    model_type: str | None = Query(
+        None, description="Filter by model type (chat, embedding, ocr). Omit for chat-only; use 'all' for all types."
+    ),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """List available LLM models."""
     try:
         llm_service = LLMService(db)
-        models = await llm_service.get_available_models(provider_id)
+        if model_type is None:
+            model_types = [ModelType.CHAT]
+        elif model_type == "all":
+            model_types = None
+        elif model_type in ModelType.__members__.values():
+            model_types = [model_type]
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid model_type '{model_type}'. Valid values: {', '.join(ModelType)}, all",
+            )
+        models = await llm_service.get_available_models(provider_id, model_types=model_types)
         return ShuResponse.success(models)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error listing LLM models: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list LLM models")

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -512,6 +512,13 @@ class Settings(BaseSettings):
     )
     # Note: No page limits - OCR processes all pages in document
 
+    # Service backend configuration
+    # Controls whether local OCR/embedding models are loaded into memory.
+    # Set to false for hosted deployments that use external API providers,
+    # avoiding the memory overhead of EasyOCR and sentence-transformers.
+    local_ocr_enabled: bool = Field(True, alias="SHU_LOCAL_OCR_ENABLED")
+    local_embedding_enabled: bool = Field(True, alias="SHU_LOCAL_EMBEDDING_ENABLED")
+
     @field_validator("database_url")
     @classmethod
     def validate_database_url(cls, v: str) -> str:

--- a/backend/src/shu/core/embedding_protocol.py
+++ b/backend/src/shu/core/embedding_protocol.py
@@ -1,0 +1,69 @@
+"""EmbeddingService protocol definition.
+
+Separated from embedding_service.py to allow importing the protocol
+without loading sentence-transformers (~2GB). This enables external
+embedding backends to implement the protocol without triggering
+local model initialization.
+"""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class EmbeddingService(Protocol):
+    """Protocol for embedding generation services.
+
+    Implementations must provide async methods for generating embeddings
+    from text. Supports both batch and single-query paths.
+    """
+
+    @property
+    def dimension(self) -> int:
+        """Dimensionality of the embedding vectors produced by this service."""
+        ...
+
+    @property
+    def model_name(self) -> str:
+        """Name of the underlying embedding model."""
+        ...
+
+    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for a batch of texts.
+
+        Args:
+            texts: List of text strings to embed. Empty list returns [].
+
+        Returns:
+            List of embedding vectors, one per input text.
+
+        """
+        ...
+
+    async def embed_query(self, text: str) -> list[float]:
+        """Generate an embedding for a single query text.
+
+        Args:
+            text: The query text to embed.
+
+        Returns:
+            A single embedding vector.
+
+        """
+        ...
+
+    async def embed_queries(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for a batch of query texts.
+
+        Like embed_texts(), but applies the query prompt for asymmetric
+        models (e.g., Snowflake arctic-embed). Use this when embedding
+        synthesized queries or any text that will be matched against
+        user search queries.
+
+        Args:
+            texts: List of query strings to embed. Empty list returns [].
+
+        Returns:
+            List of embedding vectors, one per input text.
+
+        """
+        ...

--- a/backend/src/shu/core/embedding_service.py
+++ b/backend/src/shu/core/embedding_service.py
@@ -1,8 +1,8 @@
-"""EmbeddingService protocol and LocalEmbeddingService implementation.
+"""LocalEmbeddingService implementation and DI wiring.
 
-Abstracts embedding generation behind a protocol interface following the
-CacheBackend/QueueBackend pattern. LocalEmbeddingService wraps
-sentence-transformers for local embedding generation.
+Wraps sentence-transformers for local embedding generation. The
+EmbeddingService protocol lives in embedding_protocol.py to avoid
+loading sentence-transformers (~2GB) when only the protocol is needed.
 
 DI wiring:
     - get_embedding_service()           — async singleton factory (workers, services)
@@ -15,79 +15,18 @@ import asyncio
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Protocol, runtime_checkable
 
-import sentence_transformers
-
+from ..models.llm_provider import ModelType
 from .config import get_settings_instance
+from .embedding_protocol import EmbeddingService
+from .exceptions import LLMConfigurationError
+from .external_model_resolver import resolve_external_model
 from .logging import get_logger
 
 logger = get_logger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Protocol
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class EmbeddingService(Protocol):
-    """Protocol for embedding generation services.
-
-    Implementations must provide async methods for generating embeddings
-    from text. Supports both batch and single-query paths.
-    """
-
-    @property
-    def dimension(self) -> int:
-        """Dimensionality of the embedding vectors produced by this service."""
-        ...
-
-    @property
-    def model_name(self) -> str:
-        """Name of the underlying embedding model."""
-        ...
-
-    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings for a batch of texts.
-
-        Args:
-            texts: List of text strings to embed. Empty list returns [].
-
-        Returns:
-            List of embedding vectors, one per input text.
-
-        """
-        ...
-
-    async def embed_query(self, text: str) -> list[float]:
-        """Generate an embedding for a single query text.
-
-        Args:
-            text: The query text to embed.
-
-        Returns:
-            A single embedding vector.
-
-        """
-        ...
-
-    async def embed_queries(self, texts: list[str]) -> list[list[float]]:
-        """Generate embeddings for a batch of query texts.
-
-        Like embed_texts(), but applies the query prompt for asymmetric
-        models (e.g., Snowflake arctic-embed). Use this when embedding
-        synthesized queries or any text that will be matched against
-        user search queries.
-
-        Args:
-            texts: List of query strings to embed. Empty list returns [].
-
-        Returns:
-            List of embedding vectors, one per input text.
-
-        """
-        ...
+# Re-export so existing callers don't break
+__all__ = ["EmbeddingService", "LocalEmbeddingService"]
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +118,11 @@ class LocalEmbeddingService:
         executor: ThreadPoolExecutor,
         dtype: str = "float32",
     ) -> None:
+        # Deferred import: sentence-transformers loads ~2GB of models on import.
+        # Kept inside __init__ (not at module level) so that importing this module
+        # doesn't trigger the load when SHU_LOCAL_EMBEDDING_ENABLED=false.
+        import sentence_transformers
+
         self._model_name = model_name
         self._device = device
         self._batch_size = batch_size
@@ -450,13 +394,18 @@ _embedding_service: EmbeddingService | None = None
 async def get_embedding_service() -> EmbeddingService:
     """Get the configured embedding service (singleton).
 
-    Creates a LocalEmbeddingService using settings for model, device, batch
-    size, and dtype. Suitable for use in background tasks, workers, and
-    services. For FastAPI endpoints, prefer get_embedding_service_dependency().
+    Resolution order:
+    1. Return cached singleton if already initialized.
+    2. If SHU_LOCAL_EMBEDDING_ENABLED=true, create a LocalEmbeddingService
+       (default, backward-compatible — local is preferred when enabled).
+    3. If SHU_LOCAL_EMBEDDING_ENABLED=false and an active model with
+       model_type="embedding" exists in the DB, create an
+       ExternalEmbeddingService using the provider's credentials.
+    4. If local is disabled and no external model is configured, raise
+       LLMConfigurationError.
 
-    Returns:
-        The configured EmbeddingService instance.
-
+    Suitable for use in background tasks, workers, and services. For
+    FastAPI endpoints, prefer get_embedding_service_dependency().
     """
     global _embedding_service  # noqa: PLW0603
 
@@ -464,16 +413,46 @@ async def get_embedding_service() -> EmbeddingService:
         return _embedding_service
 
     settings = get_settings_instance()
-    device = resolve_embedding_device(settings.embedding_device)
-    dtype = resolve_embedding_dtype(settings.embedding_dtype, device)
 
-    _embedding_service = _service_manager.get_service(
-        model_name=settings.default_embedding_model,
-        device=device,
-        batch_size=settings.embedding_batch_size,
-        dtype=dtype,
+    if settings.local_embedding_enabled:
+        logger.info("Using local embedding service")
+        device = resolve_embedding_device(settings.embedding_device)
+        dtype = resolve_embedding_dtype(settings.embedding_dtype, device)
+        _embedding_service = _service_manager.get_service(
+            model_name=settings.default_embedding_model,
+            device=device,
+            batch_size=settings.embedding_batch_size,
+            dtype=dtype,
+        )
+        return _embedding_service
+
+    resolved = await resolve_external_model(ModelType.EMBEDDING)
+    if resolved is None:
+        raise LLMConfigurationError(
+            "No embedding service available: SHU_LOCAL_EMBEDDING_ENABLED=false "
+            "and no external embedding model (model_type='embedding') is configured "
+            "in llm_models. Either enable local embedding or register an external model."
+        )
+
+    dimension = resolved.config.get("dimension")
+    if not dimension:
+        raise LLMConfigurationError(
+            f"External embedding model '{resolved.model_name}' is missing 'dimension' "
+            f"in its config. Set config.dimension on the llm_models record."
+        )
+
+    from ..services.external_embedding_service import ExternalEmbeddingService
+
+    logger.info(
+        "Using external embedding service",
+        extra={"model": resolved.model_name, "provider": resolved.provider_name, "dimension": dimension},
     )
-
+    _embedding_service = ExternalEmbeddingService(
+        api_base_url=resolved.api_base_url,
+        api_key=resolved.api_key,
+        model_name=resolved.model_name,
+        dimension=int(dimension),
+    )
     return _embedding_service
 
 
@@ -481,7 +460,8 @@ def get_embedding_service_dependency() -> EmbeddingService:
     """Dependency injection function for EmbeddingService.
 
     Use in FastAPI endpoints with Depends(). Returns the cached singleton
-    if available, otherwise creates one synchronously via the manager.
+    if available, otherwise raises. Startup should have initialized the
+    service via initialize_embedding_service().
 
     Returns:
         An EmbeddingService instance.
@@ -492,9 +472,16 @@ def get_embedding_service_dependency() -> EmbeddingService:
     if _embedding_service is not None:
         return _embedding_service
 
-    # Fallback: create synchronously (startup should have initialized)
+    # Fallback: create synchronously via local path (startup should have initialized)
     logger.debug("get_embedding_service_dependency called before async initialization")
     settings = get_settings_instance()
+
+    if not settings.local_embedding_enabled:
+        raise LLMConfigurationError(
+            "Embedding service not initialized and local embedding is disabled. "
+            "Ensure initialize_embedding_service() is called during startup."
+        )
+
     device = resolve_embedding_device(settings.embedding_device)
     dtype = resolve_embedding_dtype(settings.embedding_dtype, device)
     _embedding_service = _service_manager.get_service(

--- a/backend/src/shu/core/embedding_service.py
+++ b/backend/src/shu/core/embedding_service.py
@@ -454,6 +454,8 @@ async def get_embedding_service() -> EmbeddingService:
         dimension=int(dimension),
         provider_id=resolved.provider_id,
         model_id=resolved.model_id,
+        query_prefix=resolved.config.get("query_prefix", ""),
+        document_prefix=resolved.config.get("document_prefix", ""),
     )
     return _embedding_service
 

--- a/backend/src/shu/core/embedding_service.py
+++ b/backend/src/shu/core/embedding_service.py
@@ -452,6 +452,8 @@ async def get_embedding_service() -> EmbeddingService:
         api_key=resolved.api_key,
         model_name=resolved.model_name,
         dimension=int(dimension),
+        provider_id=resolved.provider_id,
+        model_id=resolved.model_id,
     )
     return _embedding_service
 

--- a/backend/src/shu/core/external_model_resolver.py
+++ b/backend/src/shu/core/external_model_resolver.py
@@ -1,0 +1,112 @@
+"""Shared resolution logic for external model backends (embedding, OCR).
+
+Queries llm_models for an active model of a given type, extracts the
+provider's API base URL and decrypted API key. Used by both the embedding
+and OCR service resolution to avoid duplicate DB/credential logic.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .config import get_settings_instance
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedExternalModel:
+    """Credentials and metadata for an external model ready to use."""
+
+    model_name: str
+    api_base_url: str
+    api_key: str = field(repr=False)
+    provider_name: str
+    config: dict[str, Any]
+
+
+async def resolve_external_model(model_type: str) -> ResolvedExternalModel | None:
+    """Look up an active external model of the given type and extract its credentials.
+
+    Args:
+        model_type: The llm_models.model_type to search for (e.g. "embedding", "ocr").
+
+    Returns:
+        ResolvedExternalModel with credentials, or None if no usable model is found.
+
+    """
+    from cryptography.fernet import Fernet
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    from ..models.llm_provider import LLMModel, LLMProvider
+    from .database import get_async_session_local
+
+    # TODO: Nondeterministic when multiple active models of the same type exist.
+    # limit(1) with no order_by means the DB picks an arbitrary row. We need
+    # either a selection policy (e.g., a "preferred" flag or most-recently-created)
+    # or a uniqueness constraint ensuring only one active model per type. This is
+    # risky for embedding dimension checks and re-embedding behavior if two active
+    # embedding models with different dimensions coexist.
+    session_factory = get_async_session_local()
+    async with session_factory() as session:
+        result = await session.execute(
+            select(LLMModel)
+            .join(LLMModel.provider)
+            .where(
+                LLMModel.model_type == model_type,
+                LLMModel.is_active,
+                LLMProvider.is_active,
+            )
+            .options(selectinload(LLMModel.provider))
+            .order_by(LLMModel.created_at.desc())
+            .limit(1)
+        )
+        model = result.scalar_one_or_none()
+
+    if model is None or model.provider is None:
+        return None
+
+    provider = model.provider
+    provider_config = provider.config if isinstance(provider.config, dict) else {}
+
+    api_base_url = provider_config.get("get_api_base_url")
+    if not api_base_url:
+        logger.warning(
+            "Provider %s has no api_base_url configured, skipping external %s",
+            provider.name,
+            model_type,
+        )
+        return None
+
+    api_key = None
+    if provider.api_key_encrypted:
+        settings = get_settings_instance()
+        encryption_key = settings.llm_encryption_key
+        if encryption_key:
+            try:
+                fernet = Fernet(encryption_key.encode())
+                api_key = fernet.decrypt(provider.api_key_encrypted.encode()).decode()
+            except Exception:
+                logger.error(
+                    "Failed to decrypt API key for provider %s, skipping external %s",
+                    provider.name,
+                    model_type,
+                )
+                return None
+
+    if not api_key:
+        logger.warning(
+            "Provider %s has no API key, skipping external %s",
+            provider.name,
+            model_type,
+        )
+        return None
+
+    return ResolvedExternalModel(
+        model_name=model.model_name,
+        api_base_url=api_base_url,
+        api_key=api_key,
+        provider_name=provider.name,
+        config=model.config or {},
+    )

--- a/backend/src/shu/core/external_model_resolver.py
+++ b/backend/src/shu/core/external_model_resolver.py
@@ -18,11 +18,13 @@ logger = get_logger(__name__)
 class ResolvedExternalModel:
     """Credentials and metadata for an external model ready to use."""
 
+    model_id: str
     model_name: str
+    provider_id: str
+    provider_name: str
     api_base_url: str
     api_key: str = field(repr=False)
-    provider_name: str
-    config: dict[str, Any]
+    config: dict[str, Any] = field(default_factory=dict)
 
 
 async def resolve_external_model(model_type: str) -> ResolvedExternalModel | None:
@@ -104,9 +106,11 @@ async def resolve_external_model(model_type: str) -> ResolvedExternalModel | Non
         return None
 
     return ResolvedExternalModel(
+        model_id=model.id,
         model_name=model.model_name,
+        provider_id=provider.id,
+        provider_name=provider.name,
         api_base_url=api_base_url,
         api_key=api_key,
-        provider_name=provider.name,
         config=model.config or {},
     )

--- a/backend/src/shu/llm/service.py
+++ b/backend/src/shu/llm/service.py
@@ -24,7 +24,7 @@ from ..core.exceptions import (
     LLMConfigurationError,
     LLMProviderError,
 )
-from ..models.llm_provider import LLMModel, LLMProvider, LLMUsage
+from ..models.llm_provider import LLMModel, LLMProvider, LLMUsage, ModelType
 from ..services.provider_type_definition_service import ProviderTypeDefinitionsService
 from .client import UnifiedLLMClient
 
@@ -179,12 +179,28 @@ class LLMService:
         logger.info(f"Deleted LLM provider: {provider.name}")
         return True
 
-    async def get_available_models(self, provider_id: str | None = None) -> list[LLMModel]:
-        """Get available LLM models, optionally filtered by provider."""
+    async def get_available_models(
+        self,
+        provider_id: str | None = None,
+        model_types: list[str] | None = None,
+    ) -> list[LLMModel]:
+        """Get available LLM models, optionally filtered by provider and type.
+
+        Args:
+            provider_id: Filter to models from this provider.
+            model_types: Filter to these model types (e.g. ["chat"]).
+                Pass None to return all types (for admin model management).
+                Defaults to None (no type filter) for backward compatibility;
+                callers that serve chat contexts should pass ["chat"].
+
+        """
         stmt = select(LLMModel).where(LLMModel.is_active)
 
         if provider_id:
             stmt = stmt.where(LLMModel.provider_id == provider_id)
+
+        if model_types is not None:
+            stmt = stmt.where(LLMModel.model_type.in_(model_types))
 
         stmt = stmt.options(selectinload(LLMModel.provider))
 
@@ -338,7 +354,7 @@ class LLMService:
                         provider_id=provider_id,
                         model_name=model_name,
                         display_name=self._generate_display_name(model_name),
-                        model_type="chat",  # Default to chat
+                        model_type=ModelType.CHAT,
                         supports_streaming=True,  # Most modern models support streaming
                         supports_functions=self._supports_functions(model_name),
                         supports_vision=self._supports_vision(model_name),

--- a/backend/src/shu/models/__init__.py
+++ b/backend/src/shu/models/__init__.py
@@ -33,7 +33,7 @@ from .document import (
 )
 from .experience import Experience, ExperienceRun, ExperienceStep
 from .knowledge_base import KnowledgeBase
-from .llm_provider import Conversation, LLMModel, LLMProvider, LLMUsage, Message
+from .llm_provider import Conversation, LLMModel, LLMProvider, LLMUsage, Message, ModelType
 from .mcp_server_connection import McpServerConnection
 from .model_configuration import ModelConfiguration
 from .model_configuration_kb_prompt import ModelConfigurationKBPrompt
@@ -89,6 +89,7 @@ __all__ = [
     "Message",
     "ModelConfiguration",
     "ModelConfigurationKBPrompt",
+    "ModelType",
     "ParticipantEntityType",
     "ParticipantRole",
     "PluginDefinition",

--- a/backend/src/shu/models/llm_provider.py
+++ b/backend/src/shu/models/llm_provider.py
@@ -4,12 +4,21 @@ This module defines the database models for managing LLM providers,
 models, and usage tracking in the Shu system.
 """
 
+from enum import StrEnum
 from typing import Any
 
 from sqlalchemy import DECIMAL, JSON, Boolean, Column, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 
 from .base import BaseModel
+
+
+class ModelType(StrEnum):
+    """Valid values for LLMModel.model_type."""
+
+    CHAT = "chat"
+    EMBEDDING = "embedding"
+    OCR = "ocr"
 
 
 class LLMProvider(BaseModel):
@@ -131,7 +140,7 @@ class LLMModel(BaseModel):
     # Model information
     model_name = Column(String(100), nullable=False, index=True)  # "gpt-4", "claude-3-opus"
     display_name = Column(String(100), nullable=True)  # "GPT-4 (Latest)"
-    model_type = Column(String(50), default="chat", nullable=False)  # "chat", "completion", "embedding"
+    model_type = Column(String(50), default=ModelType.CHAT, nullable=False)
 
     # Model capabilities
     supports_streaming = Column(Boolean, default=True, nullable=False)

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -9,6 +9,7 @@ TODO: Abstract provider-specific formatting when we support more than
 OpenRouter for embedding models.
 """
 
+from decimal import Decimal
 from typing import Any
 
 import httpx
@@ -22,7 +23,8 @@ class ExternalEmbeddingService:
     """Embedding service backed by an external API provider.
 
     Conforms to the EmbeddingService protocol. Calls the provider's
-    /embeddings endpoint following the OpenAI format.
+    /embeddings endpoint following the OpenAI format. Records token
+    usage in llm_usage after each API call.
     """
 
     def __init__(
@@ -31,11 +33,15 @@ class ExternalEmbeddingService:
         api_key: str,
         model_name: str,
         dimension: int,
+        provider_id: str,
+        model_id: str,
     ) -> None:
         self._api_base_url = api_base_url.rstrip("/")
         self._api_key = api_key
         self._model_name = model_name
         self._dimension = dimension
+        self._provider_id = provider_id
+        self._model_id = model_id
 
     def __repr__(self) -> str:
         """Redact API key from repr to prevent leaking credentials in logs/tracebacks."""
@@ -55,6 +61,9 @@ class ExternalEmbeddingService:
 
         response_data = await self._call_embeddings_api(texts)
         entries = sorted(response_data["data"], key=lambda e: e["index"])
+
+        await self._record_usage(response_data.get("usage"))
+
         return [entry["embedding"] for entry in entries]
 
     async def embed_query(self, text: str) -> list[float]:
@@ -90,3 +99,36 @@ class ExternalEmbeddingService:
             response.raise_for_status()
 
         return response.json()
+
+    async def _record_usage(self, usage: dict[str, Any] | None) -> None:
+        """Record embedding API usage in llm_usage. Best-effort — failures are logged, not raised."""
+        if not usage:
+            return
+
+        try:
+            from ..core.database import get_async_session_local
+            from ..models.llm_provider import LLMUsage
+
+            prompt_tokens = usage.get("prompt_tokens", 0)
+            total_tokens = usage.get("total_tokens", 0)
+            cost = usage.get("cost", 0)
+
+            record = LLMUsage(
+                provider_id=self._provider_id,
+                model_id=self._model_id,
+                request_type="embedding",
+                input_tokens=prompt_tokens,
+                output_tokens=0,
+                total_tokens=total_tokens,
+                input_cost=Decimal(str(cost)),
+                output_cost=Decimal("0"),
+                total_cost=Decimal(str(cost)),
+                success=True,
+            )
+
+            session_factory = get_async_session_local()
+            async with session_factory() as session:
+                session.add(record)
+                await session.commit()
+        except Exception as e:
+            logger.warning("Failed to record embedding usage: %s", e)

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -35,6 +35,8 @@ class ExternalEmbeddingService:
         dimension: int,
         provider_id: str,
         model_id: str,
+        query_prefix: str = "",
+        document_prefix: str = "",
     ) -> None:
         self._api_base_url = api_base_url.rstrip("/")
         self._api_key = api_key
@@ -42,6 +44,8 @@ class ExternalEmbeddingService:
         self._dimension = dimension
         self._provider_id = provider_id
         self._model_id = model_id
+        self._query_prefix = query_prefix
+        self._document_prefix = document_prefix
 
     def __repr__(self) -> str:
         """Redact API key from repr to prevent leaking credentials in logs/tracebacks."""
@@ -56,18 +60,10 @@ class ExternalEmbeddingService:
         return self._model_name
 
     async def embed_texts(self, texts: list[str]) -> list[list[float]]:
-        if not texts:
-            return []
-
-        response_data = await self._call_embeddings_api(texts)
-        entries = sorted(response_data["data"], key=lambda e: e["index"])
-
-        await self._record_usage(response_data.get("usage"))
-
-        return [entry["embedding"] for entry in entries]
+        return await self._embed_batch(texts, prefix=self._document_prefix)
 
     async def embed_query(self, text: str) -> list[float]:
-        results = await self.embed_texts([text])
+        results = await self._embed_batch([text], prefix=self._query_prefix)
         if not results:
             raise ValueError(
                 f"embed_texts returned no results for query text "
@@ -76,13 +72,20 @@ class ExternalEmbeddingService:
         return results[0]
 
     async def embed_queries(self, texts: list[str]) -> list[list[float]]:
-        return await self.embed_texts(texts)
+        return await self._embed_batch(texts, prefix=self._query_prefix)
 
-    async def _call_embeddings_api(self, texts: list[str]) -> dict[str, Any]:
-        # See docs here: https://openrouter.ai/docs/api/reference/embeddings
+    async def _embed_batch(self, texts: list[str], prefix: str = "") -> list[list[float]]:
+        if not texts:
+            return []
+        response_data = await self._call_embeddings_api(texts, prefix=prefix)
+        entries = sorted(response_data["data"], key=lambda e: e["index"])
+        await self._record_usage(response_data.get("usage"))
+        return [entry["embedding"] for entry in entries]
+
+    async def _call_embeddings_api(self, texts: list[str], prefix: str = "") -> dict[str, Any]:
         payload = {
             "model": self._model_name,
-            "input": [{"content": [{"type": "text", "text": t}]} for t in texts],
+            "input": [{"content": [{"type": "text", "text": prefix + t}]} for t in texts],
             "encoding_format": "float",
         }
 

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -78,7 +78,12 @@ class ExternalEmbeddingService:
         if not texts:
             return []
         response_data = await self._call_embeddings_api(texts, prefix=prefix)
-        entries = sorted(response_data["data"], key=lambda e: e["index"])
+        entries = response_data.get("data") or []
+        if len(entries) != len(texts):
+            raise ValueError(
+                f"Embedding API returned {len(entries)} results for {len(texts)} inputs (model={self._model_name})"
+            )
+        entries = sorted(entries, key=lambda e: e["index"])
         await self._record_usage(response_data.get("usage"))
         return [entry["embedding"] for entry in entries]
 

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -1,0 +1,92 @@
+"""External embedding service that calls API-hosted embedding models.
+
+Implements the EmbeddingService protocol by calling a provider's embeddings
+API (initially OpenRouter, which follows the OpenAI embeddings format).
+Uses its own httpx client rather than routing through UnifiedLLMClient,
+because the request/response format differs from chat completions.
+
+TODO: Abstract provider-specific formatting when we support more than
+OpenRouter for embedding models.
+"""
+
+from typing import Any
+
+import httpx
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ExternalEmbeddingService:
+    """Embedding service backed by an external API provider.
+
+    Conforms to the EmbeddingService protocol. Calls the provider's
+    /embeddings endpoint following the OpenAI format.
+    """
+
+    def __init__(
+        self,
+        api_base_url: str,
+        api_key: str,
+        model_name: str,
+        dimension: int,
+    ) -> None:
+        self._api_base_url = api_base_url.rstrip("/")
+        self._api_key = api_key
+        self._model_name = model_name
+        self._dimension = dimension
+
+    def __repr__(self) -> str:
+        """Redact API key from repr to prevent leaking credentials in logs/tracebacks."""
+        return f"ExternalEmbeddingService(model={self._model_name!r}, dim={self._dimension})"
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+
+        response_data = await self._call_embeddings_api(texts)
+        entries = sorted(response_data["data"], key=lambda e: e["index"])
+        return [entry["embedding"] for entry in entries]
+
+    async def embed_query(self, text: str) -> list[float]:
+        results = await self.embed_texts([text])
+        if not results:
+            raise ValueError(
+                f"embed_texts returned no results for query text "
+                f"(model={self._model_name}, input_length={len(text)})"
+            )
+        return results[0]
+
+    async def embed_queries(self, texts: list[str]) -> list[list[float]]:
+        return await self.embed_texts(texts)
+
+    async def _call_embeddings_api(self, texts: list[str]) -> dict[str, Any]:
+        # See docs here: https://openrouter.ai/docs/api/reference/embeddings
+        payload = {
+            "model": self._model_name,
+            "input": [{"content": [{"type": "text", "text": t}]} for t in texts],
+            "encoding_format": "float",
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self._api_base_url}/embeddings",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0),
+            )
+            response.raise_for_status()
+
+        return response.json()

--- a/backend/src/shu/services/model_configuration_service.py
+++ b/backend/src/shu/services/model_configuration_service.py
@@ -22,7 +22,7 @@ from ..core.exceptions import ShuException, ValidationError
 from ..core.logging import get_logger
 from ..llm.param_mapping import build_provider_params
 from ..models.knowledge_base import KnowledgeBase
-from ..models.llm_provider import LLMModel, LLMProvider
+from ..models.llm_provider import LLMModel, LLMProvider, ModelType
 from ..models.model_configuration import ModelConfiguration
 from ..models.model_configuration_kb_prompt import ModelConfigurationKBPrompt
 from ..models.prompt import Prompt
@@ -74,6 +74,15 @@ class ModelConfigurationService:
                 raise ShuException(
                     f"Model {config_data.model_name} not found for provider {config_data.llm_provider_id}",
                     "MODEL_NOT_FOUND",
+                )
+
+            # TODO: We need to support creation of other model types on the frontend in the future
+            if model.model_type != ModelType.CHAT:
+                raise ShuException(
+                    f"Model {config_data.model_name} has type '{model.model_type}' which cannot be used "
+                    f"for chat configurations. Only '{ModelType.CHAT}' models are allowed.",
+                    "INVALID_MODEL_TYPE",
+                    status_code=400,
                 )
 
             # Validate prompt if provided

--- a/backend/src/shu/worker.py
+++ b/backend/src/shu/worker.py
@@ -42,6 +42,7 @@ from sqlalchemy import select
 from .auth.models import User
 from .core.config import get_settings_instance
 from .core.database import get_async_session_local, init_db
+from .core.embedding_service import get_embedding_service
 from .core.exceptions import ShuException
 from .core.logging import get_logger, setup_logging
 from .core.queue_backend import get_queue_backend
@@ -431,6 +432,16 @@ async def _handle_content_embed_job(job) -> None:
                     "chunk_count": chunk_count,
                 },
             )
+
+            # The KB's embedding_model column defaults to SHU_EMBEDDING_MODEL (the
+            # local model name) at creation time. When the active service is an
+            # external provider, the default is wrong. Correct it here so that
+            # stale-KB detection at startup compares against the model that
+            # actually produced the vectors.
+            embedding_service = await get_embedding_service()
+            if kb.embedding_model != embedding_service.model_name:
+                kb.embedding_model = embedding_service.model_name
+                await session.commit()
 
             settings = get_settings_instance()
             await _finalize_embed_job(job, session, document, document_id, settings.enable_document_profiling)

--- a/backend/src/shu/worker.py
+++ b/backend/src/shu/worker.py
@@ -42,7 +42,6 @@ from sqlalchemy import select
 from .auth.models import User
 from .core.config import get_settings_instance
 from .core.database import get_async_session_local, init_db
-from .core.embedding_service import get_embedding_service
 from .core.exceptions import ShuException
 from .core.logging import get_logger, setup_logging
 from .core.queue_backend import get_queue_backend
@@ -393,6 +392,18 @@ async def _handle_content_embed_job(job) -> None:
             return
 
         try:
+            # The KB's embedding_model defaults to SHU_EMBEDDING_MODEL (the local
+            # model name) at creation time. When the active service is an external
+            # provider, the default is wrong. Correct it on the first document so
+            # stale-KB detection at startup compares against the model that actually
+            # produced the vectors. Only runs once — subsequent documents skip this.
+            if kb.total_chunks == 0:
+                from .core.embedding_service import get_embedding_service
+
+                embedding_svc = await get_embedding_service()
+                if kb.embedding_model != embedding_svc.model_name:
+                    kb.embedding_model = embedding_svc.model_name
+
             # Set EMBEDDING status before processing so a crash mid-embed leaves
             # the document in a diagnosable state rather than the previous status.
             document.update_status(DocumentStatus.EMBEDDING)
@@ -432,16 +443,6 @@ async def _handle_content_embed_job(job) -> None:
                     "chunk_count": chunk_count,
                 },
             )
-
-            # The KB's embedding_model column defaults to SHU_EMBEDDING_MODEL (the
-            # local model name) at creation time. When the active service is an
-            # external provider, the default is wrong. Correct it here so that
-            # stale-KB detection at startup compares against the model that
-            # actually produced the vectors.
-            embedding_service = await get_embedding_service()
-            if kb.embedding_model != embedding_service.model_name:
-                kb.embedding_model = embedding_service.model_name
-                await session.commit()
 
             settings = get_settings_instance()
             await _finalize_embed_job(job, session, document, document_id, settings.enable_document_profiling)

--- a/backend/src/tests/unit/core/test_embedding_service.py
+++ b/backend/src/tests/unit/core/test_embedding_service.py
@@ -2,13 +2,16 @@
 
 Tests cover:
 - EmbeddingService protocol conformance
+- Protocol extraction (embedding_protocol.py) backward compatibility
 - _EmbeddingServiceManager caching and eviction logic
 - DI wiring (get_embedding_service, reset, dependency)
+- Service resolution logic (local vs external vs error)
 
 Model-loading tests are excluded from this file — they require downloading
 sentence-transformer models and are covered by integration tests.
 """
 
+import sys
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,6 +26,7 @@ from shu.core.embedding_service import (
     get_embedding_service_stats,
     reset_embedding_service,
 )
+from shu.core.external_model_resolver import ResolvedExternalModel
 
 # ---------------------------------------------------------------------------
 # Protocol conformance
@@ -216,6 +220,7 @@ class TestDIWiring:
         settings.embedding_device = "cpu"
         settings.embedding_batch_size = 32
         settings.embedding_dtype = "float32"
+        settings.local_embedding_enabled = True
         mock_settings.return_value = settings
 
         mock_service = _make_mock_service()
@@ -253,3 +258,193 @@ class TestDIWiring:
         mod._embedding_service = _make_mock_service()
         clear_embedding_service_cache()
         assert mod._embedding_service is None
+
+
+# ---------------------------------------------------------------------------
+# Service resolution (local vs external)
+# ---------------------------------------------------------------------------
+
+
+def _make_resolved_model(**overrides) -> ResolvedExternalModel:
+    """Build a ResolvedExternalModel with sensible defaults."""
+    defaults = {
+        "model_name": "qwen/qwen3-embedding-8b",
+        "api_base_url": "https://openrouter.ai/api/v1",
+        "api_key": "test-key",
+        "provider_name": "OpenRouter",
+        "config": {"dimension": 1024},
+    }
+    defaults.update(overrides)
+    return ResolvedExternalModel(**defaults)
+
+
+class TestServiceResolution:
+    """Test the resolution logic in get_embedding_service()."""
+
+    def setup_method(self):
+        reset_embedding_service()
+
+    def teardown_method(self):
+        reset_embedding_service()
+
+    @pytest.mark.asyncio
+    @patch("shu.core.embedding_service._service_manager")
+    @patch("shu.core.embedding_service.get_settings_instance")
+    async def test_local_enabled_uses_local(self, mock_settings, mock_manager):
+        """When SHU_LOCAL_EMBEDDING_ENABLED=true, local service is used regardless of external models."""
+        settings = MagicMock()
+        settings.local_embedding_enabled = True
+        settings.default_embedding_model = "test-model"
+        settings.embedding_device = "cpu"
+        settings.embedding_batch_size = 32
+        settings.embedding_dtype = "float32"
+        mock_settings.return_value = settings
+
+        mock_service = _make_mock_service()
+        mock_manager.get_service.return_value = mock_service
+
+        svc = await get_embedding_service()
+
+        assert svc is mock_service
+        mock_manager.get_service.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("shu.core.embedding_service.resolve_external_model")
+    @patch("shu.core.embedding_service.get_settings_instance")
+    async def test_local_disabled_with_external_model_uses_external(self, mock_settings, mock_resolve):
+        """When local is disabled and an external embedding model is configured, use ExternalEmbeddingService."""
+        settings = MagicMock()
+        settings.local_embedding_enabled = False
+        mock_settings.return_value = settings
+
+        mock_resolve.return_value = _make_resolved_model()
+
+        svc = await get_embedding_service()
+
+        from shu.services.external_embedding_service import ExternalEmbeddingService
+
+        assert isinstance(svc, ExternalEmbeddingService)
+        assert svc.model_name == "qwen/qwen3-embedding-8b"
+        assert svc.dimension == 1024
+        mock_resolve.assert_called_once_with("embedding")
+
+    @pytest.mark.asyncio
+    @patch("shu.core.embedding_service.resolve_external_model")
+    @patch("shu.core.embedding_service.get_settings_instance")
+    async def test_local_disabled_no_external_model_raises(self, mock_settings, mock_resolve):
+        """When local is disabled and no external model exists, raise LLMConfigurationError."""
+        settings = MagicMock()
+        settings.local_embedding_enabled = False
+        mock_settings.return_value = settings
+
+        mock_resolve.return_value = None
+
+        from shu.core.exceptions import LLMConfigurationError
+
+        with pytest.raises(LLMConfigurationError, match="no external embedding model"):
+            await get_embedding_service()
+
+    @pytest.mark.asyncio
+    @patch("shu.core.embedding_service.resolve_external_model")
+    @patch("shu.core.embedding_service.get_settings_instance")
+    async def test_local_disabled_external_model_missing_dimension_raises(self, mock_settings, mock_resolve):
+        """When the external model has no dimension in config, raise LLMConfigurationError."""
+        settings = MagicMock()
+        settings.local_embedding_enabled = False
+        mock_settings.return_value = settings
+
+        mock_resolve.return_value = _make_resolved_model(config={})
+
+        from shu.core.exceptions import LLMConfigurationError
+
+        with pytest.raises(LLMConfigurationError, match="missing 'dimension'"):
+            await get_embedding_service()
+
+    @pytest.mark.asyncio
+    @patch("shu.core.embedding_service.resolve_external_model")
+    @patch("shu.core.embedding_service.get_settings_instance")
+    async def test_external_singleton_returns_same_instance(self, mock_settings, mock_resolve):
+        """External service should be cached as a singleton across calls."""
+        settings = MagicMock()
+        settings.local_embedding_enabled = False
+        mock_settings.return_value = settings
+
+        mock_resolve.return_value = _make_resolved_model()
+
+        svc1 = await get_embedding_service()
+        svc2 = await get_embedding_service()
+
+        assert svc1 is svc2
+        # resolve_external_model should only be called once (singleton caches)
+        mock_resolve.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Protocol extraction (embedding_protocol.py)
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolExtraction:
+    """Verify that the protocol extraction to embedding_protocol.py works correctly."""
+
+    def test_import_from_embedding_protocol(self):
+        """EmbeddingService should be importable from embedding_protocol directly."""
+        from shu.core.embedding_protocol import EmbeddingService as ProtoService
+
+        assert ProtoService is not None
+
+    def test_reexport_is_same_class(self):
+        """EmbeddingService imported from embedding_service should be the same class as from embedding_protocol."""
+        from shu.core.embedding_protocol import EmbeddingService as ProtoService
+
+        assert EmbeddingService is ProtoService
+
+    def test_protocol_import_does_not_load_sentence_transformers(self):
+        """Importing embedding_protocol should NOT load sentence_transformers into sys.modules.
+
+        This is the core purpose of the extraction — external embedding
+        backends can import the protocol without triggering ~2GB of model
+        loading from sentence-transformers.
+        """
+        # sentence_transformers may already be loaded from other test
+        # imports in this process, so we check whether importing the
+        # protocol module itself triggers a NEW load. We verify by
+        # checking the module's own imports have no dependency on it.
+        import importlib
+
+        import shu.core.embedding_protocol as proto_mod
+
+        # Re-import from scratch to verify the module source has no
+        # sentence_transformers reference
+        source = importlib.util.find_spec("shu.core.embedding_protocol")
+        assert source is not None
+        with open(source.origin) as f:
+            source_code = f.read()
+        assert "sentence_transformers" not in source_code, (
+            "embedding_protocol.py must not reference sentence_transformers"
+        )
+        assert "import sentence" not in source_code
+
+    def test_protocol_conformance_via_embedding_protocol(self):
+        """A conforming class should pass isinstance check with the protocol from embedding_protocol."""
+        from shu.core.embedding_protocol import EmbeddingService as ProtoService
+
+        class ConformingService:
+            @property
+            def dimension(self) -> int:
+                return 768
+
+            @property
+            def model_name(self) -> str:
+                return "test"
+
+            async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+                return []
+
+            async def embed_query(self, text: str) -> list[float]:
+                return []
+
+            async def embed_queries(self, texts: list[str]) -> list[list[float]]:
+                return []
+
+        assert isinstance(ConformingService(), ProtoService)

--- a/backend/src/tests/unit/core/test_embedding_service.py
+++ b/backend/src/tests/unit/core/test_embedding_service.py
@@ -268,10 +268,12 @@ class TestDIWiring:
 def _make_resolved_model(**overrides) -> ResolvedExternalModel:
     """Build a ResolvedExternalModel with sensible defaults."""
     defaults = {
+        "model_id": "model-123",
         "model_name": "qwen/qwen3-embedding-8b",
+        "provider_id": "provider-456",
+        "provider_name": "OpenRouter",
         "api_base_url": "https://openrouter.ai/api/v1",
         "api_key": "test-key",
-        "provider_name": "OpenRouter",
         "config": {"dimension": 1024},
     }
     defaults.update(overrides)

--- a/backend/src/tests/unit/llm/test_service.py
+++ b/backend/src/tests/unit/llm/test_service.py
@@ -1,0 +1,113 @@
+"""Unit tests for LLM model type filtering and configuration validation.
+
+Tests cover:
+- Model type validation in model configuration creation (rejects ocr/embedding)
+- Model type filtering query construction
+
+The LLMService.get_available_models() filtering is 3 lines of SQLAlchemy
+(.where model_type.in_) and is tested via the API integration path. The
+configuration validation is the critical behavioral test.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _make_model(model_name: str, model_type: str = "chat") -> MagicMock:
+    """Create a mock LLMModel."""
+    model = MagicMock()
+    model.model_name = model_name
+    model.model_type = model_type
+    model.is_active = True
+    model.provider = MagicMock()
+    return model
+
+
+class TestModelConfigurationTypeValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_ocr_model(self):
+        """Creating a model configuration with an OCR model should fail with INVALID_MODEL_TYPE."""
+        from shu.core.exceptions import ShuException
+        from shu.services.model_configuration_service import ModelConfigurationService
+
+        db = AsyncMock(spec=AsyncSession)
+        service = ModelConfigurationService(db)
+
+        mock_provider_result = MagicMock()
+        mock_provider_result.scalar_one_or_none.return_value = MagicMock(is_active=True)
+
+        mock_model_result = MagicMock()
+        mock_model_result.scalar_one_or_none.return_value = _make_model("mistral-ocr", "ocr")
+
+        db.execute = AsyncMock(side_effect=[mock_provider_result, mock_model_result])
+
+        config_data = MagicMock()
+        config_data.llm_provider_id = "provider-1"
+        config_data.model_name = "mistral-ocr"
+
+        with pytest.raises(ShuException) as exc_info:
+            await service.create_model_configuration(config_data, created_by="test-user")
+        assert exc_info.value.error_code == "INVALID_MODEL_TYPE"
+
+    @pytest.mark.asyncio
+    async def test_rejects_embedding_model(self):
+        """Creating a model configuration with an embedding model should fail with INVALID_MODEL_TYPE."""
+        from shu.core.exceptions import ShuException
+        from shu.services.model_configuration_service import ModelConfigurationService
+
+        db = AsyncMock(spec=AsyncSession)
+        service = ModelConfigurationService(db)
+
+        mock_provider_result = MagicMock()
+        mock_provider_result.scalar_one_or_none.return_value = MagicMock(is_active=True)
+
+        mock_model_result = MagicMock()
+        mock_model_result.scalar_one_or_none.return_value = _make_model("qwen-embed", "embedding")
+
+        db.execute = AsyncMock(side_effect=[mock_provider_result, mock_model_result])
+
+        config_data = MagicMock()
+        config_data.llm_provider_id = "provider-1"
+        config_data.model_name = "qwen-embed"
+
+        with pytest.raises(ShuException) as exc_info:
+            await service.create_model_configuration(config_data, created_by="test-user")
+        assert exc_info.value.error_code == "INVALID_MODEL_TYPE"
+
+    @pytest.mark.asyncio
+    async def test_accepts_chat_model(self):
+        """A chat model should pass the model type validation step (may fail later at prompt validation)."""
+        from shu.core.exceptions import ShuException
+        from shu.services.model_configuration_service import ModelConfigurationService
+
+        db = AsyncMock(spec=AsyncSession)
+        service = ModelConfigurationService(db)
+
+        mock_provider_result = MagicMock()
+        mock_provider_result.scalar_one_or_none.return_value = MagicMock(is_active=True)
+
+        mock_model_result = MagicMock()
+        mock_model_result.scalar_one_or_none.return_value = _make_model("gpt-4", "chat")
+
+        mock_prompt_result = MagicMock()
+        mock_prompt_result.scalar_one_or_none.return_value = None
+
+        db.execute = AsyncMock(side_effect=[mock_provider_result, mock_model_result, mock_prompt_result])
+
+        config_data = MagicMock()
+        config_data.llm_provider_id = "provider-1"
+        config_data.model_name = "gpt-4"
+        config_data.name = "Test Config"
+        config_data.description = None
+        config_data.prompt_id = "some-prompt"
+        config_data.parameter_overrides = None
+        config_data.functionalities = None
+        config_data.knowledge_base_ids = None
+        config_data.kb_prompt_assignments = None
+
+        try:
+            await service.create_model_configuration(config_data, created_by="test-user")
+        except ShuException as e:
+            assert e.error_code != "INVALID_MODEL_TYPE", f"Chat model should pass type validation, got: {e.error_code}"

--- a/backend/src/tests/unit/services/test_external_embedding_service.py
+++ b/backend/src/tests/unit/services/test_external_embedding_service.py
@@ -26,7 +26,7 @@ PROVIDER_ID = "provider-123"
 MODEL_ID = "model-456"
 
 
-def _make_service() -> ExternalEmbeddingService:
+def _make_service(query_prefix: str = "", document_prefix: str = "") -> ExternalEmbeddingService:
     return ExternalEmbeddingService(
         api_base_url=API_BASE,
         api_key=API_KEY,
@@ -34,6 +34,8 @@ def _make_service() -> ExternalEmbeddingService:
         dimension=DIM,
         provider_id=PROVIDER_ID,
         model_id=MODEL_ID,
+        query_prefix=query_prefix,
+        document_prefix=document_prefix,
     )
 
 
@@ -186,6 +188,67 @@ class TestEmbedQueries:
         svc = _make_service()
         result = await svc.embed_queries([])
         assert result == []
+
+
+class TestPrefixes:
+    @pytest.mark.asyncio
+    async def test_embed_texts_applies_document_prefix(self):
+        """embed_texts should prepend the document prefix to each text in the API payload."""
+        with _patched_httpx(_mock_embeddings_response([[0.1]])) as mock_client:
+            svc = _make_service(document_prefix="search_document: ")
+            await svc.embed_texts(["hello"])
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["input"] == [{"content": [{"type": "text", "text": "search_document: hello"}]}]
+
+    @pytest.mark.asyncio
+    async def test_embed_query_applies_query_prefix(self):
+        """embed_query should prepend the query prefix to the text in the API payload."""
+        with _patched_httpx(_mock_embeddings_response([[0.1]])) as mock_client:
+            svc = _make_service(query_prefix="search_query: ")
+            await svc.embed_query("hello")
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["input"] == [{"content": [{"type": "text", "text": "search_query: hello"}]}]
+
+    @pytest.mark.asyncio
+    async def test_embed_queries_applies_query_prefix(self):
+        """embed_queries should prepend the query prefix to each text in the API payload."""
+        with _patched_httpx(_mock_embeddings_response([[0.1], [0.2]])) as mock_client:
+            svc = _make_service(query_prefix="search_query: ")
+            await svc.embed_queries(["q1", "q2"])
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["input"] == [
+            {"content": [{"type": "text", "text": "search_query: q1"}]},
+            {"content": [{"type": "text", "text": "search_query: q2"}]},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_prefix_when_empty_string(self):
+        """When no prefix is configured, the text should be sent unmodified."""
+        with _patched_httpx(_mock_embeddings_response([[0.1]])) as mock_client:
+            svc = _make_service()
+            await svc.embed_texts(["hello"])
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["input"] == [{"content": [{"type": "text", "text": "hello"}]}]
+
+    @pytest.mark.asyncio
+    async def test_query_and_document_prefixes_differ(self):
+        """embed_texts and embed_query on the same service should use their respective prefixes."""
+        svc = _make_service(query_prefix="query: ", document_prefix="passage: ")
+
+        with _patched_httpx(_mock_embeddings_response([[0.1]])) as mock_client:
+            await svc.embed_texts(["doc"])
+        doc_payload = mock_client.post.call_args[1]["json"]
+
+        with _patched_httpx(_mock_embeddings_response([[0.2]])) as mock_client:
+            await svc.embed_query("q")
+        query_payload = mock_client.post.call_args[1]["json"]
+
+        assert doc_payload["input"] == [{"content": [{"type": "text", "text": "passage: doc"}]}]
+        assert query_payload["input"] == [{"content": [{"type": "text", "text": "query: q"}]}]
 
 
 class TestErrorHandling:

--- a/backend/src/tests/unit/services/test_external_embedding_service.py
+++ b/backend/src/tests/unit/services/test_external_embedding_service.py
@@ -22,6 +22,8 @@ API_BASE = "https://openrouter.ai/api/v1"
 API_KEY = "test-key"
 MODEL = "qwen/qwen3-embedding-8b"
 DIM = 1024
+PROVIDER_ID = "provider-123"
+MODEL_ID = "model-456"
 
 
 def _make_service() -> ExternalEmbeddingService:
@@ -30,6 +32,8 @@ def _make_service() -> ExternalEmbeddingService:
         api_key=API_KEY,
         model_name=MODEL,
         dimension=DIM,
+        provider_id=PROVIDER_ID,
+        model_id=MODEL_ID,
     )
 
 
@@ -45,8 +49,11 @@ def _mock_embeddings_response(embeddings: list[list[float]]) -> httpx.Response:
 
 @contextmanager
 def _patched_httpx(response=None, side_effect=None):
-    """Patch httpx.AsyncClient to return a mock that yields the given response or side_effect."""
-    with patch("shu.services.external_embedding_service.httpx.AsyncClient") as mock_cls:
+    """Patch httpx.AsyncClient and usage recording to isolate API tests from the DB."""
+    with (
+        patch("shu.services.external_embedding_service.httpx.AsyncClient") as mock_cls,
+        patch.object(ExternalEmbeddingService, "_record_usage", new_callable=AsyncMock),
+    ):
         mock_client = AsyncMock()
         if side_effect:
             mock_client.post = AsyncMock(side_effect=side_effect)
@@ -83,6 +90,8 @@ class TestProperties:
             api_key="k",
             model_name="m",
             dimension=128,
+            provider_id="p",
+            model_id="m",
         )
         assert svc._api_base_url == "https://example.com/v1"
 

--- a/backend/src/tests/unit/services/test_external_embedding_service.py
+++ b/backend/src/tests/unit/services/test_external_embedding_service.py
@@ -1,0 +1,217 @@
+"""Unit tests for ExternalEmbeddingService.
+
+Tests cover:
+- EmbeddingService protocol conformance
+- embed_texts request payload and response parsing
+- embed_query and embed_queries delegation
+- dimension and model_name properties
+- HTTP error propagation
+- Empty input handling
+"""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from shu.core.embedding_protocol import EmbeddingService
+from shu.services.external_embedding_service import ExternalEmbeddingService
+
+API_BASE = "https://openrouter.ai/api/v1"
+API_KEY = "test-key"
+MODEL = "qwen/qwen3-embedding-8b"
+DIM = 1024
+
+
+def _make_service() -> ExternalEmbeddingService:
+    return ExternalEmbeddingService(
+        api_base_url=API_BASE,
+        api_key=API_KEY,
+        model_name=MODEL,
+        dimension=DIM,
+    )
+
+
+def _mock_embeddings_response(embeddings: list[list[float]]) -> httpx.Response:
+    """Build a fake httpx.Response matching the OpenRouter embeddings format."""
+    data = [{"embedding": emb, "index": i} for i, emb in enumerate(embeddings)]
+    return httpx.Response(
+        status_code=200,
+        json={"data": data, "model": MODEL, "usage": {"prompt_tokens": 10, "total_tokens": 10}},
+        request=httpx.Request("POST", f"{API_BASE}/embeddings"),
+    )
+
+
+@contextmanager
+def _patched_httpx(response=None, side_effect=None):
+    """Patch httpx.AsyncClient to return a mock that yields the given response or side_effect."""
+    with patch("shu.services.external_embedding_service.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        if side_effect:
+            mock_client.post = AsyncMock(side_effect=side_effect)
+        else:
+            mock_client.post = AsyncMock(return_value=response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_cls.return_value = mock_client
+        yield mock_client
+
+
+class TestProtocolConformance:
+    def test_isinstance_check(self):
+        """A constructed instance should satisfy the EmbeddingService runtime_checkable protocol."""
+        svc = _make_service()
+        assert isinstance(svc, EmbeddingService)
+
+
+class TestProperties:
+    def test_dimension(self):
+        """dimension property should return the value passed at construction."""
+        svc = _make_service()
+        assert svc.dimension == DIM
+
+    def test_model_name(self):
+        """model_name property should return the value passed at construction."""
+        svc = _make_service()
+        assert svc.model_name == MODEL
+
+    def test_api_base_url_trailing_slash_stripped(self):
+        """Constructor should strip trailing slashes from api_base_url to avoid double-slash in endpoint URLs."""
+        svc = ExternalEmbeddingService(
+            api_base_url="https://example.com/v1/",
+            api_key="k",
+            model_name="m",
+            dimension=128,
+        )
+        assert svc._api_base_url == "https://example.com/v1"
+
+    def test_repr_redacts_api_key(self):
+        """repr should not contain the API key."""
+        svc = _make_service()
+        r = repr(svc)
+        assert API_KEY not in r
+        assert MODEL in r
+
+
+class TestEmbedTexts:
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty(self):
+        """Passing an empty list should short-circuit and return [] without making an API call."""
+        svc = _make_service()
+        result = await svc.embed_texts([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_single_text(self):
+        """Single text should produce correct OpenRouter payload format and parse the response embedding."""
+        embedding = [0.1, 0.2, 0.3]
+
+        with _patched_httpx(_mock_embeddings_response([embedding])) as mock_client:
+            svc = _make_service()
+            result = await svc.embed_texts(["hello"])
+
+        assert result == [embedding]
+
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs[0][0] == f"{API_BASE}/embeddings"
+        payload = call_kwargs[1]["json"]
+        assert payload["model"] == MODEL
+        assert payload["input"] == [{"content": [{"type": "text", "text": "hello"}]}]
+        assert payload["encoding_format"] == "float"
+        assert "Bearer test-key" in call_kwargs[1]["headers"]["Authorization"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_texts_sorted_by_index(self):
+        """When the API returns embeddings out of order, results should be sorted by index to match input order."""
+        emb_0 = [1.0, 2.0]
+        emb_1 = [3.0, 4.0]
+        data = [
+            {"embedding": emb_1, "index": 1},
+            {"embedding": emb_0, "index": 0},
+        ]
+        response = httpx.Response(
+            status_code=200,
+            json={"data": data, "model": MODEL},
+            request=httpx.Request("POST", f"{API_BASE}/embeddings"),
+        )
+
+        with _patched_httpx(response):
+            svc = _make_service()
+            result = await svc.embed_texts(["first", "second"])
+
+        assert result == [emb_0, emb_1]
+
+
+class TestEmbedQuery:
+    @pytest.mark.asyncio
+    async def test_delegates_to_embed_texts(self):
+        """embed_query wraps the text in a single-element list and returns the first (only) result vector."""
+        embedding = [0.5, 0.6]
+
+        with _patched_httpx(_mock_embeddings_response([embedding])) as mock_client:
+            svc = _make_service()
+            result = await svc.embed_query("search query")
+
+        assert result == embedding
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["input"] == [{"content": [{"type": "text", "text": "search query"}]}]
+
+
+class TestEmbedQueries:
+    @pytest.mark.asyncio
+    async def test_delegates_to_embed_texts(self):
+        """embed_queries should call the same API endpoint as embed_texts and return all vectors."""
+        emb_0 = [0.1]
+        emb_1 = [0.2]
+
+        with _patched_httpx(_mock_embeddings_response([emb_0, emb_1])):
+            svc = _make_service()
+            result = await svc.embed_queries(["q1", "q2"])
+
+        assert result == [emb_0, emb_1]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty(self):
+        """Empty query list should short-circuit and return [] without making an API call."""
+        svc = _make_service()
+        result = await svc.embed_queries([])
+        assert result == []
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_http_timeout_propagates(self):
+        """Timeouts from the provider should propagate as-is so the worker retry mechanism can handle them."""
+        with _patched_httpx(side_effect=httpx.TimeoutException("read timeout")):
+            svc = _make_service()
+            with pytest.raises(httpx.TimeoutException):
+                await svc.embed_texts(["test"])
+
+    @pytest.mark.asyncio
+    async def test_http_5xx_propagates(self):
+        """Server errors (500) should propagate as HTTPStatusError — no silent fallback."""
+        error_response = httpx.Response(
+            status_code=500,
+            text="Internal Server Error",
+            request=httpx.Request("POST", f"{API_BASE}/embeddings"),
+        )
+
+        with _patched_httpx(error_response):
+            svc = _make_service()
+            with pytest.raises(httpx.HTTPStatusError):
+                await svc.embed_texts(["test"])
+
+    @pytest.mark.asyncio
+    async def test_http_401_propagates(self):
+        """Auth failures (401) should propagate as HTTPStatusError — indicates misconfigured API key."""
+        error_response = httpx.Response(
+            status_code=401,
+            text="Unauthorized",
+            request=httpx.Request("POST", f"{API_BASE}/embeddings"),
+        )
+
+        with _patched_httpx(error_response):
+            svc = _make_service()
+            with pytest.raises(httpx.HTTPStatusError):
+                await svc.embed_texts(["test"])


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

- The OCR flag is in preparation of the external OCR handler. We'll see if we will still go that route.
- I'll update the host script to accommodate seeding different embedding models directly.
- For now we'll just seed this when we run the host setup script: https://github.com/Open-Shu/shu/pull/124


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle local OCR and embedding via env (defaults true); support resolving and using external embedding providers.
  * Retrieve available models filtered by type (chat, embedding, OCR, or all).

* **Behavior**
  * Embedding jobs align knowledge-base records to the active embedding model when initializing chunks.
  * Model-configuration now rejects non-chat models for chat configurations.

* **Tests**
  * Added tests for embedding resolution, external embedding integration, and protocol conformance.

* **Documentation**
  * Example env updated with new service toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->