### PR TITLE
[SHU-400] External OCR services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,14 +161,17 @@ SHU_OCR_PAGE_TIMEOUT=180
 # SERVICE BACKEND CONFIGURATION
 # =============================================================================
 
-# Controls whether local OCR/embedding models are loaded into memory.
-# Set to false for hosted deployments that use external API providers
-# (e.g., OpenRouter), avoiding memory overhead per model.
-# When false, an external model must be registered in llm_models with the
-# appropriate model_type ("ocr" or "embedding"), otherwise startup fails.
+# Embedding: set to false to skip local sentence-transformers loading (~2GB).
+# When false, an external embedding model must be registered in llm_models,
+# otherwise startup fails.
 # Default: true (backward-compatible — local models loaded as before)
-SHU_LOCAL_OCR_ENABLED=true
 SHU_LOCAL_EMBEDDING_ENABLED=true
+
+# OCR: set API key to use Mistral OCR instead of local EasyOCR/Tesseract.
+# If not set, local OCR is used automatically.
+# SHU_MISTRAL_OCR_API_KEY=your_mistral_api_key_here
+# SHU_MISTRAL_OCR_BASE_URL=https://api.mistral.ai/v1
+# SHU_MISTRAL_OCR_MODEL=mistral-ocr-latest
 
 
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,11 @@ SHU_LOCAL_EMBEDDING_ENABLED=true
 # SHU_MISTRAL_OCR_BASE_URL=https://api.mistral.ai/v1
 # SHU_MISTRAL_OCR_MODEL=mistral-ocr-latest
 
+# Minimum character count from fast text extraction before OCR is skipped.
+# Scanned PDFs with tiny garbage text layers produce < 50 chars; raising
+# this triggers OCR more aggressively.
+# SHU_OCR_FALLBACK_MIN_TEXT_LENGTH=50
+
 
 # =============================================================================
 # TEXT PROCESSING CONFIGURATION

--- a/backend/migrations/versions/008_0007_mcp_server_connections.py
+++ b/backend/migrations/versions/008_0007_mcp_server_connections.py
@@ -1,7 +1,7 @@
 """Create mcp_server_connections table
 
-Revision ID: 008_0006
-Revises: 008_0005
+Revision ID: 008_0007
+Revises: 008_0006
 Create Date: 2026-03-26
 """
 
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "008_0006"
-down_revision = "008_0005"
+revision = "008_0007"
+down_revision = "008_0006"
 branch_labels = None
 depends_on = None
 

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -513,11 +513,15 @@ class Settings(BaseSettings):
     # Note: No page limits - OCR processes all pages in document
 
     # Service backend configuration
-    # Controls whether local OCR/embedding models are loaded into memory.
-    # Set to false for hosted deployments that use external API providers,
-    # avoiding the memory overhead of EasyOCR and sentence-transformers.
-    local_ocr_enabled: bool = Field(True, alias="SHU_LOCAL_OCR_ENABLED")
+    # Embedding: set to false for hosted deployments that use external API providers,
+    # avoiding the memory overhead of sentence-transformers (~2GB).
     local_embedding_enabled: bool = Field(True, alias="SHU_LOCAL_EMBEDDING_ENABLED")
+
+    # OCR: set SHU_MISTRAL_OCR_API_KEY to use Mistral OCR via OpenRouter
+    # instead of local EasyOCR/Tesseract. API key presence is the switch.
+    mistral_ocr_api_key: str | None = Field(None, alias="SHU_MISTRAL_OCR_API_KEY")
+    mistral_ocr_base_url: str = Field("https://api.mistral.ai/v1", alias="SHU_MISTRAL_OCR_BASE_URL")
+    mistral_ocr_model: str = Field("mistral-ocr-latest", alias="SHU_MISTRAL_OCR_MODEL")
 
     @field_validator("database_url")
     @classmethod

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -523,6 +523,11 @@ class Settings(BaseSettings):
     mistral_ocr_base_url: str = Field("https://api.mistral.ai/v1", alias="SHU_MISTRAL_OCR_BASE_URL")
     mistral_ocr_model: str = Field("mistral-ocr-latest", alias="SHU_MISTRAL_OCR_MODEL")
 
+    # Minimum character count from fast text extraction before OCR is skipped.
+    # Scanned PDFs with tiny garbage text layers produce < 50 chars; raising
+    # this triggers OCR more aggressively, lowering it trusts the text layer.
+    ocr_fallback_min_text_length: int = Field(50, alias="SHU_OCR_FALLBACK_MIN_TEXT_LENGTH")
+
     @field_validator("database_url")
     @classmethod
     def validate_database_url(cls, v: str) -> str:

--- a/backend/src/shu/core/logging.py
+++ b/backend/src/shu/core/logging.py
@@ -496,6 +496,10 @@ def setup_logging() -> None:  # noqa: PLR0915
 
 def get_logger(name: str) -> logging.Logger:
     """Get a logger with the specified name."""
+    # __name__ inside the shu package is already "shu.some.module",
+    # so prefixing again would produce "shu.shu.some.module".
+    if name.startswith("shu."):
+        return logging.getLogger(name)
     return logging.getLogger(f"shu.{name}")
 
 

--- a/backend/src/shu/core/ocr_service.py
+++ b/backend/src/shu/core/ocr_service.py
@@ -9,11 +9,17 @@ DI wiring:
     - reset_ocr_service() — test teardown
 """
 
-from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from ..processors.text_extractor import TextExtractor
 from .config import get_settings_instance
 from .logging import get_logger
+
+if TYPE_CHECKING:
+    from .config import ConfigurationManager
 
 logger = get_logger(__name__)
 
@@ -93,3 +99,90 @@ def reset_ocr_service() -> None:
     """Reset the OCR service singleton (for testing only)."""
     global _ocr_service  # noqa: PLW0603
     _ocr_service = None
+
+
+async def extract_text_with_ocr_fallback(
+    file_bytes: bytes,
+    mime_type: str,
+    config_manager: ConfigurationManager,
+    *,
+    filename: str | None = None,
+    ocr_mode: str = "auto",
+) -> dict:
+    """Two-step text extraction: fast extraction first, OCR service if needed.
+
+    Step 1 uses TextExtractor with ocr_mode="text_only" (PDF text, DOCX, etc.).
+    Step 2 routes through get_ocr_service() (Mistral or local EasyOCR/Tesseract)
+    only when step 1 yields insufficient text and ocr_mode permits it.
+
+    "auto" and "fallback" behave identically: try fast text extraction,
+    fall back to OCR when the result is below the minimum threshold.
+
+    Args:
+        file_bytes: Raw document bytes.
+        mime_type: MIME type of the document.
+        config_manager: ConfigurationManager for TextExtractor.
+        filename: Optional filename for extension detection in fast extraction.
+        ocr_mode: One of "auto", "always", "never", "fallback", "text_only".
+
+    Returns:
+        Dict with "text" and "metadata" keys, same shape as TextExtractor.extract_text().
+
+    """
+    effective_mode = (ocr_mode or "auto").strip().lower()
+    settings = get_settings_instance()
+
+    if effective_mode in ("never", "text_only"):
+        return await TextExtractor(config_manager=config_manager).extract_text(
+            file_bytes=file_bytes,
+            mime_type=mime_type,
+            ocr_mode="text_only",
+            **({"file_path": filename} if filename else {}),
+        )
+
+    if effective_mode == "always":
+        return await _run_ocr_service(file_bytes, mime_type, effective_mode)
+
+    # auto / fallback: try cheap text extraction, fall back to OCR if
+    # the result is missing or below the minimum length threshold.
+    try:
+        result = await TextExtractor(config_manager=config_manager).extract_text(
+            file_bytes=file_bytes,
+            mime_type=mime_type,
+            ocr_mode="text_only",
+            **({"file_path": filename} if filename else {}),
+        )
+        extracted_text = result.get("text", "")
+    except Exception:
+        extracted_text = ""
+        result = {"text": "", "metadata": {}}
+
+    if len(extracted_text.strip()) >= settings.ocr_fallback_min_text_length:
+        return result
+
+    return await _run_ocr_service(file_bytes, mime_type, effective_mode)
+
+
+async def _run_ocr_service(file_bytes: bytes, mime_type: str, ocr_mode: str) -> dict:
+    """Call the configured OCR service and return a result dict with timing."""
+    import time
+
+    start = time.monotonic()
+    ocr_service = get_ocr_service()
+    ocr_result = await ocr_service.extract_text(file_bytes, mime_type)
+    duration = time.monotonic() - start
+
+    return {
+        "text": ocr_result.text,
+        "metadata": {
+            "method": "ocr",
+            "engine": ocr_result.engine,
+            "confidence": ocr_result.confidence,
+            "duration": duration,
+            "details": {
+                "page_count": ocr_result.page_count,
+                "ocr_mode": ocr_mode,
+                "processing_time": duration,
+            },
+        },
+    }

--- a/backend/src/shu/core/ocr_service.py
+++ b/backend/src/shu/core/ocr_service.py
@@ -1,0 +1,95 @@
+"""OCRService protocol, OCRResult dataclass, and DI wiring.
+
+Provides an abstract interface for OCR text extraction with two backends:
+- ExternalOCRService: Mistral OCR via OpenRouter (when SHU_MISTRAL_OCR_API_KEY is set)
+- LocalOCRService: EasyOCR/Tesseract via TextExtractor (default fallback)
+
+DI wiring:
+    - get_ocr_service()  — singleton factory (workers, services, FastAPI Depends())
+    - reset_ocr_service() — test teardown
+"""
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from .config import get_settings_instance
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class OCRResult:
+    """Result of an OCR text extraction operation."""
+
+    text: str
+    engine: str
+    page_count: int | None = None
+    confidence: float | None = None
+
+
+@runtime_checkable
+class OCRService(Protocol):
+    """Protocol for OCR text extraction services."""
+
+    async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
+        """Extract text from a document using OCR.
+
+        Args:
+            file_bytes: Raw bytes of the document to process.
+            mime_type: MIME type of the document (e.g., "application/pdf", "image/png").
+
+        Returns:
+            OCRResult with extracted text and metadata.
+
+        """
+        ...
+
+
+# Module-level singleton
+_ocr_service: OCRService | None = None
+
+
+def get_ocr_service() -> OCRService:
+    """Get the configured OCR service (singleton).
+
+    Resolution is purely settings-based (no DB query), so this is sync.
+    SHU_MISTRAL_OCR_API_KEY set → ExternalOCRService, otherwise → LocalOCRService.
+
+    Usable everywhere: workers, services, FastAPI Depends().
+    """
+    global _ocr_service  # noqa: PLW0603
+
+    if _ocr_service is not None:
+        return _ocr_service
+
+    settings = get_settings_instance()
+
+    if settings.mistral_ocr_api_key:
+        from ..services.external_ocr_service import ExternalOCRService
+
+        logger.info(
+            "Using external OCR service (Mistral OCR)",
+            extra={
+                "model": settings.mistral_ocr_model,
+                "base_url": settings.mistral_ocr_base_url,
+            },
+        )
+        _ocr_service = ExternalOCRService(
+            api_key=settings.mistral_ocr_api_key,
+            api_base_url=settings.mistral_ocr_base_url,
+            model_name=settings.mistral_ocr_model,
+        )
+        return _ocr_service
+
+    from ..services.local_ocr_service import LocalOCRService
+
+    logger.info("Using local OCR service (EasyOCR/Tesseract)")
+    _ocr_service = LocalOCRService()
+    return _ocr_service
+
+
+def reset_ocr_service() -> None:
+    """Reset the OCR service singleton (for testing only)."""
+    global _ocr_service  # noqa: PLW0603
+    _ocr_service = None

--- a/backend/src/shu/llm/client.py
+++ b/backend/src/shu/llm/client.py
@@ -853,9 +853,9 @@ class UnifiedLLMClient:
             True if error is a capability mismatch, False otherwise.
 
         """
