### PR TITLE
Update paradedb tag and add some info on paradedb to Docker Compose instructions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": "README.md",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 235
+        "line_number": 239
       }
     ],
     "backend/scripts/database.py": [

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ redis-cli ping  # Should return "PONG"
 
    The docker-compose file at `deployment/compose/docker-compose.yml` will load this `.env` automatically.
 
+   > **Postgres image note**: The compose stack uses [`paradedb/paradedb`](https://hub.docker.com/r/paradedb/paradedb)
+   > as its Postgres image. Check Docker Hub for the correct tag as specified by `deployment/compose/docker-compose.yml` in `shu-postgres`
+   > and pull paradedb into Docker if necessary
+
 2. **Start the full stack (Postgres + Redis + API + frontend)**:
 
    Using the Makefile:

--- a/deployment/compose/docker-compose.yml
+++ b/deployment/compose/docker-compose.yml
@@ -78,7 +78,7 @@ services:
 
   # Shu Postgres
   shu-postgres:
-    image: paradedb/paradedb:pg15
+    image: paradedb/paradedb:latest-pg18
     environment:
       POSTGRES_USER: shu
       POSTGRES_PASSWORD: password  # pragma: allowlist secret
@@ -86,7 +86,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - shu-postgres-data:/var/lib/postgresql/data
+      - shu-postgres-data:/var/lib/postgresql
       - ../../init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     networks:
       - shu-network


### PR DESCRIPTION
…

## Description
Update to the docker-compose.yml to change the tag for the shu-postgres image to 'latest-pg18'. Also, adding a blurb in the README to call out the paradedb dependency and including the link to Docker Hub where new developers can pull the paradedb image

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Changes Made
<!-- List the main changes made in this PR -->
- update shu-postgres image to paradedb/paradedb:latest-pg18
- Add some information on paradedb to the README
-

### Documentation
- [x ] README updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified quick-start notes to state which PostgreSQL image is used and to verify/pull the correct image tag before starting.

* **Chores**
  * Upgraded the PostgreSQL image to a newer tag and adjusted its on-container data mount path.
  * Minor metadata update to the secrets baseline entry line reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->