-        provider_message = (details.get("provider_message") or "").lower()
-        provider_error_type = (details.get("provider_error_type") or "").lower()
-        provider_error_code = (details.get("provider_error_code") or "").lower()
+        provider_message = str(details.get("provider_message") or "").lower()
+        provider_error_type = str(details.get("provider_error_type") or "").lower()
+        provider_error_code = str(details.get("provider_error_code") or "").lower()
 
         # Common patterns for vision capability mismatches
         vision_patterns = [

--- a/backend/src/shu/plugins/host/ocr_capability.py
+++ b/backend/src/shu/plugins/host/ocr_capability.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
-from ...processors.text_extractor import TextExtractor
+from ...core.logging import get_logger
+from ...core.ocr_service import extract_text_with_ocr_fallback
 from .base import ImmutableCapabilityMixin
 
 if TYPE_CHECKING:
     from ...core.config import ConfigurationManager
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Valid OCR mode values accepted by the ingestion pipeline.
 _VALID_OCR_MODES = {"auto", "always", "never", "fallback", "text_only"}
@@ -49,10 +49,10 @@ class OcrCapability(ImmutableCapabilityMixin):
     async def extract_text(self, *, file_bytes: bytes, mime_type: str, mode: str | None = None) -> dict[str, Any]:
         mm = (mode or self._ocr_mode or "auto").strip().lower()
 
-        extractor = TextExtractor(config_manager=self._config_manager)
-        res = await extractor.extract_text(
-            file_bytes=file_bytes,
-            mime_type=mime_type,
+        res = await extract_text_with_ocr_fallback(
+            file_bytes,
+            mime_type,
+            self._config_manager,
             ocr_mode=mm,
         )
 

--- a/backend/src/shu/processors/text_extractor.py
+++ b/backend/src/shu/processors/text_extractor.py
@@ -11,8 +11,6 @@ import time
 from pathlib import Path
 from typing import Any, ClassVar
 
-import easyocr
-
 from ..core.config import ConfigurationManager
 from ..core.logging import get_logger
 from ..ingestion.filetypes import (
@@ -54,7 +52,7 @@ class TextExtractor:
     # --- EasyOCR singleton management ---
     # The Reader loads ~1.5-2.5 GiB of models; creating one per call causes OOM
     # under concurrency.  We cache a single instance and guard init with an async lock.
-    _ocr_instance: ClassVar[easyocr.Reader | None] = None
+    _ocr_instance: ClassVar[Any] = None
     _ocr_init_lock: ClassVar[asyncio.Lock | None] = None
     _ocr_init_failed: ClassVar[bool] = False
 
@@ -103,7 +101,7 @@ class TextExtractor:
         return cls._ocr_init_lock
 
     @classmethod
-    async def get_ocr_instance(cls) -> easyocr.Reader | None:
+    async def get_ocr_instance(cls) -> Any:
         """Get or create the singleton EasyOCR Reader.
 
         Uses double-checked locking: fast path returns the cached instance without
@@ -135,6 +133,10 @@ class TextExtractor:
             try:
                 logger.info("Initializing EasyOCR singleton Reader")
                 loop = asyncio.get_running_loop()
+                # Deferred import: easyocr loads ~2GB of models on import,
+                # must not load when external OCR is configured.
+                import easyocr
+
                 instance = await loop.run_in_executor(None, lambda: easyocr.Reader(["en"]))
                 cls._ocr_instance = instance
                 logger.info("EasyOCR singleton Reader initialized successfully")

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -117,7 +117,7 @@ class ExternalEmbeddingService:
 
         prompt_tokens = usage.get("prompt_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
-        cost = usage.get("cost", 0)
+        cost = usage.get("cost")
 
         await record_llm_usage(
             provider_id=self._provider_id,
@@ -125,6 +125,16 @@ class ExternalEmbeddingService:
             request_type="embedding",
             input_tokens=prompt_tokens,
             total_tokens=total_tokens,
-            input_cost=Decimal(str(cost)),
-            total_cost=Decimal(str(cost)),
+            input_cost=_safe_decimal(cost),
+            total_cost=_safe_decimal(cost),
         )
+
+
+def _safe_decimal(value: Any) -> Decimal:
+    """Convert a value to Decimal, falling back to zero for None or non-numeric."""
+    if value is None:
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return Decimal("0")

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -113,30 +113,18 @@ class ExternalEmbeddingService:
         if not usage:
             return
 
-        try:
-            from ..core.database import get_async_session_local
-            from ..models.llm_provider import LLMUsage
+        from .usage_recording import record_llm_usage
 
-            prompt_tokens = usage.get("prompt_tokens", 0)
-            total_tokens = usage.get("total_tokens", 0)
-            cost = usage.get("cost", 0)
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        total_tokens = usage.get("total_tokens", 0)
+        cost = usage.get("cost", 0)
 
-            record = LLMUsage(
-                provider_id=self._provider_id,
-                model_id=self._model_id,
-                request_type="embedding",
-                input_tokens=prompt_tokens,
-                output_tokens=0,
-                total_tokens=total_tokens,
-                input_cost=Decimal(str(cost)),
-                output_cost=Decimal("0"),
-                total_cost=Decimal(str(cost)),
-                success=True,
-            )
-
-            session_factory = get_async_session_local()
-            async with session_factory() as session:
-                session.add(record)
-                await session.commit()
-        except Exception as e:
-            logger.warning("Failed to record embedding usage: %s", e)
+        await record_llm_usage(
+            provider_id=self._provider_id,
+            model_id=self._model_id,
+            request_type="embedding",
+            input_tokens=prompt_tokens,
+            total_tokens=total_tokens,
+            input_cost=Decimal(str(cost)),
+            total_cost=Decimal(str(cost)),
+        )

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -115,6 +115,16 @@ class ExternalEmbeddingService:
 
         from .usage_recording import record_llm_usage
 
+        # Always log the raw usage payload so costs can be reconstructed
+        # from logs if DB recording ever fails.
+        logger.info(
+            "Embedding API usage",
+            extra={
+                "model": self._model_name,
+                "raw_usage": usage,
+            },
+        )
+
         prompt_tokens = usage.get("prompt_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
         cost = usage.get("cost")

--- a/backend/src/shu/services/external_ocr_service.py
+++ b/backend/src/shu/services/external_ocr_service.py
@@ -40,6 +40,22 @@ _PROVIDER_TYPE_KEY = "generic_completions"
 _PROVIDER_NAME = "Mistral OCR (auto-provisioned)"
 
 
+def _coerce_non_negative_int(value: Any, fallback: int) -> int:
+    """Coerce an untrusted external value to a non-negative int, or use fallback.
+
+    The Mistral API's pages_processed field is user-facing billing data — we
+    can't assume it's always a well-formed int. Negative, missing, or
+    non-numeric values fall back to our own observed page count.
+    """
+    if value is None:
+        return fallback
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return coerced if coerced >= 0 else fallback
+
+
 class ExternalOCRService:
     """Calls Mistral OCR via Mistral's native /ocr API endpoint."""
 
@@ -115,10 +131,13 @@ class ExternalOCRService:
                 page_confidences.append(avg)
         confidence = sum(page_confidences) / len(page_confidences) if page_confidences else None
 
-        # Get pages processed from the reported usage stats so we record the usage correctly.
+        # pages_processed comes from the API — normalize it before cost math.
         usage_info = result.get("usage_info") or {}
-        pages_processed = usage_info.get("pages_processed", len(pages))
-        await self._record_usage(pages_processed)
+        pages_processed = _coerce_non_negative_int(
+            usage_info.get("pages_processed"),
+            fallback=len(pages),
+        )
+        await self._record_usage(pages_processed, usage_info=usage_info, observed_page_count=len(pages))
 
         return OCRResult(
             text="\n\n".join(page_texts),
@@ -161,12 +180,34 @@ class ExternalOCRService:
         )
         return False
 
-    async def _record_usage(self, page_count: int) -> None:
-        """Record OCR usage in llm_usage. Best-effort — failures are logged, not raised."""
+    async def _record_usage(
+        self,
+        page_count: int,
+        *,
+        usage_info: dict[str, Any] | None = None,
+        observed_page_count: int | None = None,
+    ) -> None:
+        """Record OCR usage in llm_usage. Best-effort — failures are logged, not raised.
+
+        Always logs the raw usage payload alongside the computed cost so costs
+        can be reconstructed from logs if DB recording ever fails.
+        """
+        total_cost = _COST_PER_PAGE * page_count
+
+        logger.info(
+            "Mistral OCR usage",
+            extra={
+                "model": self._model_name,
+                "raw_usage_info": usage_info or {},
+                "observed_page_count": observed_page_count,
+                "pages_billed": page_count,
+                "total_cost": str(total_cost),
+            },
+        )
+
         try:
             from ..core.database import get_async_session_local
 
-            total_cost = _COST_PER_PAGE * page_count
             session_factory = get_async_session_local()
             async with session_factory() as session:
                 if not await self._resolve_provider_and_model(session):

--- a/backend/src/shu/services/external_ocr_service.py
+++ b/backend/src/shu/services/external_ocr_service.py
@@ -127,38 +127,39 @@ class ExternalOCRService:
             confidence=confidence,
         )
 
-    async def _ensure_provider_and_model(self, session) -> None:
-        """Find or create the Mistral OCR provider and model records for usage tracking."""
-        if self._provider_id is not None:
-            return
+    async def _resolve_provider_and_model(self, session) -> bool:
+        """Look up pre-seeded provider and model records for usage tracking.
+
+        Returns True if both were found and cached, False otherwise.
+        Provider/model rows must be created by the hosting seed script;
+        this method only performs lookups to avoid races under concurrency.
+        """
+        if self._provider_id is not None and self._model_id is not None:
+            return True
 
         llm_service = LLMService(session)
 
         provider = await llm_service.get_provider_by_name(_PROVIDER_NAME)
         if provider is None:
-            provider = await llm_service.create_provider(
-                name=_PROVIDER_NAME,
-                provider_type=_PROVIDER_TYPE_KEY,
-                api_endpoint=self._api_base_url,
+            logger.error(
+                "Mistral OCR provider %r not found — seed it via the hosting script",
+                _PROVIDER_NAME,
             )
+            return False
 
         self._provider_id = provider.id
 
-        existing_model = None
         for m in provider.models:
             if m.model_name == self._model_name and m.model_type == ModelType.OCR:
-                existing_model = m
-                break
+                self._model_id = m.id
+                return True
 
-        if existing_model is None:
-            existing_model = await llm_service.create_model(
-                provider_id=provider.id,
-                model_name=self._model_name,
-                display_name="Mistral OCR",
-                model_type=ModelType.OCR,
-            )
-
-        self._model_id = existing_model.id
+        logger.error(
+            "Mistral OCR model %r not found on provider %s — seed it via the hosting script",
+            self._model_name,
+            provider.id,
+        )
+        return False
 
     async def _record_usage(self, page_count: int) -> None:
         """Record OCR usage in llm_usage. Best-effort — failures are logged, not raised."""
@@ -168,7 +169,8 @@ class ExternalOCRService:
             total_cost = _COST_PER_PAGE * page_count
             session_factory = get_async_session_local()
             async with session_factory() as session:
-                await self._ensure_provider_and_model(session)
+                if not await self._resolve_provider_and_model(session):
+                    return
                 await record_llm_usage(
                     provider_id=self._provider_id,
                     model_id=self._model_id,

--- a/backend/src/shu/services/external_ocr_service.py
+++ b/backend/src/shu/services/external_ocr_service.py
@@ -1,0 +1,15 @@
+"""ExternalOCRService — Mistral OCR via OpenRouter."""
+
+from shu.core.ocr_service import OCRResult
+
+
+class ExternalOCRService:
+    """Calls Mistral OCR via OpenRouter's chat completions API."""
+
+    def __init__(self, api_key: str, api_base_url: str, model_name: str) -> None:
+        self._api_key = api_key
+        self._api_base_url = api_base_url
+        self._model_name = model_name
+
+    async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
+        raise NotImplementedError("ExternalOCRService not yet implemented (task 11)")

--- a/backend/src/shu/services/external_ocr_service.py
+++ b/backend/src/shu/services/external_ocr_service.py
@@ -1,15 +1,182 @@
-"""ExternalOCRService — Mistral OCR via OpenRouter."""
+"""ExternalOCRService — Mistral OCR via Mistral's native OCR API.
 
-from shu.core.ocr_service import OCRResult
+Sends the entire document as a base64 data URL to Mistral's /ocr endpoint.
+The API handles PDF page splitting internally — no need to render pages
+to images on our side.
+
+Failures raise — no silent fallback to local. The worker retry mechanism
+handles transient errors.
+"""
+
+import base64
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+from ..core.logging import get_logger
+from ..core.ocr_service import OCRResult
+from ..llm.service import LLMService
+from ..models.llm_provider import ModelType
+from .usage_recording import record_llm_usage
+
+logger = get_logger(__name__)
+
+# $1 per 1000 pages
+_COST_PER_PAGE = Decimal("0.001")
+
+_MIME_TO_DATA_URL_PREFIX: dict[str, str] = {
+    "application/pdf": "data:application/pdf;base64,",
+    "image/png": "data:image/png;base64,",
+    "image/jpeg": "data:image/jpeg;base64,",
+    "image/jpg": "data:image/jpeg;base64,",
+    "image/gif": "data:image/gif;base64,",
+    "image/tiff": "data:image/tiff;base64,",
+    "image/bmp": "data:image/bmp;base64,",
+    "image/webp": "data:image/webp;base64,",
+}
+
+_PROVIDER_TYPE_KEY = "generic_completions"
+_PROVIDER_NAME = "Mistral OCR (auto-provisioned)"
 
 
 class ExternalOCRService:
-    """Calls Mistral OCR via OpenRouter's chat completions API."""
+    """Calls Mistral OCR via Mistral's native /ocr API endpoint."""
 
     def __init__(self, api_key: str, api_base_url: str, model_name: str) -> None:
         self._api_key = api_key
-        self._api_base_url = api_base_url
+        self._api_base_url = api_base_url.rstrip("/")
         self._model_name = model_name
+        self._provider_id: str | None = None
+        self._model_id: str | None = None
+
+    def __repr__(self) -> str:
+        """Redact API key to prevent leaking credentials in logs/tracebacks."""
+        return f"ExternalOCRService(model={self._model_name!r})"
 
     async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
-        raise NotImplementedError("ExternalOCRService not yet implemented (task 11)")
+        """Extract text by sending the document to Mistral's OCR API.
+
+        Args:
+            file_bytes: Raw bytes of the document to process.
+            mime_type: MIME type of the document.
+
+        Returns:
+            OCRResult with extracted text from all pages.
+
+        Raises:
+            httpx.HTTPStatusError: On API errors (4xx/5xx).
+            ValueError: On unsupported mime types.
+
+        """
+        prefix = _MIME_TO_DATA_URL_PREFIX.get(mime_type)
+        if prefix is None:
+            raise ValueError(
+                f"ExternalOCRService does not support mime type {mime_type!r}. "
+                f"Supported: {sorted(_MIME_TO_DATA_URL_PREFIX.keys())}"
+            )
+
+        b64 = base64.b64encode(file_bytes).decode("ascii")
+        data_url = f"{prefix}{b64}"
+
+        payload: dict[str, Any] = {
+            "model": self._model_name,
+            "document": {
+                "type": "document_url",
+                "document_url": data_url,
+            },
+            "confidence_scores_granularity": "page",
+            "table_format": None,  # inline MD tables
+            "include_image_base64": False,  # TODO: we may be able to support ingestion intelligence on images in the future?
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self._api_base_url}/ocr",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0),
+            )
+            response.raise_for_status()
+
+        result = response.json()
+        pages = result.get("pages", [])
+        page_texts = [page.get("markdown", "") for page in pages]
+
+        # Confidences are returned per page. We take the AVG of each and AVG those out.
+        page_confidences = []
+        for page in pages:
+            scores = page.get("confidence_scores") or {}
+            avg = scores.get("average_page_confidence_score")
+            if avg is not None:
+                page_confidences.append(avg)
+        confidence = sum(page_confidences) / len(page_confidences) if page_confidences else None
+
+        # Get pages processed from the reported usage stats so we record the usage correctly.
+        usage_info = result.get("usage_info") or {}
+        pages_processed = usage_info.get("pages_processed", len(pages))
+        await self._record_usage(pages_processed)
+
+        return OCRResult(
+            text="\n\n".join(page_texts),
+            engine=self._model_name,
+            page_count=len(pages),
+            confidence=confidence,
+        )
+
+    async def _ensure_provider_and_model(self, session) -> None:
+        """Find or create the Mistral OCR provider and model records for usage tracking."""
+        if self._provider_id is not None:
+            return
+
+        llm_service = LLMService(session)
+
+        provider = await llm_service.get_provider_by_name(_PROVIDER_NAME)
+        if provider is None:
+            provider = await llm_service.create_provider(
+                name=_PROVIDER_NAME,
+                provider_type=_PROVIDER_TYPE_KEY,
+                api_endpoint=self._api_base_url,
+            )
+
+        self._provider_id = provider.id
+
+        existing_model = None
+        for m in provider.models:
+            if m.model_name == self._model_name and m.model_type == ModelType.OCR:
+                existing_model = m
+                break
+
+        if existing_model is None:
+            existing_model = await llm_service.create_model(
+                provider_id=provider.id,
+                model_name=self._model_name,
+                display_name="Mistral OCR",
+                model_type=ModelType.OCR,
+            )
+
+        self._model_id = existing_model.id
+
+    async def _record_usage(self, page_count: int) -> None:
+        """Record OCR usage in llm_usage. Best-effort — failures are logged, not raised."""
+        try:
+            from ..core.database import get_async_session_local
+
+            total_cost = _COST_PER_PAGE * page_count
+            session_factory = get_async_session_local()
+            async with session_factory() as session:
+                await self._ensure_provider_and_model(session)
+                await record_llm_usage(
+                    provider_id=self._provider_id,
+                    model_id=self._model_id,
+                    request_type="ocr",
+                    input_cost=total_cost,
+                    total_cost=total_cost,
+                    request_metadata={"page_count": page_count},
+                    session=session,
+                )
+        except Exception as e:
+            logger.warning("Failed to record OCR usage: %s", e)

--- a/backend/src/shu/services/local_ocr_service.py
+++ b/backend/src/shu/services/local_ocr_service.py
@@ -1,0 +1,42 @@
+"""LocalOCRService — wraps existing EasyOCR/Tesseract via TextExtractor."""
+
+from shu.core.config import ConfigurationManager, get_config_manager
+from shu.core.logging import get_logger
+from shu.core.ocr_service import OCRResult
+
+logger = get_logger(__name__)
+
+
+class LocalOCRService:
+    """Delegates OCR to the existing TextExtractor pipeline."""
+
+    def __init__(self, config_manager: ConfigurationManager | None = None) -> None:
+        self._config_manager = config_manager or get_config_manager()
+
+    async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
+        """Extract text using local EasyOCR/Tesseract via TextExtractor.
+
+        Args:
+            file_bytes: Raw bytes of the document to process.
+            mime_type: MIME type of the document.
+
+        Returns:
+            OCRResult with extracted text and metadata.
+
+        """
+        from shu.processors.text_extractor import TextExtractor
+
+        extractor = TextExtractor(config_manager=self._config_manager)
+        result = await extractor.extract_text(
+            file_bytes=file_bytes,
+            mime_type=mime_type,
+            ocr_mode="auto",
+        )
+
+        metadata = result.get("metadata", {})
+        return OCRResult(
+            text=result.get("text", ""),
+            engine=metadata.get("engine", "unknown"),
+            page_count=metadata.get("details", {}).get("page_count"),
+            confidence=metadata.get("confidence"),
+        )

--- a/backend/src/shu/services/local_ocr_service.py
+++ b/backend/src/shu/services/local_ocr_service.py
@@ -1,8 +1,16 @@
-"""LocalOCRService — wraps existing EasyOCR/Tesseract via TextExtractor."""
+"""LocalOCRService — wraps existing EasyOCR/Tesseract via TextExtractor.
 
-from shu.core.config import ConfigurationManager, get_config_manager
-from shu.core.logging import get_logger
-from shu.core.ocr_service import OCRResult
+TODO: TextExtractor currently owns both text extraction AND OCR orchestration.
+LocalOCRService should own the local OCR path directly (EasyOCR/Tesseract),
+and TextExtractor should be reduced to non-OCR text extraction only.
+This avoids the round-trip where LocalOCRService calls TextExtractor with
+ocr_mode="auto", which re-enters the same OCR logic that should live here.
+"""
+
+from ..core.config import ConfigurationManager, get_config_manager
+from ..core.logging import get_logger
+from ..core.ocr_service import OCRResult
+from ..processors.text_extractor import TextExtractor
 
 logger = get_logger(__name__)
 
@@ -24,8 +32,6 @@ class LocalOCRService:
             OCRResult with extracted text and metadata.
 
         """
-        from shu.processors.text_extractor import TextExtractor
-
         extractor = TextExtractor(config_manager=self._config_manager)
         result = await extractor.extract_text(
             file_bytes=file_bytes,

--- a/backend/src/shu/services/usage_recording.py
+++ b/backend/src/shu/services/usage_recording.py
@@ -56,8 +56,9 @@ async def record_llm_usage(
         )
 
         if session is not None:
-            session.add(record)
-            await session.commit()
+            async with session.begin_nested():
+                session.add(record)
+                await session.flush()
         else:
             session_factory = get_async_session_local()
             async with session_factory() as new_session:

--- a/backend/src/shu/services/usage_recording.py
+++ b/backend/src/shu/services/usage_recording.py
@@ -1,0 +1,82 @@
+"""Shared helper for recording LLM/API usage in llm_usage.
+
+Best-effort: failures are logged, never raised, so callers don't
+break when the DB is temporarily unreachable.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from ..core.database import get_async_session_local
+from ..core.logging import get_logger
+from ..models.llm_provider import LLMUsage
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = get_logger(__name__)
+
+
+async def record_llm_usage(
+    *,
+    provider_id: str,
+    model_id: str,
+    request_type: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    total_tokens: int = 0,
+    input_cost: Decimal = Decimal("0"),
+    output_cost: Decimal = Decimal("0"),
+    total_cost: Decimal = Decimal("0"),
+    success: bool = True,
+    request_metadata: dict[str, Any] | None = None,
+    session: AsyncSession | None = None,
+) -> None:
+    """Insert a single LLMUsage row. Swallows all exceptions.
+
+    Pass an existing `session` to reuse a connection already checked out
+    (e.g. when the caller ran a query in the same unit of work).
+    When omitted, a fresh session is created and committed automatically.
+    """
+    try:
+        record = LLMUsage(
+            provider_id=provider_id,
+            model_id=model_id,
+            request_type=request_type,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+            input_cost=input_cost,
+            output_cost=output_cost,
+            total_cost=total_cost,
+            success=success,
+            request_metadata=request_metadata,
+        )
+
+        if session is not None:
+            session.add(record)
+            await session.commit()
+        else:
+            session_factory = get_async_session_local()
+            async with session_factory() as new_session:
+                new_session.add(record)
+                await new_session.commit()
+    except Exception as e:
+        # If we hit this we are in trouble, we'll probably want to try to aggregate this in whatever the hosting's CloudWatch equivalent is
+        logger.error(
+            "Failed to record usage: %s - %s",
+            request_type,
+            e,
+            extra={
+                "provider_id": provider_id,
+                "model_id": model_id,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": total_tokens,
+                "input_cost": str(input_cost),
+                "output_cost": str(output_cost),
+                "total_cost": str(total_cost),
+            },
+        )

--- a/backend/src/shu/worker.py
+++ b/backend/src/shu/worker.py
@@ -116,7 +116,6 @@ async def _handle_ocr_job(job) -> None:  # noqa: PLR0915
     from .core.queue_backend import get_queue_backend
     from .core.workload_routing import WorkloadType, enqueue_job
     from .models.document import Document, DocumentStatus
-    from .processors.text_extractor import TextExtractor
     from .services.file_staging_service import FileStagingError, FileStagingService
 
     # Validate required payload fields
@@ -202,15 +201,15 @@ async def _handle_ocr_job(job) -> None:  # noqa: PLR0915
                 },
             )
 
-            # Extract text using TextExtractor
-            extractor = TextExtractor(config_manager=get_config_manager())
+            from .core.ocr_service import extract_text_with_ocr_fallback
 
-            extraction_result = await extractor.extract_text(
-                file_path=filename,
-                file_bytes=file_bytes,
-                ocr_mode=ocr_mode,
+            extraction_result = await extract_text_with_ocr_fallback(
+                file_bytes,
+                mime_type,
+                get_config_manager(),
+                filename=filename,
+                ocr_mode=ocr_mode or "auto",
             )
-
             extracted_text = extraction_result.get("text", "")
             extraction_metadata = extraction_result.get("metadata", {})
 

--- a/backend/src/tests/unit/core/test_extract_text_with_ocr_fallback.py
+++ b/backend/src/tests/unit/core/test_extract_text_with_ocr_fallback.py
@@ -1,0 +1,244 @@
+"""Unit tests for extract_text_with_ocr_fallback and _run_ocr_service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shu.core.ocr_service import (
+    OCRResult,
+    _run_ocr_service,
+    extract_text_with_ocr_fallback,
+    reset_ocr_service,
+)
+
+
+def _mock_settings(min_text_length: int = 50):
+    settings = MagicMock()
+    settings.ocr_fallback_min_text_length = min_text_length
+    settings.mistral_ocr_api_key = None
+    return settings
+
+
+def _mock_text_extractor(text: str = "", metadata: dict | None = None):
+    """Return a patched TextExtractor class whose extract_text returns given text."""
+    mock_instance = MagicMock()
+    mock_instance.extract_text = AsyncMock(
+        return_value={
+            "text": text,
+            "metadata": metadata or {"method": "pdf_text", "engine": "pymupdf", "duration": 0.1},
+        }
+    )
+    mock_cls = MagicMock(return_value=mock_instance)
+    return mock_cls, mock_instance
+
+
+def _mock_ocr_service(text: str = "OCR result", engine: str = "mistral-ocr"):
+    svc = MagicMock()
+    svc.extract_text = AsyncMock(
+        return_value=OCRResult(text=text, engine=engine, page_count=1, confidence=0.95)
+    )
+    return svc
+
+
+class TestExtractTextNeverMode:
+    """text_only and never modes should never call the OCR service."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["never", "text_only"])
+    async def test_never_calls_ocr(self, mode):
+        mock_cls, mock_instance = _mock_text_extractor("Some extracted text")
+        mock_settings = _mock_settings()
+        config_manager = MagicMock()
+
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service") as mock_get_ocr,
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", config_manager, ocr_mode=mode,
+            )
+
+        assert result["text"] == "Some extracted text"
+        mock_get_ocr.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_never_mode_returns_empty_when_no_text(self):
+        mock_cls, _ = _mock_text_extractor("")
+        mock_settings = _mock_settings()
+        config_manager = MagicMock()
+
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service") as mock_get_ocr,
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", config_manager, ocr_mode="never",
+            )
+
+        assert result["text"] == ""
+        mock_get_ocr.assert_not_called()
+
+
+class TestExtractTextAlwaysMode:
+    """always mode should skip text extraction and go directly to OCR."""
+
+    @pytest.mark.asyncio
+    async def test_always_skips_text_extraction(self):
+        ocr_svc = _mock_ocr_service("OCR text")
+        mock_settings = _mock_settings()
+
+        with (
+            patch("shu.core.ocr_service.TextExtractor") as mock_cls,
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service", return_value=ocr_svc),
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", MagicMock(), ocr_mode="always",
+            )
+
+        mock_cls.assert_not_called()
+        assert result["text"] == "OCR text"
+        assert result["metadata"]["method"] == "ocr"
+
+
+class TestExtractTextAutoFallbackMode:
+    """auto and fallback modes try text extraction first, OCR if insufficient."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["auto", "fallback"])
+    async def test_sufficient_text_skips_ocr(self, mode):
+        long_text = "A" * 100
+        mock_cls, _ = _mock_text_extractor(long_text)
+        mock_settings = _mock_settings(min_text_length=50)
+        config_manager = MagicMock()
+
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service") as mock_get_ocr,
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", config_manager, ocr_mode=mode,
+            )
+
+        assert result["text"] == long_text
+        mock_get_ocr.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mode", ["auto", "fallback"])
+    async def test_insufficient_text_triggers_ocr(self, mode):
+        short_text = "tiny"
+        mock_cls, _ = _mock_text_extractor(short_text)
+        mock_settings = _mock_settings(min_text_length=50)
+        ocr_svc = _mock_ocr_service("Full OCR text")
+
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service", return_value=ocr_svc),
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", MagicMock(), ocr_mode=mode,
+            )
+
+        assert result["text"] == "Full OCR text"
+        assert result["metadata"]["method"] == "ocr"
+
+    @pytest.mark.asyncio
+    async def test_empty_text_triggers_ocr(self):
+        mock_cls, _ = _mock_text_extractor("")
+        mock_settings = _mock_settings()
+        ocr_svc = _mock_ocr_service("OCR from empty")
+
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service", return_value=ocr_svc),
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", MagicMock(), ocr_mode="auto",
+            )
+
+        assert result["text"] == "OCR from empty"
+
+    @pytest.mark.asyncio
+    async def test_text_extraction_exception_falls_back_to_ocr(self):
+        """UnsupportedFileFormatError or other exceptions should trigger OCR."""
+        mock_instance = MagicMock()
+        mock_instance.extract_text = AsyncMock(
+            side_effect=RuntimeError("Unsupported format")
+        )
+        mock_cls = MagicMock(return_value=mock_instance)
+        mock_settings = _mock_settings()
+        ocr_svc = _mock_ocr_service("OCR after error")
+
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service", return_value=ocr_svc),
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"image-bytes", "image/png", MagicMock(), ocr_mode="auto",
+            )
+
+        assert result["text"] == "OCR after error"
+        assert result["metadata"]["method"] == "ocr"
+
+    @pytest.mark.asyncio
+    async def test_configurable_threshold(self):
+        """Threshold from settings should control the cutoff."""
+        mock_cls, _ = _mock_text_extractor("A" * 30)
+        ocr_svc = _mock_ocr_service("OCR text")
+
+        # With threshold=20, 30 chars is sufficient
+        mock_settings = _mock_settings(min_text_length=20)
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service") as mock_get_ocr,
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", MagicMock(), ocr_mode="auto",
+            )
+        assert result["text"] == "A" * 30
+        mock_get_ocr.assert_not_called()
+
+        # With threshold=50, 30 chars is insufficient
+        mock_settings = _mock_settings(min_text_length=50)
+        with (
+            patch("shu.core.ocr_service.TextExtractor", mock_cls),
+            patch("shu.core.ocr_service.get_settings_instance", return_value=mock_settings),
+            patch("shu.core.ocr_service.get_ocr_service", return_value=ocr_svc),
+        ):
+            result = await extract_text_with_ocr_fallback(
+                b"pdf-bytes", "application/pdf", MagicMock(), ocr_mode="auto",
+            )
+        assert result["text"] == "OCR text"
+
+
+class TestRunOCRService:
+    """Test _run_ocr_service timing and metadata shape."""
+
+    def setup_method(self):
+        reset_ocr_service()
+
+    def teardown_method(self):
+        reset_ocr_service()
+
+    @pytest.mark.asyncio
+    async def test_returns_duration_in_metadata(self):
+        ocr_svc = _mock_ocr_service("text", engine="mistral-ocr-latest")
+
+        with patch("shu.core.ocr_service.get_ocr_service", return_value=ocr_svc):
+            result = await _run_ocr_service(b"data", "application/pdf", "auto")
+
+        assert result["metadata"]["method"] == "ocr"
+        assert result["metadata"]["engine"] == "mistral-ocr-latest"
+        assert result["metadata"]["confidence"] == 0.95
+        assert "duration" in result["metadata"]
+        assert result["metadata"]["duration"] > 0
+        assert result["metadata"]["details"]["page_count"] == 1
+        assert result["metadata"]["details"]["ocr_mode"] == "auto"
+        assert result["metadata"]["details"]["processing_time"] > 0

--- a/backend/src/tests/unit/core/test_ocr_service.py
+++ b/backend/src/tests/unit/core/test_ocr_service.py
@@ -1,0 +1,160 @@
+"""Unit tests for OCRService protocol and DI wiring.
+
+Tests cover:
+- OCRService protocol conformance
+- OCRResult dataclass
+- DI wiring (get_ocr_service, reset_ocr_service)
+- Service resolution logic (API key set → external, absent → local)
+"""
+
+from unittest.mock import MagicMock, patch
+
+from shu.core.ocr_service import (
+    OCRResult,
+    OCRService,
+    get_ocr_service,
+    reset_ocr_service,
+)
+
+
+class _ConformingOCRService:
+    """Minimal class that satisfies the OCRService protocol."""
+
+    async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
+        return OCRResult(text="hello", engine="test")
+
+
+class _NonConformingService:
+    """Class that does NOT satisfy the OCRService protocol."""
+
+    async def do_something(self) -> None:
+        pass
+
+
+class TestOCRServiceProtocol:
+    """Test OCRService protocol conformance checks."""
+
+    def test_conforming_class_passes_isinstance(self):
+        assert isinstance(_ConformingOCRService(), OCRService)
+
+    def test_non_conforming_class_fails_isinstance(self):
+        assert not isinstance(_NonConformingService(), OCRService)
+
+    def test_protocol_is_runtime_checkable(self):
+        assert hasattr(OCRService, "__protocol_attrs__") or hasattr(
+            OCRService, "_is_runtime_protocol"
+        )
+
+
+class TestOCRResult:
+    """Test OCRResult dataclass."""
+
+    def test_required_fields(self):
+        result = OCRResult(text="extracted", engine="easyocr")
+        assert result.text == "extracted"
+        assert result.engine == "easyocr"
+        assert result.page_count is None
+        assert result.confidence is None
+
+    def test_all_fields(self):
+        result = OCRResult(
+            text="extracted", engine="mistral-ocr", page_count=3, confidence=0.95
+        )
+        assert result.page_count == 3
+        assert result.confidence == 0.95
+
+
+class TestGetOCRService:
+    """Test get_ocr_service() singleton and resolution logic."""
+
+    def setup_method(self):
+        reset_ocr_service()
+
+    def teardown_method(self):
+        reset_ocr_service()
+
+    @patch("shu.core.ocr_service.get_settings_instance")
+    def test_returns_singleton(self, mock_settings):
+        """Two calls should return the same instance."""
+        settings = MagicMock()
+        settings.mistral_ocr_api_key = None
+        mock_settings.return_value = settings
+
+        svc1 = get_ocr_service()
+        svc2 = get_ocr_service()
+
+        assert svc1 is svc2
+
+    def test_reset_clears_singleton(self):
+        import shu.core.ocr_service as mod
+
+        mod._ocr_service = MagicMock(spec=OCRService)
+        assert mod._ocr_service is not None
+
+        reset_ocr_service()
+        assert mod._ocr_service is None
+
+    def test_returns_cached_singleton(self):
+        import shu.core.ocr_service as mod
+
+        mock_svc = MagicMock(spec=OCRService)
+        mod._ocr_service = mock_svc
+
+        assert get_ocr_service() is mock_svc
+
+    @patch("shu.core.ocr_service.get_settings_instance")
+    def test_api_key_set_uses_external(self, mock_settings):
+        """When SHU_MISTRAL_OCR_API_KEY is set, ExternalOCRService is used."""
+        settings = MagicMock()
+        settings.mistral_ocr_api_key = "sk-test-key"
+        settings.mistral_ocr_base_url = "https://openrouter.ai/api/v1"
+        settings.mistral_ocr_model = "mistralai/mistral-ocr-latest"
+        mock_settings.return_value = settings
+
+        svc = get_ocr_service()
+
+        from shu.services.external_ocr_service import ExternalOCRService
+
+        assert isinstance(svc, ExternalOCRService)
+        assert svc._api_key == "sk-test-key"
+        assert svc._model_name == "mistralai/mistral-ocr-latest"
+
+    @patch("shu.core.ocr_service.get_settings_instance")
+    def test_no_api_key_uses_local(self, mock_settings):
+        """When SHU_MISTRAL_OCR_API_KEY is not set, LocalOCRService is used."""
+        settings = MagicMock()
+        settings.mistral_ocr_api_key = None
+        mock_settings.return_value = settings
+
+        svc = get_ocr_service()
+
+        from shu.services.local_ocr_service import LocalOCRService
+
+        assert isinstance(svc, LocalOCRService)
+
+    @patch("shu.core.ocr_service.get_settings_instance")
+    def test_empty_string_api_key_uses_local(self, mock_settings):
+        """An empty string API key should fall back to local."""
+        settings = MagicMock()
+        settings.mistral_ocr_api_key = ""
+        mock_settings.return_value = settings
+
+        svc = get_ocr_service()
+
+        from shu.services.local_ocr_service import LocalOCRService
+
+        assert isinstance(svc, LocalOCRService)
+
+    @patch("shu.core.ocr_service.get_settings_instance")
+    def test_external_singleton_returns_same_instance(self, mock_settings):
+        """External service should be cached as a singleton across calls."""
+        settings = MagicMock()
+        settings.mistral_ocr_api_key = "sk-test"
+        settings.mistral_ocr_base_url = "https://openrouter.ai/api/v1"
+        settings.mistral_ocr_model = "mistralai/mistral-ocr-latest"
+        mock_settings.return_value = settings
+
+        svc1 = get_ocr_service()
+        svc2 = get_ocr_service()
+
+        assert svc1 is svc2

--- a/backend/src/tests/unit/services/test_external_ocr_service.py
+++ b/backend/src/tests/unit/services/test_external_ocr_service.py
@@ -1,0 +1,326 @@
+"""Unit tests for ExternalOCRService."""
+
+import base64
+from contextlib import contextmanager
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from shu.core.ocr_service import OCRResult
+from shu.services.external_ocr_service import ExternalOCRService, _COST_PER_PAGE
+
+
+def _make_service(**kwargs) -> ExternalOCRService:
+    defaults = {
+        "api_key": "sk-test",
+        "api_base_url": "https://api.mistral.ai/v1",
+        "model_name": "mistral-ocr-latest",
+    }
+    defaults.update(kwargs)
+    return ExternalOCRService(**defaults)
+
+
+def _mock_ocr_response(pages: list[dict]) -> httpx.Response:
+    """Build a mock httpx.Response with the given pages."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = {"pages": pages}
+    response.raise_for_status = MagicMock()
+    return response
+
+
+@contextmanager
+def _patched_httpx(response):
+    """Patch httpx.AsyncClient to return a mock that yields `response` on post."""
+    with patch("shu.services.external_ocr_service.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = response
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        yield mock_client
+
+
+class TestExternalOCRService:
+    """Test ExternalOCRService API calls and response parsing."""
+
+    @pytest.mark.asyncio
+    async def test_extract_text_pdf(self):
+        """Should send PDF as base64 data URL and parse page markdown."""
+        pdf_bytes = b"%PDF-fake-content"
+        response = _mock_ocr_response([
+            {"index": 0, "markdown": "Page one text"},
+            {"index": 1, "markdown": "Page two text"},
+        ])
+
+        svc = _make_service()
+
+        with _patched_httpx(response) as mock_client:
+            result = await svc.extract_text(pdf_bytes, "application/pdf")
+
+        assert isinstance(result, OCRResult)
+        assert result.text == "Page one text\n\nPage two text"
+        assert result.engine == "mistral-ocr-latest"
+        assert result.page_count == 2
+        assert result.confidence is None
+
+        call_kwargs = mock_client.post.call_args
+        assert call_kwargs[0][0] == "https://api.mistral.ai/v1/ocr"
+        payload = call_kwargs[1]["json"]
+        assert payload["model"] == "mistral-ocr-latest"
+        assert payload["document"]["type"] == "document_url"
+        expected_b64 = base64.b64encode(pdf_bytes).decode("ascii")
+        assert payload["document"]["document_url"] == f"data:application/pdf;base64,{expected_b64}"
+
+    @pytest.mark.asyncio
+    async def test_extract_text_image(self):
+        """Should send image bytes as base64 data URL."""
+        image_bytes = b"\x89PNG\r\n\x1a\n"
+        response = _mock_ocr_response([
+            {"index": 0, "markdown": "Image text"},
+        ])
+
+        svc = _make_service()
+
+        with _patched_httpx(response) as mock_client:
+            result = await svc.extract_text(image_bytes, "image/png")
+
+        assert result.text == "Image text"
+        assert result.page_count == 1
+
+        payload = mock_client.post.call_args[1]["json"]
+        expected_b64 = base64.b64encode(image_bytes).decode("ascii")
+        assert payload["document"]["document_url"] == f"data:image/png;base64,{expected_b64}"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_mime_type_raises(self):
+        svc = _make_service()
+        with pytest.raises(ValueError, match="does not support mime type"):
+            await svc.extract_text(b"data", "text/plain")
+
+    @pytest.mark.asyncio
+    async def test_http_error_propagates(self):
+        """API errors must raise, not be swallowed."""
+        svc = _make_service()
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=mock_response
+        )
+
+        with _patched_httpx(mock_response):
+            with pytest.raises(httpx.HTTPStatusError):
+                await svc.extract_text(b"%PDF-content", "application/pdf")
+
+    @pytest.mark.asyncio
+    async def test_empty_pages_response(self):
+        """Should handle response with no pages gracefully."""
+        response = _mock_ocr_response([])
+        svc = _make_service()
+
+        with _patched_httpx(response):
+            result = await svc.extract_text(b"%PDF-content", "application/pdf")
+
+        assert result.text == ""
+        assert result.page_count == 0
+
+    @pytest.mark.asyncio
+    async def test_auth_header(self):
+        """Should send Bearer token in Authorization header."""
+        response = _mock_ocr_response([{"markdown": "text"}])
+        svc = _make_service(api_key="sk-secret-key")
+
+        with _patched_httpx(response) as mock_client:
+            await svc.extract_text(b"data", "image/jpeg")
+
+        headers = mock_client.post.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer sk-secret-key"
+
+    def test_base_url_trailing_slash_stripped(self):
+        svc = ExternalOCRService(
+            api_key="k", api_base_url="https://api.mistral.ai/v1/", model_name="m"
+        )
+        assert svc._api_base_url == "https://api.mistral.ai/v1"
+
+    @pytest.mark.asyncio
+    async def test_confidence_score_aggregation(self):
+        """Should compute average confidence across pages with scores."""
+        response = _mock_ocr_response([
+            {
+                "markdown": "Page 1",
+                "confidence_scores": {"average_page_confidence_score": 0.90},
+            },
+            {
+                "markdown": "Page 2",
+                "confidence_scores": {"average_page_confidence_score": 0.80},
+            },
+            {
+                "markdown": "Page 3",
+                "confidence_scores": {},
+            },
+        ])
+
+        svc = _make_service()
+
+        with _patched_httpx(response):
+            result = await svc.extract_text(b"%PDF-content", "application/pdf")
+
+        assert result.confidence == pytest.approx(0.85)
+        assert result.page_count == 3
+
+
+class TestUsageRecording:
+    """Test that OCR usage is recorded with correct cost."""
+
+    @pytest.mark.asyncio
+    async def test_record_usage_inserts_correct_cost(self):
+        """_record_usage should record via shared helper with per-page cost."""
+        svc = _make_service()
+        svc._provider_id = "provider-123"
+        svc._model_id = "model-456"
+
+        mock_session = AsyncMock()
+        mock_session_factory = MagicMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "shu.core.database.get_async_session_local",
+            return_value=mock_session_factory,
+        ), patch(
+            "shu.services.usage_recording.get_async_session_local",
+            return_value=mock_session_factory,
+        ):
+            await svc._record_usage(page_count=5)
+
+        assert mock_session.add.call_count == 1
+        record = mock_session.add.call_args[0][0]
+        assert record.provider_id == "provider-123"
+        assert record.model_id == "model-456"
+        assert record.request_type == "ocr"
+        assert record.total_cost == _COST_PER_PAGE * 5
+        assert record.input_cost == _COST_PER_PAGE * 5
+        assert record.output_cost == Decimal("0")
+        assert record.request_metadata == {"page_count": 5}
+        assert record.success is True
+
+    @pytest.mark.asyncio
+    async def test_record_usage_calls_ensure_provider(self):
+        """_record_usage should call _ensure_provider_and_model on first use."""
+        svc = _make_service()
+        assert svc._provider_id is None
+
+        with patch.object(svc, "_ensure_provider_and_model", new_callable=AsyncMock) as mock_ensure:
+            await svc._record_usage(page_count=1)
+
+        mock_ensure.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_record_usage_failure_is_logged_not_raised(self):
+        """Usage recording failures should not propagate to the caller."""
+        svc = _make_service()
+        svc._provider_id = "p"
+        svc._model_id = "m"
+
+        with patch(
+            "shu.core.database.get_async_session_local",
+            side_effect=RuntimeError("DB down"),
+        ):
+            await svc._record_usage(page_count=3)
+
+    @pytest.mark.asyncio
+    async def test_extract_text_calls_record_usage(self):
+        """extract_text should call _record_usage with the page count."""
+        response = _mock_ocr_response([
+            {"markdown": "Page 1"},
+            {"markdown": "Page 2"},
+            {"markdown": "Page 3"},
+        ])
+        svc = _make_service()
+
+        with _patched_httpx(response):
+            with patch.object(svc, "_record_usage", new_callable=AsyncMock) as mock_record:
+                await svc.extract_text(b"%PDF-content", "application/pdf")
+
+        mock_record.assert_called_once_with(3)
+
+
+class TestEnsureProviderAndModel:
+    """Test _ensure_provider_and_model provider/model auto-provisioning."""
+
+    @pytest.mark.asyncio
+    async def test_creates_provider_and_model_when_missing(self):
+        """Should create both provider and model if neither exists."""
+        svc = _make_service()
+        assert svc._provider_id is None
+
+        mock_provider = MagicMock()
+        mock_provider.id = "new-provider-id"
+        mock_provider.models = []
+
+        mock_model = MagicMock()
+        mock_model.id = "new-model-id"
+
+        mock_llm_service = MagicMock()
+        mock_llm_service.get_provider_by_name = AsyncMock(return_value=None)
+        mock_llm_service.create_provider = AsyncMock(return_value=mock_provider)
+        mock_llm_service.create_model = AsyncMock(return_value=mock_model)
+
+        mock_session = AsyncMock()
+
+        with patch("shu.services.external_ocr_service.LLMService", return_value=mock_llm_service):
+            await svc._ensure_provider_and_model(mock_session)
+
+        assert svc._provider_id == "new-provider-id"
+        assert svc._model_id == "new-model-id"
+        mock_llm_service.create_provider.assert_called_once()
+        mock_llm_service.create_model.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reuses_existing_provider_and_model(self):
+        """Should reuse existing provider and model if they already exist."""
+        svc = _make_service()
+
+        mock_model = MagicMock()
+        mock_model.id = "existing-model-id"
+        mock_model.model_name = "mistral-ocr-latest"
+        mock_model.model_type = MagicMock()
+        mock_model.model_type.value = "ocr"
+
+        # Make model_type comparison work
+        from shu.models.llm_provider import ModelType
+        mock_model.model_type = ModelType.OCR
+
+        mock_provider = MagicMock()
+        mock_provider.id = "existing-provider-id"
+        mock_provider.models = [mock_model]
+
+        mock_llm_service = MagicMock()
+        mock_llm_service.get_provider_by_name = AsyncMock(return_value=mock_provider)
+
+        mock_session = AsyncMock()
+
+        with patch("shu.services.external_ocr_service.LLMService", return_value=mock_llm_service):
+            await svc._ensure_provider_and_model(mock_session)
+
+        assert svc._provider_id == "existing-provider-id"
+        assert svc._model_id == "existing-model-id"
+        mock_llm_service.create_provider.assert_not_called()
+        mock_llm_service.create_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_cached(self):
+        """Should return immediately if provider_id is already set."""
+        svc = _make_service()
+        svc._provider_id = "cached-p"
+        svc._model_id = "cached-m"
+
+        mock_session = AsyncMock()
+
+        with patch("shu.services.external_ocr_service.LLMService") as mock_cls:
+            await svc._ensure_provider_and_model(mock_session)
+
+        mock_cls.assert_not_called()
+        assert svc._provider_id == "cached-p"

--- a/backend/src/tests/unit/services/test_external_ocr_service.py
+++ b/backend/src/tests/unit/services/test_external_ocr_service.py
@@ -182,6 +182,12 @@ class TestUsageRecording:
         svc._model_id = "model-456"
 
         mock_session = AsyncMock()
+        # begin_nested() is sync, returns an async context manager (AsyncSessionTransaction)
+        mock_savepoint = MagicMock()
+        mock_savepoint.__aenter__ = AsyncMock()
+        mock_savepoint.__aexit__ = AsyncMock(return_value=False)
+        mock_session.begin_nested = MagicMock(return_value=mock_savepoint)
+
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -189,13 +195,10 @@ class TestUsageRecording:
         with patch(
             "shu.core.database.get_async_session_local",
             return_value=mock_session_factory,
-        ), patch(
-            "shu.services.usage_recording.get_async_session_local",
-            return_value=mock_session_factory,
         ):
             await svc._record_usage(page_count=5)
 
-        assert mock_session.add.call_count == 1
+        mock_session.add.assert_called_once()
         record = mock_session.add.call_args[0][0]
         assert record.provider_id == "provider-123"
         assert record.model_id == "model-456"
@@ -208,11 +211,19 @@ class TestUsageRecording:
 
     @pytest.mark.asyncio
     async def test_record_usage_calls_ensure_provider(self):
-        """_record_usage should call _ensure_provider_and_model on first use."""
+        """_record_usage should call _resolve_provider_and_model on first use."""
         svc = _make_service()
         assert svc._provider_id is None
 
-        with patch.object(svc, "_ensure_provider_and_model", new_callable=AsyncMock) as mock_ensure:
+        mock_session = AsyncMock()
+        mock_session_factory = MagicMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "shu.core.database.get_async_session_local",
+            return_value=mock_session_factory,
+        ), patch.object(svc, "_resolve_provider_and_model", new_callable=AsyncMock) as mock_ensure:
             await svc._record_usage(page_count=1)
 
         mock_ensure.assert_called_once()
@@ -247,40 +258,49 @@ class TestUsageRecording:
         mock_record.assert_called_once_with(3)
 
 
-class TestEnsureProviderAndModel:
-    """Test _ensure_provider_and_model provider/model auto-provisioning."""
+class TestResolveProviderAndModel:
+    """Test _resolve_provider_and_model lookup-only behavior."""
 
     @pytest.mark.asyncio
-    async def test_creates_provider_and_model_when_missing(self):
-        """Should create both provider and model if neither exists."""
+    async def test_returns_false_when_provider_missing(self):
+        """Should return False and not cache IDs when provider not seeded."""
         svc = _make_service()
-        assert svc._provider_id is None
-
-        mock_provider = MagicMock()
-        mock_provider.id = "new-provider-id"
-        mock_provider.models = []
-
-        mock_model = MagicMock()
-        mock_model.id = "new-model-id"
 
         mock_llm_service = MagicMock()
         mock_llm_service.get_provider_by_name = AsyncMock(return_value=None)
-        mock_llm_service.create_provider = AsyncMock(return_value=mock_provider)
-        mock_llm_service.create_model = AsyncMock(return_value=mock_model)
 
         mock_session = AsyncMock()
 
         with patch("shu.services.external_ocr_service.LLMService", return_value=mock_llm_service):
-            await svc._ensure_provider_and_model(mock_session)
+            result = await svc._resolve_provider_and_model(mock_session)
 
-        assert svc._provider_id == "new-provider-id"
-        assert svc._model_id == "new-model-id"
-        mock_llm_service.create_provider.assert_called_once()
-        mock_llm_service.create_model.assert_called_once()
+        assert result is False
+        assert svc._provider_id is None
 
     @pytest.mark.asyncio
-    async def test_reuses_existing_provider_and_model(self):
-        """Should reuse existing provider and model if they already exist."""
+    async def test_returns_false_when_model_missing(self):
+        """Should return False when provider exists but model not seeded."""
+        svc = _make_service()
+
+        mock_provider = MagicMock()
+        mock_provider.id = "provider-id"
+        mock_provider.models = []
+
+        mock_llm_service = MagicMock()
+        mock_llm_service.get_provider_by_name = AsyncMock(return_value=mock_provider)
+
+        mock_session = AsyncMock()
+
+        with patch("shu.services.external_ocr_service.LLMService", return_value=mock_llm_service):
+            result = await svc._resolve_provider_and_model(mock_session)
+
+        assert result is False
+        assert svc._provider_id == "provider-id"
+        assert svc._model_id is None
+
+    @pytest.mark.asyncio
+    async def test_finds_existing_provider_and_model(self):
+        """Should cache IDs and return True when both are seeded."""
         svc = _make_service()
 
         mock_model = MagicMock()
@@ -303,7 +323,7 @@ class TestEnsureProviderAndModel:
         mock_session = AsyncMock()
 
         with patch("shu.services.external_ocr_service.LLMService", return_value=mock_llm_service):
-            await svc._ensure_provider_and_model(mock_session)
+            await svc._resolve_provider_and_model(mock_session)
 
         assert svc._provider_id == "existing-provider-id"
         assert svc._model_id == "existing-model-id"
@@ -320,7 +340,7 @@ class TestEnsureProviderAndModel:
         mock_session = AsyncMock()
 
         with patch("shu.services.external_ocr_service.LLMService") as mock_cls:
-            await svc._ensure_provider_and_model(mock_session)
+            await svc._resolve_provider_and_model(mock_session)
 
         mock_cls.assert_not_called()
         assert svc._provider_id == "cached-p"

--- a/backend/src/tests/unit/services/test_external_ocr_service.py
+++ b/backend/src/tests/unit/services/test_external_ocr_service.py
@@ -255,7 +255,7 @@ class TestUsageRecording:
             with patch.object(svc, "_record_usage", new_callable=AsyncMock) as mock_record:
                 await svc.extract_text(b"%PDF-content", "application/pdf")
 
-        mock_record.assert_called_once_with(3)
+        mock_record.assert_called_once_with(3, usage_info={}, observed_page_count=3)
 
 
 class TestResolveProviderAndModel:

--- a/backend/src/tests/unit/services/test_local_ocr_service.py
+++ b/backend/src/tests/unit/services/test_local_ocr_service.py
@@ -31,7 +31,7 @@ class TestLocalOCRService:
         svc = LocalOCRService(config_manager=config_manager)
 
         with patch(
-            "shu.processors.text_extractor.TextExtractor",
+            "shu.services.local_ocr_service.TextExtractor",
             return_value=mock_extractor,
         ) as mock_cls:
             result = await svc.extract_text(b"pdf bytes", "application/pdf")
@@ -61,7 +61,7 @@ class TestLocalOCRService:
         svc = LocalOCRService(config_manager=config_manager)
 
         with patch(
-            "shu.processors.text_extractor.TextExtractor",
+            "shu.services.local_ocr_service.TextExtractor",
             return_value=mock_extractor,
         ):
             result = await svc.extract_text(b"data", "image/png")
@@ -81,7 +81,7 @@ class TestLocalOCRService:
         svc = LocalOCRService(config_manager=config_manager)
 
         with patch(
-            "shu.processors.text_extractor.TextExtractor",
+            "shu.services.local_ocr_service.TextExtractor",
             return_value=mock_extractor,
         ):
             with pytest.raises(RuntimeError, match="OCR failed"):

--- a/backend/src/tests/unit/services/test_local_ocr_service.py
+++ b/backend/src/tests/unit/services/test_local_ocr_service.py
@@ -1,0 +1,97 @@
+"""Unit tests for LocalOCRService."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shu.core.ocr_service import OCRResult
+from shu.services.local_ocr_service import LocalOCRService
+
+
+class TestLocalOCRService:
+    """Test LocalOCRService delegates to TextExtractor correctly."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_text_extractor(self):
+        """extract_text should call TextExtractor.extract_text with correct params."""
+        mock_extractor = MagicMock()
+        mock_extractor.extract_text = AsyncMock(
+            return_value={
+                "text": "extracted text",
+                "metadata": {
+                    "method": "ocr",
+                    "engine": "easyocr",
+                    "confidence": 0.85,
+                    "details": {"page_count": 2},
+                },
+            }
+        )
+
+        config_manager = MagicMock()
+        svc = LocalOCRService(config_manager=config_manager)
+
+        with patch(
+            "shu.processors.text_extractor.TextExtractor",
+            return_value=mock_extractor,
+        ) as mock_cls:
+            result = await svc.extract_text(b"pdf bytes", "application/pdf")
+
+        mock_cls.assert_called_once_with(config_manager=config_manager)
+        mock_extractor.extract_text.assert_called_once_with(
+            file_bytes=b"pdf bytes",
+            mime_type="application/pdf",
+            ocr_mode="auto",
+        )
+
+        assert isinstance(result, OCRResult)
+        assert result.text == "extracted text"
+        assert result.engine == "easyocr"
+        assert result.confidence == 0.85
+        assert result.page_count == 2
+
+    @pytest.mark.asyncio
+    async def test_maps_result_with_missing_metadata(self):
+        """Should handle missing metadata fields gracefully."""
+        mock_extractor = MagicMock()
+        mock_extractor.extract_text = AsyncMock(
+            return_value={"text": "some text", "metadata": {}}
+        )
+
+        config_manager = MagicMock()
+        svc = LocalOCRService(config_manager=config_manager)
+
+        with patch(
+            "shu.processors.text_extractor.TextExtractor",
+            return_value=mock_extractor,
+        ):
+            result = await svc.extract_text(b"data", "image/png")
+
+        assert result.text == "some text"
+        assert result.engine == "unknown"
+        assert result.confidence is None
+        assert result.page_count is None
+
+    @pytest.mark.asyncio
+    async def test_propagates_exceptions(self):
+        """Errors from TextExtractor should propagate, not be swallowed."""
+        mock_extractor = MagicMock()
+        mock_extractor.extract_text = AsyncMock(side_effect=RuntimeError("OCR failed"))
+
+        config_manager = MagicMock()
+        svc = LocalOCRService(config_manager=config_manager)
+
+        with patch(
+            "shu.processors.text_extractor.TextExtractor",
+            return_value=mock_extractor,
+        ):
+            with pytest.raises(RuntimeError, match="OCR failed"):
+                await svc.extract_text(b"data", "application/pdf")
+
+    @patch("shu.services.local_ocr_service.get_config_manager")
+    def test_default_config_manager(self, mock_get_cm):
+        """Should use get_config_manager() if none provided."""
+        mock_cm = MagicMock()
+        mock_get_cm.return_value = mock_cm
+
+        svc = LocalOCRService()
+        assert svc._config_manager is mock_cm

--- a/backend/src/tests/unit/workers/test_text_extractor_edge_cases.py
+++ b/backend/src/tests/unit/workers/test_text_extractor_edge_cases.py
@@ -396,7 +396,7 @@ class TestOcrCapabilityIntegration:
             new_callable=AsyncMock,
             return_value=mock_result,
         ):
-            with caplog.at_level(logging.INFO, logger="shu.shu.plugins.host.ocr_capability"):
+            with caplog.at_level(logging.INFO, logger="shu.plugins.host.ocr_capability"):
                 await cap.extract_text(
                     file_bytes=b"data",
                     mime_type="text/plain",

--- a/backend/src/tests/unit/workers/test_text_extractor_edge_cases.py
+++ b/backend/src/tests/unit/workers/test_text_extractor_edge_cases.py
@@ -335,45 +335,53 @@ class TestOcrCapabilityIntegration:
         )
 
     @pytest.mark.asyncio
-    async def test_file_bytes_and_mime_reach_extractor(self):
+    async def test_delegates_to_extract_text_with_ocr_fallback(self):
+        """Should delegate to extract_text_with_ocr_fallback with correct args."""
         cap = self._make_capability()
 
-        mock_result = {"text": "extracted", "metadata": {"method": "ocr"}}
-        with patch.object(_ocr_mod, "TextExtractor") as mock_cls:
-            instance = mock_cls.return_value
-            instance.extract_text = AsyncMock(return_value=mock_result)
-
+        mock_result = {"text": "extracted", "metadata": {"method": "pdf_text"}}
+        with patch.object(
+            _ocr_mod,
+            "extract_text_with_ocr_fallback",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_fn:
             result = await cap.extract_text(
                 file_bytes=b"pdf-data",
                 mime_type="application/pdf",
                 mode="fallback",
             )
 
-        instance.extract_text.assert_called_once_with(
-            file_bytes=b"pdf-data",
-            mime_type="application/pdf",
+        mock_fn.assert_called_once_with(
+            b"pdf-data",
+            "application/pdf",
+            cap._config_manager,
             ocr_mode="fallback",
         )
         assert result == mock_result
 
     @pytest.mark.asyncio
     async def test_ocr_mode_resolved_from_capability_default(self):
+        """When mode=None, uses the capability's default ocr_mode."""
         cap = self._make_capability(ocr_mode="never")
 
         mock_result = {"text": "", "metadata": {}}
-        with patch.object(_ocr_mod, "TextExtractor") as mock_cls:
-            instance = mock_cls.return_value
-            instance.extract_text = AsyncMock(return_value=mock_result)
-
+        with patch.object(
+            _ocr_mod,
+            "extract_text_with_ocr_fallback",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_fn:
             await cap.extract_text(
                 file_bytes=b"data",
                 mime_type="text/plain",
                 mode=None,
             )
 
-        instance.extract_text.assert_called_once_with(
-            file_bytes=b"data",
-            mime_type="text/plain",
+        mock_fn.assert_called_once_with(
+            b"data",
+            "text/plain",
+            cap._config_manager,
             ocr_mode="never",
         )
 
@@ -382,11 +390,13 @@ class TestOcrCapabilityIntegration:
         cap = self._make_capability()
 
         mock_result = {"text": "ok", "metadata": {}}
-        with patch.object(_ocr_mod, "TextExtractor") as mock_cls:
-            instance = mock_cls.return_value
-            instance.extract_text = AsyncMock(return_value=mock_result)
-
-            with caplog.at_level(logging.INFO, logger="shu.plugins.host.ocr_capability"):
+        with patch.object(
+            _ocr_mod,
+            "extract_text_with_ocr_fallback",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            with caplog.at_level(logging.INFO, logger="shu.shu.plugins.host.ocr_capability"):
                 await cap.extract_text(
                     file_bytes=b"data",
                     mime_type="text/plain",


### PR DESCRIPTION
# DEAR FUTURE PATRICK, do not merge this until https://github.com/Open-Shu/shu/pull/125 is merged. Also change the base branch first.


## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Changes Made
<!-- List the main changes made in this PR -->
-
-
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Mistral OCR integration as an alternative to local OCR processing
  * Implemented intelligent OCR fallback system that automatically triggers based on extracted text quality and configurable thresholds

* **Configuration**
  * Updated OCR configuration options to support both local and external OCR providers
  * Added new settings for external OCR API credentials and model selection

* **Tests**
  * Expanded test coverage for OCR functionality, fallback behavior, and service integrations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->