### PR TITLE
Shu 700 llm cost correctness and user_id passthrough to DB

### DIFF
--- a/backend/migrations/versions/008_0009_rename_llm_models_cost_columns_to_unit.py
+++ b/backend/migrations/versions/008_0009_rename_llm_models_cost_columns_to_unit.py
@@ -1,0 +1,63 @@
+"""Rename llm_models cost_per_input_token / cost_per_output_token to _unit.
+
+The OCR model type stores per-page rates in the same columns as chat/embedding
+models store per-token rates; `llm_models.model_type` already disambiguates the
+unit (chat/embedding -> per-token, ocr -> per-page). Rename the columns to
+`cost_per_input_unit` / `cost_per_output_unit` so the schema no longer claims
+the rate is per-token.
+
+Idempotent — safe to re-run.
+
+Revision ID: 008_0009
+Revises: 008_0008
+Create Date: 2026-04-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from migrations.helpers import column_exists
+
+# revision identifiers, used by Alembic.
+revision = "008_0009"
+down_revision = "008_0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if column_exists(inspector, "llm_models", "cost_per_input_token"):
+        op.alter_column(
+            "llm_models",
+            "cost_per_input_token",
+            new_column_name="cost_per_input_unit",
+        )
+
+    if column_exists(inspector, "llm_models", "cost_per_output_token"):
+        op.alter_column(
+            "llm_models",
+            "cost_per_output_token",
+            new_column_name="cost_per_output_unit",
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if column_exists(inspector, "llm_models", "cost_per_input_unit"):
+        op.alter_column(
+            "llm_models",
+            "cost_per_input_unit",
+            new_column_name="cost_per_input_token",
+        )
+
+    if column_exists(inspector, "llm_models", "cost_per_output_unit"):
+        op.alter_column(
+            "llm_models",
+            "cost_per_output_unit",
+            new_column_name="cost_per_output_token",
+        )

--- a/backend/src/shu/api/llm.py
+++ b/backend/src/shu/api/llm.py
@@ -126,8 +126,12 @@ class LLMModelCreate(BaseModel):
     supports_streaming: bool = Field(True, description="Supports streaming")
     supports_functions: bool = Field(False, description="Supports function calling")
     supports_vision: bool = Field(False, description="Supports vision/image inputs")
-    cost_per_input_token: float | None = Field(None, description="Cost per input token")
-    cost_per_output_token: float | None = Field(None, description="Cost per output token")
+    cost_per_input_unit: float | None = Field(
+        None, description="Cost per input unit (per-token for chat/embedding, per-page for ocr)"
+    )
+    cost_per_output_unit: float | None = Field(
+        None, description="Cost per output unit (per-token for chat/embedding, per-page for ocr)"
+    )
 
 
 class LLMModelResponse(BaseModel):
@@ -143,8 +147,8 @@ class LLMModelResponse(BaseModel):
     supports_streaming: bool
     supports_functions: bool
     supports_vision: bool
-    cost_per_input_token: float | None
-    cost_per_output_token: float | None
+    cost_per_input_unit: float | None
+    cost_per_output_unit: float | None
     is_active: bool
     created_at: datetime
 

--- a/backend/src/shu/core/embedding_protocol.py
+++ b/backend/src/shu/core/embedding_protocol.py
@@ -27,11 +27,13 @@ class EmbeddingService(Protocol):
         """Name of the underlying embedding model."""
         ...
 
-    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+    async def embed_texts(self, texts: list[str], *, user_id: str | None = None) -> list[list[float]]:
         """Generate embeddings for a batch of texts.
 
         Args:
             texts: List of text strings to embed. Empty list returns [].
+            user_id: Optional user attribution for llm_usage rows written by
+                billable external providers. Local services ignore it.
 
         Returns:
             List of embedding vectors, one per input text.
@@ -39,11 +41,13 @@ class EmbeddingService(Protocol):
         """
         ...
 
-    async def embed_query(self, text: str) -> list[float]:
+    async def embed_query(self, text: str, *, user_id: str | None = None) -> list[float]:
         """Generate an embedding for a single query text.
 
         Args:
             text: The query text to embed.
+            user_id: Optional user attribution for llm_usage rows written by
+                billable external providers. Local services ignore it.
 
         Returns:
             A single embedding vector.
@@ -51,7 +55,7 @@ class EmbeddingService(Protocol):
         """
         ...
 
-    async def embed_queries(self, texts: list[str]) -> list[list[float]]:
+    async def embed_queries(self, texts: list[str], *, user_id: str | None = None) -> list[list[float]]:
         """Generate embeddings for a batch of query texts.
 
         Like embed_texts(), but applies the query prompt for asymmetric
@@ -61,6 +65,8 @@ class EmbeddingService(Protocol):
 
         Args:
             texts: List of query strings to embed. Empty list returns [].
+            user_id: Optional user attribution for llm_usage rows written by
+                billable external providers. Local services ignore it.
 
         Returns:
             List of embedding vectors, one per input text.

--- a/backend/src/shu/core/embedding_service.py
+++ b/backend/src/shu/core/embedding_service.py
@@ -190,7 +190,7 @@ class LocalEmbeddingService:
     def model_name(self) -> str:
         return self._model_name
 
-    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+    async def embed_texts(self, texts: list[str], *, user_id: str | None = None) -> list[list[float]]:
         if not texts:
             return []
 
@@ -206,7 +206,7 @@ class LocalEmbeddingService:
         )
         return [e.tolist() for e in embeddings]
 
-    async def embed_query(self, text: str) -> list[float]:
+    async def embed_query(self, text: str, *, user_id: str | None = None) -> list[float]:
         loop = asyncio.get_running_loop()
         embedding = await loop.run_in_executor(
             self._executor,
@@ -216,7 +216,7 @@ class LocalEmbeddingService:
         )
         return embedding.tolist()
 
-    async def embed_queries(self, texts: list[str]) -> list[list[float]]:
+    async def embed_queries(self, texts: list[str], *, user_id: str | None = None) -> list[list[float]]:
         if not texts:
             return []
 

--- a/backend/src/shu/core/model_pricing.py
+++ b/backend/src/shu/core/model_pricing.py
@@ -118,8 +118,10 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
             continue
 
         # Skip zero-cost models (local/self-hosted) — leave DB columns as NULL
-        # so "has pricing" checks (IS NOT NULL) work correctly.
-        if not pricing["input"] and not pricing["output"]:
+        # so "has pricing" checks (IS NOT NULL) work correctly. Using explicit
+        # equality (not Python truthiness) keeps the intent clear and avoids
+        # the Decimal-falsiness foot-gun that bit us in LLMService.record_usage.
+        if pricing["input"] == 0 and pricing["output"] == 0:
             continue
 
         await db.execute(

--- a/backend/src/shu/core/model_pricing.py
+++ b/backend/src/shu/core/model_pricing.py
@@ -100,8 +100,12 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
     cost_per_input_unit and cost_per_output_unit. Models not in the
     reference dict are left untouched.
 
-    Returns {"updated": N, "skipped": N} where skipped means the model_name
-    was in MODEL_PRICING but not found in llm_models.
+    Returns {"updated": N, "cleared": N, "skipped": N}:
+      - updated: row written with non-zero rates.
+      - cleared: row explicitly NULLed because the reference pricing is zero
+        (demote-to-free case — prevents stale rates from a prior sync leaking
+        into DB-rate-fallback cost math).
+      - skipped: model_name was in MODEL_PRICING but not found in llm_models.
     """
     from shu.models.llm_provider import LLMModel
 
@@ -110,6 +114,7 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
     db_model_names = {row[0] for row in result.all()}
 
     updated = 0
+    cleared = 0
     skipped = 0
 
     for model_name, pricing in MODEL_PRICING.items():
@@ -117,11 +122,24 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
             skipped += 1
             continue
 
-        # Skip zero-cost models (local/self-hosted) — leave DB columns as NULL
-        # so "has pricing" checks (IS NOT NULL) work correctly. Using explicit
-        # equality (not Python truthiness) keeps the intent clear and avoids
-        # the Decimal-falsiness foot-gun that bit us in LLMService.record_usage.
+        # Zero-cost models (local/self-hosted) should have NULL rate columns so
+        # "has pricing" checks (IS NOT NULL) are truthful. If a model used to be
+        # paid and got demoted to free in model_pricing.py, a bare `continue`
+        # here would leave stale non-null rates in the DB and the fallback cost
+        # math would keep billing the old rates. Explicitly NULL the columns so
+        # the source-of-truth change actually lands. Explicit equality (not
+        # Python truthiness) avoids the Decimal-falsiness foot-gun that bit us
+        # in LLMService.record_usage.
         if pricing["input"] == 0 and pricing["output"] == 0:
+            await db.execute(
+                update(LLMModel)
+                .where(LLMModel.model_name == model_name)
+                .values(
+                    cost_per_input_unit=None,
+                    cost_per_output_unit=None,
+                )
+            )
+            cleared += 1
             continue
 
         await db.execute(
@@ -135,5 +153,10 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
         updated += 1
 
     await db.commit()
-    logger.info("Model pricing sync complete: %d updated, %d skipped (not in DB)", updated, skipped)
-    return {"updated": updated, "skipped": skipped}
+    logger.info(
+        "Model pricing sync complete: %d updated, %d cleared, %d skipped (not in DB)",
+        updated,
+        cleared,
+        skipped,
+    )
+    return {"updated": updated, "cleared": cleared, "skipped": skipped}

--- a/backend/src/shu/core/model_pricing.py
+++ b/backend/src/shu/core/model_pricing.py
@@ -1,14 +1,29 @@
 """Reference pricing for LLM models.
 
 This module is the **source of truth** for model pricing. On startup the
-application syncs these values into ``llm_models.cost_per_input_token`` /
-``cost_per_output_token`` so they are queryable for budgeting and analytics.
+application syncs these values into ``llm_models.cost_per_input_unit`` /
+``cost_per_output_unit`` so they are queryable for budgeting and analytics.
 
-Per-token costs in USD per million tokens ($/MTok).
+Unit semantics are determined by ``llm_models.model_type``:
+- ``chat`` / ``embedding`` — rates are per-token.
+- ``ocr`` — rates are per-page.
+
+Two input tables reflect this:
+- ``_PRICING_PER_MTOK`` holds per-token rates expressed in USD per million
+  tokens ($/MTok), which matches how vendors publish token pricing.
+- ``_PRICING_PER_UNIT`` holds per-unit rates expressed as the absolute
+  USD cost of one unit (e.g. one page for OCR), avoiding an artificial
+  million-unit scaling for non-token pricing.
+
+Both merge into the public ``MODEL_PRICING`` map with identical shape
+(``{"input": Decimal, "output": Decimal}``) so downstream code doesn't
+need to care which input table a model came from.
+
 Sources (verified 2026-03-19):
 - Anthropic: https://platform.claude.com/docs/en/docs/about-claude/models
 - OpenAI: https://developers.openai.com/api/docs/pricing
 - Google: https://ai.google.dev/gemini-api/docs/pricing
+- Mistral OCR: https://docs.mistral.ai/capabilities/OCR/basic_ocr/
 Local/self-hosted models have zero cost.
 
 Usage:
@@ -28,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 _MTOK = Decimal("1000000")
 
-# $/MTok pricing: (input, output)
+# $/MTok pricing (per-token, for chat and embedding models): (input, output)
 # fmt: off
 _PRICING_PER_MTOK: dict[str, tuple[str, str]] = {
     # --- Anthropic ---
@@ -52,19 +67,29 @@ _PRICING_PER_MTOK: dict[str, tuple[str, str]] = {
     "openai/gpt-oss-120b":              ("0",     "0"),
     "qwen/qwen3-vl-8b":                 ("0",     "0"),
 }
+
+# Absolute per-unit pricing (e.g. per-page for OCR): (input, output)
+_PRICING_PER_UNIT: dict[str, tuple[str, str]] = {
+    # --- Mistral OCR (per page) ---
+    "mistral-ocr-latest": ("0.002", "0"),
+}
 # fmt: on
 
 MODEL_PRICING: dict[str, dict[str, Decimal]] = {
-    name: {
-        "input": Decimal(inp) / _MTOK,
-        "output": Decimal(out) / _MTOK,
-    }
-    for name, (inp, out) in _PRICING_PER_MTOK.items()
+    **{
+        name: {"input": Decimal(inp) / _MTOK, "output": Decimal(out) / _MTOK}
+        for name, (inp, out) in _PRICING_PER_MTOK.items()
+    },
+    **{name: {"input": Decimal(inp), "output": Decimal(out)} for name, (inp, out) in _PRICING_PER_UNIT.items()},
 }
 
 
 def get_pricing(model_name: str) -> dict[str, Decimal] | None:
-    """Look up per-token pricing for a model name. Returns None if unknown."""
+    """Look up per-unit pricing for a model name. Returns None if unknown.
+
+    Unit is per-token for chat/embedding models and per-page for ocr models,
+    matching ``llm_models.model_type``.
+    """
     return MODEL_PRICING.get(model_name)
 
 
@@ -72,7 +97,7 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
     """Push reference pricing into llm_models rows.
 
     For every model_name in MODEL_PRICING that exists in llm_models, sets
-    cost_per_input_token and cost_per_output_token. Models not in the
+    cost_per_input_unit and cost_per_output_unit. Models not in the
     reference dict are left untouched.
 
     Returns {"updated": N, "skipped": N} where skipped means the model_name
@@ -101,8 +126,8 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
             update(LLMModel)
             .where(LLMModel.model_name == model_name)
             .values(
-                cost_per_input_token=pricing["input"],
-                cost_per_output_token=pricing["output"],
+                cost_per_input_unit=pricing["input"],
+                cost_per_output_unit=pricing["output"],
             )
         )
         updated += 1

--- a/backend/src/shu/core/ocr_service.py
+++ b/backend/src/shu/core/ocr_service.py
@@ -201,7 +201,7 @@ async def extract_text_with_ocr_fallback(
     if mime_type not in OCR_ELIGIBLE_MIME_PREFIXES:
         return result
 
-    return await _run_ocr_service(file_bytes, mime_type, effective_mode)
+    return await _run_ocr_service(file_bytes, mime_type, effective_mode, user_id=user_id)
 
 
 async def _run_ocr_service(file_bytes: bytes, mime_type: str, ocr_mode: str, *, user_id: str | None = None) -> dict:

--- a/backend/src/shu/core/ocr_service.py
+++ b/backend/src/shu/core/ocr_service.py
@@ -54,12 +54,20 @@ class OCRResult:
 class OCRService(Protocol):
     """Protocol for OCR text extraction services."""
 
-    async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
+    async def extract_text(
+        self,
+        file_bytes: bytes,
+        mime_type: str,
+        *,
+        user_id: str | None = None,
+    ) -> OCRResult:
         """Extract text from a document using OCR.
 
         Args:
             file_bytes: Raw bytes of the document to process.
             mime_type: MIME type of the document (e.g., "application/pdf", "image/png").
+            user_id: Optional user attribution for llm_usage rows written by
+                billable OCR providers (ExternalOCRService). Local OCR ignores it.
 
         Returns:
             OCRResult with extracted text and metadata.
@@ -124,6 +132,7 @@ async def extract_text_with_ocr_fallback(
     *,
     filename: str | None = None,
     ocr_mode: str = "auto",
+    user_id: str | None = None,
 ) -> dict:
     """Two-step text extraction: fast extraction first, OCR service if needed.
 
@@ -168,7 +177,7 @@ async def extract_text_with_ocr_fallback(
                 ocr_mode="text_only",
                 **({"file_path": filename} if filename else {}),
             )
-        return await _run_ocr_service(file_bytes, mime_type, effective_mode)
+        return await _run_ocr_service(file_bytes, mime_type, effective_mode, user_id=user_id)
 
     # auto / fallback: try cheap text extraction, fall back to OCR if
     # the result is missing or below the minimum length threshold.
@@ -195,13 +204,13 @@ async def extract_text_with_ocr_fallback(
     return await _run_ocr_service(file_bytes, mime_type, effective_mode)
 
 
-async def _run_ocr_service(file_bytes: bytes, mime_type: str, ocr_mode: str) -> dict:
+async def _run_ocr_service(file_bytes: bytes, mime_type: str, ocr_mode: str, *, user_id: str | None = None) -> dict:
     """Call the configured OCR service and return a result dict with timing."""
     import time
 
     start = time.monotonic()
     ocr_service = get_ocr_service()
-    ocr_result = await ocr_service.extract_text(file_bytes, mime_type)
+    ocr_result = await ocr_service.extract_text(file_bytes, mime_type, user_id=user_id)
     duration = time.monotonic() - start
 
     return {

--- a/backend/src/shu/core/safe_decimal.py
+++ b/backend/src/shu/core/safe_decimal.py
@@ -1,0 +1,25 @@
+"""Defensive Decimal coercion for untrusted external values.
+
+Provider APIs return cost fields in varying shapes: numeric, stringified
+number, sometimes `None` or the literal `"N/A"` when a cost is unavailable.
+`safe_decimal` coerces whatever comes in to a `Decimal`, falling back to
+`Decimal(0)` and logging a warning for anything it can't parse.
+"""
+
+from decimal import Decimal
+from typing import Any
+
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def safe_decimal(value: Any) -> Decimal:
+    """Convert a value to Decimal, falling back to zero for None or non-numeric."""
+    if value is None:
+        return Decimal(0)
+    try:
+        return Decimal(str(value))
+    except Exception:
+        logger.warning("Malformed decimal value, defaulting to 0: %r", value)
+        return Decimal(0)

--- a/backend/src/shu/llm/service.py
+++ b/backend/src/shu/llm/service.py
@@ -418,15 +418,36 @@ class LLMService:
         error_message: str | None = None,
         request_metadata: dict[str, Any] | None = None,
     ) -> LLMUsage:
-        """Record LLM usage for analytics and cost tracking."""
-        # Calculate individual costs if model has pricing info
+        """Record LLM usage for analytics and cost tracking.
+
+        Cost resolution is two-tiered:
+
+        1. **Provider-authoritative** — if the caller passes ``total_cost > 0``,
+           the value is recorded verbatim. ``input_cost`` and ``output_cost``
+           stay at ``Decimal(0)`` because providers return a single total, not
+           a split. This is the hot path for OpenRouter, which returns
+           ``usage.cost`` on the wire.
+
+        2. **DB-rate fallback** — if the caller passes ``total_cost = Decimal(0)``
+           (the sentinel meaning "no wire-reported cost"), cost is computed as
+           ``input_tokens * cost_per_input_unit + output_tokens * cost_per_output_unit``
+           using the resolved ``LLMModel`` row. ``input_cost + output_cost == total_cost``
+           holds on this path.
+
+        When neither path produces a cost (no wire cost, no DB rates — e.g. a
+        local/self-hosted model), all three cost columns are recorded as
+        ``Decimal(0)``.
+        """
         model = await self.db.get(LLMModel, model_id)
         input_cost = Decimal("0")
         output_cost = Decimal("0")
 
-        if model and model.cost_per_input_token and model.cost_per_output_token:
-            input_cost = Decimal(str(input_tokens)) * model.cost_per_input_token
-            output_cost = Decimal(str(output_tokens)) * model.cost_per_output_token
+        if total_cost > Decimal("0"):
+            # Provider-authoritative: leave input_cost/output_cost at 0.
+            pass
+        elif model and model.cost_per_input_unit and model.cost_per_output_unit:
+            input_cost = Decimal(str(input_tokens)) * model.cost_per_input_unit
+            output_cost = Decimal(str(output_tokens)) * model.cost_per_output_unit
             total_cost = input_cost + output_cost
 
         usage = LLMUsage(

--- a/backend/src/shu/llm/service.py
+++ b/backend/src/shu/llm/service.py
@@ -445,9 +445,14 @@ class LLMService:
         if total_cost > Decimal("0"):
             # Provider-authoritative: leave input_cost/output_cost at 0.
             pass
-        elif model and model.cost_per_input_unit and model.cost_per_output_unit:
-            input_cost = Decimal(str(input_tokens)) * model.cost_per_input_unit
-            output_cost = Decimal(str(output_tokens)) * model.cost_per_output_unit
+        elif model and (model.cost_per_input_unit is not None or model.cost_per_output_unit is not None):
+            # Use `is not None` (not truthiness) so a legitimate Decimal(0) rate on one
+            # side — e.g. a model with free output tokens — doesn't collapse the entire
+            # fallback and silently lose the other side's cost.
+            input_rate = model.cost_per_input_unit if model.cost_per_input_unit is not None else Decimal(0)
+            output_rate = model.cost_per_output_unit if model.cost_per_output_unit is not None else Decimal(0)
+            input_cost = Decimal(str(input_tokens)) * input_rate
+            output_cost = Decimal(str(output_tokens)) * output_rate
             total_cost = input_cost + output_cost
 
         usage = LLMUsage(

--- a/backend/src/shu/models/llm_provider.py
+++ b/backend/src/shu/models/llm_provider.py
@@ -147,9 +147,10 @@ class LLMModel(BaseModel):
     supports_functions = Column(Boolean, default=False, nullable=False)
     supports_vision = Column(Boolean, default=False, nullable=False)
 
-    # Cost information (per-model pricing)
-    cost_per_input_token = Column(DECIMAL(12, 10), nullable=True)
-    cost_per_output_token = Column(DECIMAL(12, 10), nullable=True)
+    # Cost information (per-model pricing). Unit is per-token for chat/embedding
+    # models and per-page for ocr models; disambiguated by model_type.
+    cost_per_input_unit = Column(DECIMAL(12, 10), nullable=True)
+    cost_per_output_unit = Column(DECIMAL(12, 10), nullable=True)
 
     # Status
     is_active = Column(Boolean, default=True, nullable=False, index=True)

--- a/backend/src/shu/plugins/host/ocr_capability.py
+++ b/backend/src/shu/plugins/host/ocr_capability.py
@@ -49,11 +49,17 @@ class OcrCapability(ImmutableCapabilityMixin):
     async def extract_text(self, *, file_bytes: bytes, mime_type: str, mode: str | None = None) -> dict[str, Any]:
         mm = (mode or self._ocr_mode or "auto").strip().lower()
 
+        # Forward user_id so the resulting llm_usage row attributes to the
+        # plugin's acting user, matching the ingestion-worker OCR path.
+        # Dropping it here would leave every plugin-initiated OCR row with
+        # NULL user_id — same class of bug as the extract_text_with_ocr_fallback
+        # auto/fallback drop caught earlier in SHU-700.
         res = await extract_text_with_ocr_fallback(
             file_bytes,
             mime_type,
             self._config_manager,
             ocr_mode=mm,
+            user_id=self._user_id,
         )
 
         logger.info(

--- a/backend/src/shu/services/chat_service.py
+++ b/backend/src/shu/services/chat_service.py
@@ -1066,10 +1066,19 @@ class ChatService:
         # finally:
         #     await release_conversation_lock(self.db_session, conversation_id, lock_id)
 
-    async def _handle_exception(self, conversation_id: str, model: LLMModel, e: Exception | ShuException) -> Message:
+    async def _handle_exception(
+        self,
+        conversation_id: str,
+        model: LLMModel,
+        e: Exception | ShuException,
+        user_id: str | None = None,
+    ) -> Message:
         logger.error("LLM completion failed: %s", e)
 
-        # Record failed usage
+        # Record failed usage. Tokens and cost stay at 0 — the request never
+        # produced output, so there's nothing to bill. user_id is still
+        # populated so failed attempts appear under the originating user in
+        # any per-user usage dashboard.
         try:
             await self.llm_service.record_usage(
                 provider_id=model.provider_id,
@@ -1078,6 +1087,7 @@ class ChatService:
                 input_tokens=0,
                 output_tokens=0,
                 total_cost=Decimal("0"),
+                user_id=user_id,
                 success=False,
                 error_message=str(e),
             )

--- a/backend/src/shu/services/chat_streaming.py
+++ b/backend/src/shu/services/chat_streaming.py
@@ -4,7 +4,6 @@ import uuid
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, Self
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from shu.core.config import ConfigurationManager, get_settings_instance
 from shu.core.exceptions import LLMError, LLMProviderError, LLMRateLimitError
 from shu.core.rate_limiting import get_rate_limit_service
+from shu.core.safe_decimal import safe_decimal
 from shu.llm.client import UnifiedLLMClient
 from shu.services.message_context_builder import MessageContextBuilder
 from shu.services.providers.adapter_base import (
@@ -516,7 +516,8 @@ class EnsembleStreamingHelper:
                     request_type="chat",
                     input_tokens=usage_from_event.get("input_tokens", 0),
                     output_tokens=usage_from_event.get("output_tokens", 0),
-                    total_cost=Decimal("0"),
+                    total_cost=safe_decimal(usage_from_event.get("cost")),
+                    user_id=str(conversation_owner_id) if conversation_owner_id else None,
                     response_time_ms=metadata.get("response_time_ms"),
                     success=True,
                 )
@@ -543,7 +544,12 @@ class EnsembleStreamingHelper:
                     getattr(exc, "details", None),
                     exc_info=True,
                 )
-                await service._handle_exception(conversation_id, inputs.model, exc)
+                await service._handle_exception(
+                    conversation_id,
+                    inputs.model,
+                    exc,
+                    user_id=str(conversation_owner_id) if conversation_owner_id else None,
+                )
                 # Pass through the technical error message - it will be sanitized by the endpoint
                 await queue.put(
                     self._create_error_event(exc.message, variant_index, inputs, model_snapshot, model_display_name)
@@ -556,7 +562,12 @@ class EnsembleStreamingHelper:
                     type(exc).__name__,
                     stack_info=True,
                 )
-                await service._handle_exception(conversation_id, inputs.model, exc)
+                await service._handle_exception(
+                    conversation_id,
+                    inputs.model,
+                    exc,
+                    user_id=str(conversation_owner_id) if conversation_owner_id else None,
+                )
                 # For unknown errors, show details only in development
                 settings = get_settings_instance()
                 if settings.environment == "development":

--- a/backend/src/shu/services/document_service.py
+++ b/backend/src/shu/services/document_service.py
@@ -347,6 +347,8 @@ class DocumentService:
         document: Document,
         title: str,
         content: str,
+        *,
+        user_id: str | None = None,
     ) -> tuple[int, int, int]:
         """Generate chunks for a document and update processing stats."""
         from ..core.embedding_service import get_embedding_service
@@ -365,6 +367,7 @@ class DocumentService:
             knowledge_base=kb,
             text=content,
             document_title=title,
+            user_id=user_id,
         )
 
         await self.db.execute(delete(DocumentChunk).where(DocumentChunk.document_id == document.id))

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -9,6 +9,7 @@ TODO: Abstract provider-specific formatting when we support more than
 OpenRouter for embedding models.
 """
 
+from decimal import Decimal
 from typing import Any
 
 import httpx
@@ -111,7 +112,14 @@ class ExternalEmbeddingService:
         return response.json()
 
     async def _record_usage(self, usage: dict[str, Any] | None, *, user_id: str | None = None) -> None:
-        """Record embedding API usage in llm_usage. Best-effort — failures are logged, not raised."""
+        """Record embedding API usage in llm_usage. Best-effort — failures are logged, not raised.
+
+        Cost-column contract (SHU-700): provider-authoritative wire cost is stored
+        verbatim on ``total_cost`` and ``input_cost`` / ``output_cost`` stay at
+        ``Decimal(0)`` — providers return a single total, not a split. This matches
+        the chat/side-call path's contract so downstream aggregations can identify
+        provider-authoritative rows consistently regardless of request_type.
+        """
         if not usage:
             return
 
@@ -129,7 +137,7 @@ class ExternalEmbeddingService:
 
         prompt_tokens = usage.get("prompt_tokens", 0)
         total_tokens = usage.get("total_tokens", 0)
-        cost = usage.get("cost")
+        cost = safe_decimal(usage.get("cost"))
 
         await record_llm_usage(
             provider_id=self._provider_id,
@@ -138,6 +146,7 @@ class ExternalEmbeddingService:
             user_id=user_id,
             input_tokens=prompt_tokens,
             total_tokens=total_tokens,
-            input_cost=safe_decimal(cost),
-            total_cost=safe_decimal(cost),
+            input_cost=Decimal(0),
+            output_cost=Decimal(0),
+            total_cost=cost,
         )

--- a/backend/src/shu/services/external_embedding_service.py
+++ b/backend/src/shu/services/external_embedding_service.py
@@ -9,12 +9,12 @@ TODO: Abstract provider-specific formatting when we support more than
 OpenRouter for embedding models.
 """
 
-from decimal import Decimal
 from typing import Any
 
 import httpx
 
 from ..core.logging import get_logger
+from ..core.safe_decimal import safe_decimal
 
 logger = get_logger(__name__)
 
@@ -59,11 +59,11 @@ class ExternalEmbeddingService:
     def model_name(self) -> str:
         return self._model_name
 
-    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
-        return await self._embed_batch(texts, prefix=self._document_prefix)
+    async def embed_texts(self, texts: list[str], *, user_id: str | None = None) -> list[list[float]]:
+        return await self._embed_batch(texts, prefix=self._document_prefix, user_id=user_id)
 
-    async def embed_query(self, text: str) -> list[float]:
-        results = await self._embed_batch([text], prefix=self._query_prefix)
+    async def embed_query(self, text: str, *, user_id: str | None = None) -> list[float]:
+        results = await self._embed_batch([text], prefix=self._query_prefix, user_id=user_id)
         if not results:
             raise ValueError(
                 f"embed_texts returned no results for query text "
@@ -71,10 +71,12 @@ class ExternalEmbeddingService:
             )
         return results[0]
 
-    async def embed_queries(self, texts: list[str]) -> list[list[float]]:
-        return await self._embed_batch(texts, prefix=self._query_prefix)
+    async def embed_queries(self, texts: list[str], *, user_id: str | None = None) -> list[list[float]]:
+        return await self._embed_batch(texts, prefix=self._query_prefix, user_id=user_id)
 
-    async def _embed_batch(self, texts: list[str], prefix: str = "") -> list[list[float]]:
+    async def _embed_batch(
+        self, texts: list[str], prefix: str = "", *, user_id: str | None = None
+    ) -> list[list[float]]:
         if not texts:
             return []
         response_data = await self._call_embeddings_api(texts, prefix=prefix)
@@ -84,7 +86,7 @@ class ExternalEmbeddingService:
                 f"Embedding API returned {len(entries)} results for {len(texts)} inputs (model={self._model_name})"
             )
         entries = sorted(entries, key=lambda e: e["index"])
-        await self._record_usage(response_data.get("usage"))
+        await self._record_usage(response_data.get("usage"), user_id=user_id)
         return [entry["embedding"] for entry in entries]
 
     async def _call_embeddings_api(self, texts: list[str], prefix: str = "") -> dict[str, Any]:
@@ -108,7 +110,7 @@ class ExternalEmbeddingService:
 
         return response.json()
 
-    async def _record_usage(self, usage: dict[str, Any] | None) -> None:
+    async def _record_usage(self, usage: dict[str, Any] | None, *, user_id: str | None = None) -> None:
         """Record embedding API usage in llm_usage. Best-effort — failures are logged, not raised."""
         if not usage:
             return
@@ -133,19 +135,9 @@ class ExternalEmbeddingService:
             provider_id=self._provider_id,
             model_id=self._model_id,
             request_type="embedding",
+            user_id=user_id,
             input_tokens=prompt_tokens,
             total_tokens=total_tokens,
-            input_cost=_safe_decimal(cost),
-            total_cost=_safe_decimal(cost),
+            input_cost=safe_decimal(cost),
+            total_cost=safe_decimal(cost),
         )
-
-
-def _safe_decimal(value: Any) -> Decimal:
-    """Convert a value to Decimal, falling back to zero for None or non-numeric."""
-    if value is None:
-        return Decimal("0")
-    try:
-        return Decimal(str(value))
-    except Exception:
-        logger.warning("Malformed cost value, defaulting to 0: %r", value)
-        return Decimal("0")

--- a/backend/src/shu/services/external_ocr_service.py
+++ b/backend/src/shu/services/external_ocr_service.py
@@ -211,6 +211,21 @@ class ExternalOCRService:
             session_factory = get_async_session_local()
             async with session_factory() as session:
                 if not await self._resolve_provider_and_model(session):
+                    # Provider/model lookup failed (see upstream error in _resolve_provider_and_model).
+                    # Billing loses a row for a real OCR call here — surface that explicitly so
+                    # ops can correlate the raw_usage_info log above with missing llm_usage
+                    # entries and drive the seed fix. See SHU-713.
+                    logger.error(
+                        "Dropping OCR llm_usage row — Mistral OCR provider/model not seeded. "
+                        "Reconstruct cost from the raw_usage_info log above (pages_billed=%d). "
+                        "Fix by seeding via the hosting script.",
+                        page_count,
+                        extra={
+                            "model": self._model_name,
+                            "pages_billed": page_count,
+                            "usage_recording": "dropped",
+                        },
+                    )
                     return
 
                 model = await session.get(LLMModel, self._model_id)

--- a/backend/src/shu/services/external_ocr_service.py
+++ b/backend/src/shu/services/external_ocr_service.py
@@ -17,13 +17,10 @@ import httpx
 from ..core.logging import get_logger
 from ..core.ocr_service import OCR_ELIGIBLE_MIME_PREFIXES, OCRResult
 from ..llm.service import LLMService
-from ..models.llm_provider import ModelType
+from ..models.llm_provider import LLMModel, ModelType
 from .usage_recording import record_llm_usage
 
 logger = get_logger(__name__)
-
-# $1 per 1000 pages
-_COST_PER_PAGE = Decimal("0.002")
 
 _PROVIDER_TYPE_KEY = "generic_completions"
 _PROVIDER_NAME = "Mistral OCR (auto-provisioned)"
@@ -59,12 +56,19 @@ class ExternalOCRService:
         """Redact API key to prevent leaking credentials in logs/tracebacks."""
         return f"ExternalOCRService(model={self._model_name!r})"
 
-    async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
+    async def extract_text(
+        self,
+        file_bytes: bytes,
+        mime_type: str,
+        *,
+        user_id: str | None = None,
+    ) -> OCRResult:
         """Extract text by sending the document to Mistral's OCR API.
 
         Args:
             file_bytes: Raw bytes of the document to process.
             mime_type: MIME type of the document.
+            user_id: Optional user attribution for the resulting llm_usage row.
 
         Returns:
             OCRResult with extracted text from all pages.
@@ -126,7 +130,9 @@ class ExternalOCRService:
             usage_info.get("pages_processed"),
             fallback=len(pages),
         )
-        await self._record_usage(pages_processed, usage_info=usage_info, observed_page_count=len(pages))
+        await self._record_usage(
+            pages_processed, usage_info=usage_info, observed_page_count=len(pages), user_id=user_id
+        )
 
         return OCRResult(
             text="\n\n".join(page_texts),
@@ -175,22 +181,27 @@ class ExternalOCRService:
         *,
         usage_info: dict[str, Any] | None = None,
         observed_page_count: int | None = None,
+        user_id: str | None = None,
     ) -> None:
         """Record OCR usage in llm_usage. Best-effort — failures are logged, not raised.
 
-        Always logs the raw usage payload alongside the computed cost so costs
-        can be reconstructed from logs if DB recording ever fails.
-        """
-        total_cost = _COST_PER_PAGE * page_count
+        Cost is sourced from the resolved ``llm_models.cost_per_input_unit`` (synced
+        from ``core/model_pricing.py`` at startup) rather than a module-level constant,
+        so repricing is a one-entry change in ``model_pricing.py`` plus a restart.
 
+        Always logs the raw usage payload so costs can be reconstructed from logs
+        if DB recording ever fails. The computed cost is logged separately once the
+        DB-sourced rate is known.
+        """
+        # Log raw usage payload first — unconditional, independent of DB state,
+        # so cost reconstruction from logs works even if the DB write later fails.
         logger.info(
-            "Mistral OCR usage",
+            "Mistral OCR usage (raw)",
             extra={
                 "model": self._model_name,
                 "raw_usage_info": usage_info or {},
                 "observed_page_count": observed_page_count,
                 "pages_billed": page_count,
-                "total_cost": str(total_cost),
             },
         )
 
@@ -201,10 +212,34 @@ class ExternalOCRService:
             async with session_factory() as session:
                 if not await self._resolve_provider_and_model(session):
                     return
+
+                model = await session.get(LLMModel, self._model_id)
+                per_page_rate = model.cost_per_input_unit if model else None
+                if per_page_rate is None:
+                    logger.warning(
+                        "OCR model %r has no cost_per_input_unit set — recording $0. "
+                        "Ensure model_pricing.sync_pricing_to_db ran at startup.",
+                        self._model_name,
+                    )
+                    per_page_rate = Decimal(0)
+
+                total_cost = per_page_rate * page_count
+
+                logger.info(
+                    "Mistral OCR cost computed",
+                    extra={
+                        "model": self._model_name,
+                        "pages_billed": page_count,
+                        "per_page_rate": str(per_page_rate),
+                        "total_cost": str(total_cost),
+                    },
+                )
+
                 await record_llm_usage(
                     provider_id=self._provider_id,
                     model_id=self._model_id,
                     request_type="ocr",
+                    user_id=user_id,
                     input_cost=total_cost,
                     total_cost=total_cost,
                     request_metadata={"page_count": page_count},

--- a/backend/src/shu/services/ingestion_service.py
+++ b/backend/src/shu/services/ingestion_service.py
@@ -733,6 +733,7 @@ async def ingest_email(
             document,
             title,
             content,
+            user_id=user_id,
         )
     except Exception as e:
         logger.error(

--- a/backend/src/shu/services/ingestion_service.py
+++ b/backend/src/shu/services/ingestion_service.py
@@ -75,7 +75,7 @@ def _build_skipped_result(
     }
 
 
-async def _trigger_profiling_if_enabled(document_id: str) -> None:
+async def _trigger_profiling_if_enabled(document_id: str, user_id: str | None = None) -> None:
     """Trigger async document profiling if enabled (SHU-344).
 
     Enqueues a profiling job to the QueueBackend with PROFILING WorkloadType.
@@ -111,6 +111,7 @@ async def _trigger_profiling_if_enabled(document_id: str) -> None:
             WorkloadType.PROFILING,
             payload={
                 "document_id": document_id,
+                "user_id": user_id,
                 "action": "profile_document",
             },
             max_attempts=5,  # Retry up to 5 times for transient failures
@@ -267,13 +268,20 @@ def _check_skip(
     return None
 
 
-async def _enqueue_embed_job(queue: QueueBackend, document_id: str, knowledge_base_id: str) -> None:
+async def _enqueue_embed_job(
+    queue: QueueBackend,
+    document_id: str,
+    knowledge_base_id: str,
+    user_id: str | None = None,
+) -> None:
     """Enqueue an embedding job for a document.
 
     Args:
         queue: QueueBackend instance
         document_id: Document ID to embed
         knowledge_base_id: Knowledge base ID
+        user_id: User ID performing the ingestion, threaded through to
+            llm_usage attribution on the resulting embedding API call.
 
     """
     from ..core.workload_routing import WorkloadType, enqueue_job
@@ -284,6 +292,7 @@ async def _enqueue_embed_job(queue: QueueBackend, document_id: str, knowledge_ba
         payload={
             "document_id": document_id,
             "knowledge_base_id": knowledge_base_id,
+            "user_id": user_id,
             "action": "embed_document",
         },
         max_attempts=3,
@@ -575,6 +584,7 @@ async def ingest_document(  # noqa: PLR0915
             "source_id": source_id,
             "staging_key": staging_key,
             "ocr_mode": ocr_mode,
+            "user_id": user_id,
             "action": "extract_text",
         }
 
@@ -744,7 +754,7 @@ async def ingest_email(
     await db.commit()
 
     # Trigger async profiling if enabled
-    await _trigger_profiling_if_enabled(document.id)
+    await _trigger_profiling_if_enabled(document.id, user_id=user_id)
 
     return {
         "ko_id": deterministic_ko_id(f"{plugin_name}:{user_id}", external_id),
@@ -869,7 +879,7 @@ async def ingest_text(  # noqa: PLR0915
     # where the document is EMBEDDING with no job in the queue.
     try:
         queue = await get_queue_backend()
-        await _enqueue_embed_job(queue, document.id, knowledge_base_id)
+        await _enqueue_embed_job(queue, document.id, knowledge_base_id, user_id=user_id)
     except Exception as e:
         logger.error(
             "Failed to enqueue text ingestion embedding job",
@@ -1017,7 +1027,7 @@ async def ingest_thread(  # noqa: PLR0915
     # where the document is EMBEDDING with no job in the queue.
     try:
         queue = await get_queue_backend()
-        await _enqueue_embed_job(queue, document.id, knowledge_base_id)
+        await _enqueue_embed_job(queue, document.id, knowledge_base_id, user_id=user_id)
     except Exception as e:
         logger.error(
             "Failed to enqueue thread ingestion embedding job",

--- a/backend/src/shu/services/local_ocr_service.py
+++ b/backend/src/shu/services/local_ocr_service.py
@@ -21,12 +21,20 @@ class LocalOCRService:
     def __init__(self, config_manager: ConfigurationManager | None = None) -> None:
         self._config_manager = config_manager or get_config_manager()
 
-    async def extract_text(self, file_bytes: bytes, mime_type: str) -> OCRResult:
+    async def extract_text(
+        self,
+        file_bytes: bytes,
+        mime_type: str,
+        *,
+        user_id: str | None = None,
+    ) -> OCRResult:
         """Extract text using local EasyOCR/Tesseract via TextExtractor.
 
         Args:
             file_bytes: Raw bytes of the document to process.
             mime_type: MIME type of the document.
+            user_id: Accepted for protocol parity with ExternalOCRService;
+                local OCR doesn't record llm_usage, so the value is unused.
 
         Returns:
             OCRResult with extracted text and metadata.

--- a/backend/src/shu/services/profiling_orchestrator.py
+++ b/backend/src/shu/services/profiling_orchestrator.py
@@ -48,7 +48,7 @@ class ProfilingOrchestrator:
         self.settings = settings
         self.profiling_service = ProfilingService(side_call_service, settings)
 
-    async def run_for_document(self, document_id: str) -> ProfilingResult:
+    async def run_for_document(self, document_id: str, *, user_id: str | None = None) -> ProfilingResult:
         """Run profiling for a document and its chunks.
 
         This is the main entry point called by ingestion integration.
@@ -58,6 +58,11 @@ class ProfilingOrchestrator:
 
         Args:
             document_id: ID of the document to profile
+            user_id: Originating ingestion user. Currently accepted for API
+                parity but NOT yet threaded into the internal side-call chain,
+                so side-call llm_usage rows emitted during profiling still land
+                with NULL user_id. Follow-up ticket will plumb this through
+                ProfilingService and its SideCallService invocations.
 
         Returns:
             ProfilingResult with document and chunk profiles
@@ -400,7 +405,9 @@ class ProfilingOrchestrator:
 # ---------------------------------------------------------------------------
 
 
-async def embed_profile_artifacts(db: AsyncSession, document: Document) -> tuple[bool, int, int]:
+async def embed_profile_artifacts(
+    db: AsyncSession, document: Document, *, user_id: str | None = None
+) -> tuple[bool, int, int]:
     """Embed synopsis, chunk summaries, and synthesized query vectors for a profiled document.
 
     This is a standalone function (not on ProfilingOrchestrator) because it only
@@ -415,6 +422,8 @@ async def embed_profile_artifacts(db: AsyncSession, document: Document) -> tuple
     Args:
         db: Async database session.
         document: The profiled document (must have synopsis set).
+        user_id: Optional user attribution for llm_usage rows on the
+            embedding API calls (threaded from the ingestion job).
 
     Returns:
         Tuple of (synopsis_embedded, chunk_summaries_embedded_count, queries_embedded_count).
@@ -429,7 +438,7 @@ async def embed_profile_artifacts(db: AsyncSession, document: Document) -> tuple
 
     # Phase 1: Embed synopsis using document encoder
     if document.synopsis and document.synopsis.strip():
-        embeddings = await embedding_service.embed_texts([str(document.synopsis)])
+        embeddings = await embedding_service.embed_texts([str(document.synopsis)], user_id=user_id)
         if not embeddings:
             logger.warning("synopsis_embedding_empty", document_id=document.id)
         else:
@@ -456,7 +465,7 @@ async def embed_profile_artifacts(db: AsyncSession, document: Document) -> tuple
     if chunks_to_embed:
         try:
             summary_texts = [str(c.summary) for c in chunks_to_embed]
-            embeddings = await embedding_service.embed_texts(summary_texts)
+            embeddings = await embedding_service.embed_texts(summary_texts, user_id=user_id)
             entries = [VectorEntry(id=c.id, vector=emb) for c, emb in zip(chunks_to_embed, embeddings, strict=True)]
             await vector_store.store_embeddings("chunk_summaries", entries, db=db)
             chunk_summaries_embedded = len(entries)
@@ -479,7 +488,7 @@ async def embed_profile_artifacts(db: AsyncSession, document: Document) -> tuple
     if queries:
         try:
             query_texts = [q.query_text for q in queries]
-            embeddings = await embedding_service.embed_queries(query_texts)
+            embeddings = await embedding_service.embed_queries(query_texts, user_id=user_id)
             entries = [VectorEntry(id=q.id, vector=emb) for q, emb in zip(queries, embeddings, strict=True)]
             await vector_store.store_embeddings("queries", entries, db=db)
             queries_embedded = len(queries)

--- a/backend/src/shu/services/providers/adapter_base.py
+++ b/backend/src/shu/services/providers/adapter_base.py
@@ -10,6 +10,7 @@ import base64
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Self
 
@@ -165,7 +166,7 @@ class BaseProviderAdapter:
         self.settings = get_settings_instance()
         self.encryption_key = self.settings.llm_encryption_key
         self.api_key = None
-        self.usage: dict[str, int] = {}
+        self.usage: dict[str, int | Decimal] = {}
 
         self.db_session = context.db_session
 
@@ -221,16 +222,22 @@ class BaseProviderAdapter:
         cached_tokens: int,
         reasoning_tokens: int,
         total_tokens: int,
-    ) -> dict[str, int]:
-        return {
+        cost: Decimal | None = None,
+    ) -> dict[str, int | Decimal]:
+        usage: dict[str, int | Decimal] = {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "cached_tokens": cached_tokens,
             "reasoning_tokens": reasoning_tokens,
             "total_tokens": total_tokens,
         }
+        if cost is not None:
+            usage["cost"] = cost
+        return usage
 
-    def _aggregate_usage(self, first: dict[str, int], second: dict[str, int]) -> dict[str, int]:
+    def _aggregate_usage(
+        self, first: dict[str, int | Decimal], second: dict[str, int | Decimal]
+    ) -> dict[str, int | Decimal]:
         return {k: first.get(k, 0) + second.get(k, 0) for k in set(first) | set(second)}
 
     def _flatten_chat_context(
@@ -341,6 +348,7 @@ class BaseProviderAdapter:
         cached_tokens: int,
         reasoning_tokens: int,
         total_tokens: int,
+        cost: Decimal | None = None,
     ) -> None:
         usage_dict = self._get_usage(
             input_tokens,
@@ -348,6 +356,7 @@ class BaseProviderAdapter:
             cached_tokens,
             reasoning_tokens,
             total_tokens,
+            cost,
         )
         if not self.usage:
             self.usage = usage_dict

--- a/backend/src/shu/services/providers/adapter_base.py
+++ b/backend/src/shu/services/providers/adapter_base.py
@@ -166,7 +166,12 @@ class BaseProviderAdapter:
         self.settings = get_settings_instance()
         self.encryption_key = self.settings.llm_encryption_key
         self.api_key = None
-        self.usage: dict[str, int | Decimal] = {}
+        # Usage dict is stored JSON-safe: tokens as int, cost as a stringified
+        # Decimal (not a Decimal object). The dict flows into message_metadata,
+        # which is persisted as JSON — Decimal is not JSON-serializable by
+        # default. Callers convert cost back to Decimal via safe_decimal() when
+        # recording usage.
+        self.usage: dict[str, int | str] = {}
 
         self.db_session = context.db_session
 
@@ -223,8 +228,8 @@ class BaseProviderAdapter:
         reasoning_tokens: int,
         total_tokens: int,
         cost: Decimal | None = None,
-    ) -> dict[str, int | Decimal]:
-        usage: dict[str, int | Decimal] = {
+    ) -> dict[str, int | str]:
+        usage: dict[str, int | str] = {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "cached_tokens": cached_tokens,
@@ -232,13 +237,22 @@ class BaseProviderAdapter:
             "total_tokens": total_tokens,
         }
         if cost is not None:
-            usage["cost"] = cost
+            # Stringify so the dict stays JSON-serializable (see self.usage docstring).
+            usage["cost"] = str(cost)
         return usage
 
-    def _aggregate_usage(
-        self, first: dict[str, int | Decimal], second: dict[str, int | Decimal]
-    ) -> dict[str, int | Decimal]:
-        return {k: first.get(k, 0) + second.get(k, 0) for k in set(first) | set(second)}
+    def _aggregate_usage(self, first: dict[str, int | str], second: dict[str, int | str]) -> dict[str, int | str]:
+        result: dict[str, int | str] = {}
+        for k in set(first) | set(second):
+            if k == "cost":
+                # Cost is stored as a stringified Decimal; sum with Decimal math
+                # to preserve precision, then restringify for JSON safety.
+                a = Decimal(str(first.get(k, "0")))
+                b = Decimal(str(second.get(k, "0")))
+                result[k] = str(a + b)
+            else:
+                result[k] = first.get(k, 0) + second.get(k, 0)  # type: ignore[operator]
+        return result
 
     def _flatten_chat_context(
         self,

--- a/backend/src/shu/services/providers/adapter_base.py
+++ b/backend/src/shu/services/providers/adapter_base.py
@@ -262,13 +262,18 @@ class BaseProviderAdapter:
         return usage
 
     def _aggregate_usage(self, first: UsageDict, second: UsageDict) -> UsageDict:
+        from shu.core.safe_decimal import safe_decimal
+
         result: UsageDict = {}
         for k in set(first) | set(second):
             if k == "cost":
                 # Cost is stored as a stringified Decimal; sum with Decimal math
                 # to preserve precision, then restringify for JSON safety.
-                a = Decimal(str(first.get(k, "0")))
-                b = Decimal(str(second.get(k, "0")))
+                # safe_decimal keeps this consistent with the other cost-handling
+                # sites and degrades to Decimal(0) + a warning log if malformed
+                # data ever lands here instead of crashing mid-stream.
+                a = safe_decimal(first.get(k))
+                b = safe_decimal(second.get(k))
                 result[k] = str(a + b)  # type: ignore[literal-required]
             else:
                 result[k] = first.get(k, 0) + second.get(k, 0)  # type: ignore[literal-required,operator]

--- a/backend/src/shu/services/providers/adapter_base.py
+++ b/backend/src/shu/services/providers/adapter_base.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, NotRequired, Self, TypedDict
 
 from cryptography.fernet import Fernet
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,6 +28,26 @@ from shu.services.plugin_execution import execute_plugin
 from shu.services.providers.events import ProviderStreamEvent
 
 logger = get_logger(__name__)
+
+
+class UsageDict(TypedDict, total=False):
+    """Shape of `BaseProviderAdapter.self.usage` and entries on provider-event metadata.
+
+    Token counts are always ``int``; ``cost`` is stored as a **stringified Decimal**
+    so the dict stays JSON-serializable when persisted into ``Message.message_metadata``
+    and SSE event payloads. Callers recover precision via
+    ``safe_decimal(usage["cost"])`` at record-usage sites.
+
+    All fields are optional (``total=False``) because some provider responses
+    omit token detail breakdowns and local/self-hosted providers omit ``cost``.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cached_tokens: int
+    reasoning_tokens: int
+    total_tokens: int
+    cost: NotRequired[str]
 
 
 @dataclass
@@ -170,8 +190,8 @@ class BaseProviderAdapter:
         # Decimal (not a Decimal object). The dict flows into message_metadata,
         # which is persisted as JSON — Decimal is not JSON-serializable by
         # default. Callers convert cost back to Decimal via safe_decimal() when
-        # recording usage.
-        self.usage: dict[str, int | str] = {}
+        # recording usage. See UsageDict for the full shape.
+        self.usage: UsageDict = {}
 
         self.db_session = context.db_session
 
@@ -228,8 +248,8 @@ class BaseProviderAdapter:
         reasoning_tokens: int,
         total_tokens: int,
         cost: Decimal | None = None,
-    ) -> dict[str, int | str]:
-        usage: dict[str, int | str] = {
+    ) -> UsageDict:
+        usage: UsageDict = {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "cached_tokens": cached_tokens,
@@ -241,17 +261,17 @@ class BaseProviderAdapter:
             usage["cost"] = str(cost)
         return usage
 
-    def _aggregate_usage(self, first: dict[str, int | str], second: dict[str, int | str]) -> dict[str, int | str]:
-        result: dict[str, int | str] = {}
+    def _aggregate_usage(self, first: UsageDict, second: UsageDict) -> UsageDict:
+        result: UsageDict = {}
         for k in set(first) | set(second):
             if k == "cost":
                 # Cost is stored as a stringified Decimal; sum with Decimal math
                 # to preserve precision, then restringify for JSON safety.
                 a = Decimal(str(first.get(k, "0")))
                 b = Decimal(str(second.get(k, "0")))
-                result[k] = str(a + b)
+                result[k] = str(a + b)  # type: ignore[literal-required]
             else:
-                result[k] = first.get(k, 0) + second.get(k, 0)  # type: ignore[operator]
+                result[k] = first.get(k, 0) + second.get(k, 0)  # type: ignore[literal-required,operator]
         return result
 
     def _flatten_chat_context(

--- a/backend/src/shu/services/providers/adapters/completions_adapter.py
+++ b/backend/src/shu/services/providers/adapters/completions_adapter.py
@@ -5,6 +5,7 @@ from typing import Any
 import jmespath
 
 from shu.core.logging import get_logger
+from shu.core.safe_decimal import safe_decimal
 from shu.models.plugin_execution import CallableTool
 
 from ..adapter_base import (
@@ -107,12 +108,15 @@ class CompletionsAdapter(BaseProviderAdapter):
         usage = jmespath.search(path, chunk) or {}
         if not usage:
             return
+        raw_cost = usage.get("cost")
+        cost = safe_decimal(raw_cost) if raw_cost is not None else None
         self._update_usage(
             usage.get("prompt_tokens", 0),
             usage.get("completion_tokens", 0),
             usage.get("prompt_tokens_details", {}).get("cached_tokens", 0),
             usage.get("completion_tokens_details", {}).get("reasoning_tokens", 0),
             usage.get("total_tokens", 0),
+            cost,
         )
 
     def _format_completions_attachments(self, attachments: list[Any]) -> list[dict[str, Any]]:

--- a/backend/src/shu/services/rag_processing_service.py
+++ b/backend/src/shu/services/rag_processing_service.py
@@ -51,6 +51,8 @@ class RAGProcessingService:
         text: str,
         document_title: str | None = None,
         config_manager: Optional["ConfigurationManager"] = None,  # noqa: F821
+        *,
+        user_id: str | None = None,
     ) -> list[DocumentChunk]:
         """Chunk the document text and generate embeddings for each chunk.
         Returns a list of DocumentChunk objects (not yet added to DB).
@@ -81,7 +83,7 @@ class RAGProcessingService:
                 chunks[0] = title_prefix + chunks[0]
 
         # 3. Generate embeddings via the EmbeddingService
-        embeddings = await self.embedding_service.embed_texts(chunks)
+        embeddings = await self.embedding_service.embed_texts(chunks, user_id=user_id)
 
         if len(embeddings) != len(chunks):
             raise ValueError(f"Embedding count mismatch: got {len(embeddings)} embeddings for {len(chunks)} chunks")

--- a/backend/src/shu/services/side_call_service.py
+++ b/backend/src/shu/services/side_call_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.config import ConfigurationManager
 from ..core.exceptions import LLMProviderError
+from ..core.safe_decimal import safe_decimal
 from ..llm.service import LLMService
 from ..models.llm_provider import Message
 from ..models.model_configuration import ModelConfiguration
@@ -150,6 +151,7 @@ class SideCallService:
                 output_tokens=output_tokens,
                 response_time_ms=response_time_ms,
                 success=True,
+                total_cost=safe_decimal(usage.get("cost")),
             )
 
             return SideCallResult(
@@ -631,6 +633,7 @@ class SideCallService:
                 output_tokens=output_tokens,
                 response_time_ms=response_time_ms,
                 success=True,
+                total_cost=safe_decimal(usage.get("cost")),
             )
 
             return SideCallResult(
@@ -771,6 +774,7 @@ class SideCallService:
         output_tokens: int,
         response_time_ms: int,
         success: bool,
+        total_cost: Decimal = Decimal("0"),
         error_message: str | None = None,
     ) -> None:
         """Record usage metrics for the side-call.
@@ -783,20 +787,19 @@ class SideCallService:
             output_tokens: Number of output (completion) tokens
             response_time_ms: Response time in milliseconds
             success: Whether the call was successful
+            total_cost: Provider-reported cost (Decimal(0) triggers DB-rate fallback
+                in LLMService.record_usage).
             error_message: Error message if the call failed
 
         """
         try:
-            # Record usage in LLMUsage table
-            # LLMService.record_usage() computes input_cost, output_cost, and
-            # total_cost from the model's pricing columns — no need to duplicate here.
             await self.llm_service.record_usage(
                 provider_id=model_config.llm_provider_id,
                 model_id=model.id,
                 request_type="side_call",
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
-                total_cost=Decimal("0"),
+                total_cost=total_cost,
                 user_id=user_id,
                 response_time_ms=response_time_ms,
                 success=success,

--- a/backend/src/shu/services/usage_recording.py
+++ b/backend/src/shu/services/usage_recording.py
@@ -24,6 +24,7 @@ async def record_llm_usage(
     provider_id: str,
     model_id: str,
     request_type: str,
+    user_id: str | None = None,
     input_tokens: int = 0,
     output_tokens: int = 0,
     total_tokens: int = 0,
@@ -39,11 +40,17 @@ async def record_llm_usage(
     Pass an existing `session` to reuse a connection already checked out
     (e.g. when the caller ran a query in the same unit of work).
     When omitted, a fresh session is created and committed automatically.
+
+    `user_id` should be populated wherever the originating user is
+    identifiable (chat conversation owner, ingestion job user, etc.) so
+    billing can attribute usage per user. It is nullable only for genuinely
+    user-less surfaces (none exist today).
     """
     try:
         record = LLMUsage(
             provider_id=provider_id,
             model_id=model_id,
+            user_id=user_id,
             request_type=request_type,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -73,6 +80,7 @@ async def record_llm_usage(
             extra={
                 "provider_id": provider_id,
                 "model_id": model_id,
+                "user_id": user_id,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 "total_tokens": total_tokens,

--- a/backend/src/shu/worker.py
+++ b/backend/src/shu/worker.py
@@ -140,6 +140,7 @@ async def _handle_ocr_job(job) -> None:  # noqa: PLR0915
         raise ValueError("INGESTION_OCR job missing mime_type in payload")
 
     ocr_mode = job.payload.get("ocr_mode")
+    user_id = job.payload.get("user_id")
 
     logger.info(
         "Processing OCR job",
@@ -209,6 +210,7 @@ async def _handle_ocr_job(job) -> None:  # noqa: PLR0915
                 get_config_manager(),
                 filename=filename,
                 ocr_mode=ocr_mode or "auto",
+                user_id=user_id,
             )
             extracted_text = extraction_result.get("text", "")
             extraction_metadata = extraction_result.get("metadata", {})
@@ -243,6 +245,7 @@ async def _handle_ocr_job(job) -> None:  # noqa: PLR0915
                 payload={
                     "document_id": document_id,
                     "knowledge_base_id": knowledge_base_id,
+                    "user_id": user_id,
                     "action": "embed_document",
                 },
                 max_attempts=3,
@@ -355,6 +358,8 @@ async def _handle_content_embed_job(job) -> None:
     if not knowledge_base_id:
         raise ValueError("INGESTION_EMBED job missing knowledge_base_id in payload")
 
+    user_id = job.payload.get("user_id")
+
     logger.info(
         "Processing embedding job",
         extra={
@@ -416,6 +421,7 @@ async def _handle_content_embed_job(job) -> None:
                     document,
                     document.title,  # type: ignore[arg-type]  # SQLAlchemy Column resolves at runtime
                     document.content,  # type: ignore[arg-type]
+                    user_id=user_id,
                 )
             except ValueError as kb_err:
                 # KB was deleted between OCR and embed stages — permanent failure, no retry.
@@ -444,7 +450,9 @@ async def _handle_content_embed_job(job) -> None:
             )
 
             settings = get_settings_instance()
-            await _finalize_embed_job(job, session, document, document_id, settings.enable_document_profiling)
+            await _finalize_embed_job(
+                job, session, document, document_id, settings.enable_document_profiling, user_id=user_id
+            )
 
         except Exception as e:
             # Check if we've exhausted retries
@@ -464,7 +472,9 @@ async def _handle_content_embed_job(job) -> None:
             raise
 
 
-async def _finalize_embed_job(job, session, document, document_id: str, profiling_enabled: bool) -> None:
+async def _finalize_embed_job(
+    job, session, document, document_id: str, profiling_enabled: bool, *, user_id: str | None = None
+) -> None:
     """Set CONTENT_PROCESSED, collect KB stats, then optionally enqueue profiling."""
     from .core.queue_backend import get_queue_backend
     from .core.workload_routing import WorkloadType, enqueue_job
@@ -494,7 +504,7 @@ async def _finalize_embed_job(job, session, document, document_id: str, profilin
         await enqueue_job(
             queue,
             WorkloadType.PROFILING,
-            payload={"document_id": document_id, "action": "profile_document"},
+            payload={"document_id": document_id, "user_id": user_id, "action": "profile_document"},
             max_attempts=5,
             visibility_timeout=600,
         )
@@ -531,6 +541,8 @@ async def _handle_profile_artifact_embed_job(job) -> None:
     if not document_id:
         raise ValueError("embed_profile_artifacts job missing document_id in payload")
 
+    user_id = job.payload.get("user_id")
+
     logger.info(
         "Processing profile artifact embedding job",
         extra={"job_id": job.id, "document_id": document_id},
@@ -555,7 +567,7 @@ async def _handle_profile_artifact_embed_job(job) -> None:
             await session.commit()
 
             synopsis_embedded, chunk_summaries_embedded, queries_embedded = await embed_profile_artifacts(
-                session, document
+                session, document, user_id=user_id
             )
 
             document.update_status(DocumentStatus.PROFILE_PROCESSED)
@@ -938,6 +950,8 @@ async def _handle_profiling_job(job) -> None:
     if not document_id:
         raise ValueError("PROFILING job missing document_id in payload")
 
+    user_id = job.payload.get("user_id")
+
     logger.info("Processing profiling job", extra={"job_id": job.id, "document_id": document_id})
 
     from sqlalchemy import select
@@ -956,7 +970,7 @@ async def _handle_profiling_job(job) -> None:
         side_call_service = SideCallService(session, config_manager)
         orchestrator = ProfilingOrchestrator(session, settings, side_call_service)
 
-        result = await orchestrator.run_for_document(document_id)
+        result = await orchestrator.run_for_document(document_id, user_id=user_id)
 
         if result.skipped:
             # skipped==True means the job had nothing to do (e.g. document not found). It is appropriate to bail without retrying.
@@ -985,6 +999,7 @@ async def _handle_profiling_job(job) -> None:
                     payload={
                         "document_id": document_id,
                         "knowledge_base_id": document.knowledge_base_id,
+                        "user_id": user_id,
                         "action": "embed_profile_artifacts",
                     },
                     max_attempts=3,

--- a/backend/src/tests/integ/test_chat_comprehensive_integration.py
+++ b/backend/src/tests/integ/test_chat_comprehensive_integration.py
@@ -93,8 +93,8 @@ async def test_model_configuration_conversation_creation(client, db, auth_header
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.00003,
-        "cost_per_output_token": 0.00006,
+        "cost_per_input_unit": 0.00003,
+        "cost_per_output_unit": 0.00006,
         "is_active": True,
     }
 
@@ -188,8 +188,8 @@ async def test_rag_integration_with_model_config(client, db, auth_headers):
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.00003,
-        "cost_per_output_token": 0.00006,
+        "cost_per_input_unit": 0.00003,
+        "cost_per_output_unit": 0.00006,
         "is_active": True,
     }
 
@@ -318,8 +318,8 @@ async def test_llm_integration_with_error_handling(client, db, auth_headers):
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.00003,
-        "cost_per_output_token": 0.00006,
+        "cost_per_input_unit": 0.00003,
+        "cost_per_output_unit": 0.00006,
         "is_active": True,
     }
 
@@ -424,8 +424,8 @@ async def test_streaming_functionality(client, db, auth_headers):
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.00003,
-        "cost_per_output_token": 0.00006,
+        "cost_per_input_unit": 0.00003,
+        "cost_per_output_unit": 0.00006,
         "is_active": True,
     }
 
@@ -526,8 +526,8 @@ async def test_performance_concurrent_conversations(client, db, auth_headers):
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.00003,
-        "cost_per_output_token": 0.00006,
+        "cost_per_input_unit": 0.00003,
+        "cost_per_output_unit": 0.00006,
         "is_active": True,
     }
 
@@ -608,8 +608,8 @@ async def test_authentication_and_permissions(client, db, auth_headers):
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.00003,
-        "cost_per_output_token": 0.00006,
+        "cost_per_input_unit": 0.00003,
+        "cost_per_output_unit": 0.00006,
         "is_active": True,
     }
 
@@ -687,8 +687,8 @@ async def test_edge_cases_and_validation(client, db, auth_headers):
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.00003,
-        "cost_per_output_token": 0.00006,
+        "cost_per_input_unit": 0.00003,
+        "cost_per_output_unit": 0.00006,
         "is_active": True,
     }
 

--- a/backend/src/tests/integ/test_chat_production_scenarios.py
+++ b/backend/src/tests/integ/test_chat_production_scenarios.py
@@ -48,8 +48,8 @@ async def test_production_model_config_conversation_flow(client, db, auth_header
         "max_output_tokens": 4096,
         "supports_streaming": True,
         "supports_functions": True,
-        "cost_per_input_token": 0.00001,
-        "cost_per_output_token": 0.00003,
+        "cost_per_input_unit": 0.00001,
+        "cost_per_output_unit": 0.00003,
         "is_active": True,
     }
 
@@ -177,8 +177,8 @@ async def test_production_rag_with_knowledge_bases(client, db, auth_headers):
         "max_output_tokens": 4096,
         "supports_streaming": True,
         "supports_functions": True,
-        "cost_per_input_token": 0.00001,
-        "cost_per_output_token": 0.00003,
+        "cost_per_input_unit": 0.00001,
+        "cost_per_output_unit": 0.00003,
         "is_active": True,
     }
 

--- a/backend/src/tests/integ/test_end_to_end_workflows.py
+++ b/backend/src/tests/integ/test_end_to_end_workflows.py
@@ -50,8 +50,8 @@ async def test_complete_admin_setup_workflow(client, db, auth_headers):
         "max_output_tokens": 4096,
         "supports_streaming": True,
         "supports_functions": True,
-        "cost_per_input_token": 0.00001,
-        "cost_per_output_token": 0.00003,
+        "cost_per_input_unit": 0.00001,
+        "cost_per_output_unit": 0.00003,
         "is_active": True,
     }
 
@@ -165,8 +165,8 @@ async def test_complete_user_chat_workflow(client, db, auth_headers):
         "max_output_tokens": 4096,
         "supports_streaming": True,
         "supports_functions": True,
-        "cost_per_input_token": 0.00001,
-        "cost_per_output_token": 0.00003,
+        "cost_per_input_unit": 0.00001,
+        "cost_per_output_unit": 0.00003,
         "is_active": True,
     }
 
@@ -325,8 +325,8 @@ async def test_error_recovery_workflow(client, db, auth_headers):
         "max_output_tokens": 4096,
         "supports_streaming": True,
         "supports_functions": True,
-        "cost_per_input_token": 0.00001,
-        "cost_per_output_token": 0.00003,
+        "cost_per_input_unit": 0.00001,
+        "cost_per_output_unit": 0.00003,
         "is_active": True,
     }
 
@@ -469,8 +469,8 @@ async def test_concurrent_user_workflow(client, db, auth_headers):
         "max_output_tokens": 4096,
         "supports_streaming": True,
         "supports_functions": True,
-        "cost_per_input_token": 0.00001,
-        "cost_per_output_token": 0.00003,
+        "cost_per_input_unit": 0.00001,
+        "cost_per_output_unit": 0.00003,
         "is_active": True,
     }
 

--- a/backend/src/tests/integ/test_llm_base_models_integration.py
+++ b/backend/src/tests/integ/test_llm_base_models_integration.py
@@ -68,8 +68,8 @@ MANUAL_MODEL_DATA = {
     "supports_streaming": True,
     "supports_functions": True,
     "supports_vision": True,
-    "cost_per_input_token": 0.00001,  # Fixed field name
-    "cost_per_output_token": 0.00003,  # Fixed field name
+    "cost_per_input_unit": 0.00001,  # Fixed field name
+    "cost_per_output_unit": 0.00003,  # Fixed field name
     "is_active": True,  # Added missing field
 }
 

--- a/backend/src/tests/integ/test_model_config_kb_prompts_integration.py
+++ b/backend/src/tests/integ/test_model_config_kb_prompts_integration.py
@@ -35,8 +35,8 @@ MODEL_DATA = {
     "max_output_tokens": 4096,
     "supports_streaming": True,
     "supports_functions": True,
-    "cost_per_input_token": 0.000005,
-    "cost_per_output_token": 0.000015,
+    "cost_per_input_unit": 0.000005,
+    "cost_per_output_unit": 0.000015,
     "is_active": True,
 }
 

--- a/backend/src/tests/integ/test_model_configuration_integration.py
+++ b/backend/src/tests/integ/test_model_configuration_integration.py
@@ -47,8 +47,8 @@ MODEL_DATA = {
     "max_output_tokens": 4096,
     "supports_streaming": True,
     "supports_functions": True,
-    "cost_per_input_token": 0.000005,
-    "cost_per_output_token": 0.000015,
+    "cost_per_input_unit": 0.000005,
+    "cost_per_output_unit": 0.000015,
     "is_active": True,
 }
 

--- a/backend/src/tests/integ/test_side_call_service_integration.py
+++ b/backend/src/tests/integ/test_side_call_service_integration.py
@@ -97,8 +97,8 @@ async def _create_local_side_call_model_config(client, db, auth_headers) -> dict
         "supports_streaming": True,
         "supports_functions": False,
         "supports_vision": False,
-        "cost_per_input_token": 0.0,
-        "cost_per_output_token": 0.0,
+        "cost_per_input_unit": 0.0,
+        "cost_per_output_unit": 0.0,
     }
     model_response = await client.post(
         f"/api/v1/llm/providers/{provider['id']}/models",

--- a/backend/src/tests/unit/core/test_extract_text_with_ocr_fallback.py
+++ b/backend/src/tests/unit/core/test_extract_text_with_ocr_fallback.py
@@ -341,3 +341,74 @@ class TestRunOCRService:
         assert result["metadata"]["details"]["page_count"] == 1
         assert result["metadata"]["details"]["ocr_mode"] == "auto"
         assert result["metadata"]["details"]["processing_time"] > 0
+
+
+class TestUserIdThreading:
+    """SHU-700 regression tests: user_id must reach the OCR service regardless
+    of which branch of extract_text_with_ocr_fallback fires.
+
+    An earlier user_id plumbing edit caught the ``ocr_mode='always'`` path but
+    missed the ``auto`` / ``fallback`` path — the latter dropped user_id on its
+    way to ``_run_ocr_service``. That bug left every auto-mode OCR row in
+    ``llm_usage`` with NULL ``user_id`` despite the ingestion worker passing
+    one correctly. These tests guard both branches.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_id_reaches_ocr_service_on_auto_fallback_path(self):
+        """Real-world path: text extraction below threshold → falls back to OCR."""
+        mock_extractor_cls, _ = _mock_text_extractor(text="short")  # below default min
+        mock_ocr_svc = _mock_ocr_service()
+
+        with patch("shu.core.ocr_service.TextExtractor", mock_extractor_cls), patch(
+            "shu.core.ocr_service.get_ocr_service", return_value=mock_ocr_svc
+        ), patch("shu.core.ocr_service.get_settings_instance", return_value=_mock_settings(50)):
+            reset_ocr_service()
+            await extract_text_with_ocr_fallback(
+                b"%PDF-dummy",
+                "application/pdf",
+                MagicMock(),
+                ocr_mode="auto",
+                user_id="user-abc",
+            )
+
+        mock_ocr_svc.extract_text.assert_called_once()
+        assert mock_ocr_svc.extract_text.call_args.kwargs.get("user_id") == "user-abc", (
+            "user_id must be forwarded to the OCR service on the auto/fallback path"
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_id_reaches_ocr_service_on_always_path(self):
+        """ocr_mode='always' forces OCR; user_id must still thread through."""
+        mock_ocr_svc = _mock_ocr_service()
+
+        with patch("shu.core.ocr_service.get_ocr_service", return_value=mock_ocr_svc), patch(
+            "shu.core.ocr_service.get_settings_instance", return_value=_mock_settings()
+        ):
+            reset_ocr_service()
+            await extract_text_with_ocr_fallback(
+                b"%PDF-dummy",
+                "application/pdf",
+                MagicMock(),
+                ocr_mode="always",
+                user_id="user-xyz",
+            )
+
+        mock_ocr_svc.extract_text.assert_called_once()
+        assert mock_ocr_svc.extract_text.call_args.kwargs.get("user_id") == "user-xyz"
+
+    @pytest.mark.asyncio
+    async def test_user_id_default_is_none_when_not_provided(self):
+        """Regression guard: callers that don't pass user_id still get None-safe behavior."""
+        mock_extractor_cls, _ = _mock_text_extractor(text="short")
+        mock_ocr_svc = _mock_ocr_service()
+
+        with patch("shu.core.ocr_service.TextExtractor", mock_extractor_cls), patch(
+            "shu.core.ocr_service.get_ocr_service", return_value=mock_ocr_svc
+        ), patch("shu.core.ocr_service.get_settings_instance", return_value=_mock_settings(50)):
+            reset_ocr_service()
+            await extract_text_with_ocr_fallback(
+                b"%PDF-dummy", "application/pdf", MagicMock(), ocr_mode="auto"
+            )
+
+        assert mock_ocr_svc.extract_text.call_args.kwargs.get("user_id") is None

--- a/backend/src/tests/unit/llm/test_service.py
+++ b/backend/src/tests/unit/llm/test_service.py
@@ -122,7 +122,7 @@ class TestRecordUsage:
     """
 
     @staticmethod
-    def _make_service_with_model(model: MagicMock | None) -> tuple[MagicMock, "LLMService"]:
+    def _make_service_with_model(model):
         from shu.llm.service import LLMService
 
         db = AsyncMock(spec=AsyncSession)
@@ -135,6 +135,7 @@ class TestRecordUsage:
     @staticmethod
     def _model_with_rates(input_rate: str, output_rate: str) -> MagicMock:
         from decimal import Decimal
+
         m = MagicMock()
         m.cost_per_input_unit = Decimal(input_rate)
         m.cost_per_output_unit = Decimal(output_rate)
@@ -236,25 +237,83 @@ class TestRecordUsage:
         usage = db.add.call_args[0][0]
         assert usage.user_id is None
 
+    @pytest.mark.asyncio
+    async def test_one_sided_rate_still_computes_input_cost(self):
+        """Regression: Decimal(0) output rate must not collapse the DB-rate fallback.
+
+        An earlier guard used truthiness (`model.cost_per_input_unit and
+        model.cost_per_output_unit`), which treated a legitimate Decimal(0)
+        output rate as "no pricing" and silently recorded $0 for a chat row
+        with real input-token cost. Using `is not None` preserves each side
+        independently.
+        """
+        from decimal import Decimal
+        db, service = self._make_service_with_model(
+            self._model_with_rates("0.00001", "0")  # free output, billed input
+        )
+
+        await service.record_usage(
+            provider_id="p1",
+            model_id="m1",
+            request_type="chat",
+            input_tokens=1000,
+            output_tokens=500,
+            total_cost=Decimal("0"),
+        )
+
+        usage = db.add.call_args[0][0]
+        assert usage.input_cost == Decimal("0.01")  # 1000 * 0.00001
+        assert usage.output_cost == Decimal("0")   # 500 * 0
+        assert usage.total_cost == Decimal("0.01")
+        assert usage.input_cost + usage.output_cost == usage.total_cost
+
+    @pytest.mark.asyncio
+    async def test_only_input_rate_set_still_computes(self):
+        """Only cost_per_input_unit set (output rate NULL) falls back to Decimal(0) for output."""
+        from decimal import Decimal
+        model = MagicMock()
+        model.cost_per_input_unit = Decimal("0.00002")
+        model.cost_per_output_unit = None
+        db, service = self._make_service_with_model(model)
+
+        await service.record_usage(
+            provider_id="p1",
+            model_id="m1",
+            request_type="chat",
+            input_tokens=500,
+            output_tokens=100,
+            total_cost=Decimal("0"),
+        )
+
+        usage = db.add.call_args[0][0]
+        assert usage.input_cost == Decimal("0.01")
+        assert usage.output_cost == Decimal("0")
+        assert usage.total_cost == Decimal("0.01")
+
 
 class TestSafeDecimal:
     """safe_decimal() coerces untrusted provider values into Decimal defensively."""
 
     def test_numeric_string_is_coerced(self):
         from decimal import Decimal
+
         from shu.core.safe_decimal import safe_decimal
+
         assert safe_decimal("0.042") == Decimal("0.042")
         assert safe_decimal(0.042) == Decimal(str(0.042))
         assert safe_decimal(42) == Decimal("42")
 
     def test_none_returns_zero(self):
         from decimal import Decimal
+
         from shu.core.safe_decimal import safe_decimal
+
         assert safe_decimal(None) == Decimal(0)
 
     def test_malformed_returns_zero_with_warning(self, caplog):
         import logging
         from decimal import Decimal
+
         from shu.core.safe_decimal import safe_decimal
 
         with caplog.at_level(logging.WARNING):

--- a/backend/src/tests/unit/llm/test_service.py
+++ b/backend/src/tests/unit/llm/test_service.py
@@ -111,3 +111,154 @@ class TestModelConfigurationTypeValidation:
             await service.create_model_configuration(config_data, created_by="test-user")
         except ShuException as e:
             assert e.error_code != "INVALID_MODEL_TYPE", f"Chat model should pass type validation, got: {e.error_code}"
+
+
+class TestRecordUsage:
+    """Cover the two-tier cost-resolution contract of LLMService.record_usage.
+
+    SHU-700: provider-reported cost is authoritative when non-zero; DB-rate math
+    is the fallback when the caller passes Decimal(0). user_id is always threaded
+    through to the written llm_usage row.
+    """
+
+    @staticmethod
+    def _make_service_with_model(model: MagicMock | None) -> tuple[MagicMock, "LLMService"]:
+        from shu.llm.service import LLMService
+
+        db = AsyncMock(spec=AsyncSession)
+        db.get = AsyncMock(return_value=model)
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        service = LLMService(db)
+        return db, service
+
+    @staticmethod
+    def _model_with_rates(input_rate: str, output_rate: str) -> MagicMock:
+        from decimal import Decimal
+        m = MagicMock()
+        m.cost_per_input_unit = Decimal(input_rate)
+        m.cost_per_output_unit = Decimal(output_rate)
+        return m
+
+    @pytest.mark.asyncio
+    async def test_provider_reported_cost_recorded_verbatim(self):
+        """Non-zero caller-supplied total_cost is authoritative; input/output = 0."""
+        from decimal import Decimal
+        db, service = self._make_service_with_model(
+            self._model_with_rates("0.00001", "0.00003")  # DB rates present but should be IGNORED
+        )
+
+        await service.record_usage(
+            provider_id="p1",
+            model_id="m1",
+            request_type="chat",
+            input_tokens=1000,
+            output_tokens=500,
+            total_cost=Decimal("0.042"),  # provider-reported wire value
+            user_id="user-1",
+        )
+
+        db.add.assert_called_once()
+        usage = db.add.call_args[0][0]
+        assert usage.total_cost == Decimal("0.042")
+        assert usage.input_cost == Decimal("0")
+        assert usage.output_cost == Decimal("0")
+        assert usage.user_id == "user-1"
+
+    @pytest.mark.asyncio
+    async def test_db_rate_fallback_when_total_cost_is_zero(self):
+        """total_cost=0 triggers DB-rate math; summation invariant holds."""
+        from decimal import Decimal
+        db, service = self._make_service_with_model(
+            self._model_with_rates("0.00001", "0.00003")
+        )
+
+        await service.record_usage(
+            provider_id="p1",
+            model_id="m1",
+            request_type="chat",
+            input_tokens=1000,
+            output_tokens=500,
+            total_cost=Decimal("0"),  # sentinel for "caller has no provider cost"
+            user_id="user-2",
+        )
+
+        usage = db.add.call_args[0][0]
+        assert usage.input_cost == Decimal("0.01")   # 1000 * 0.00001
+        assert usage.output_cost == Decimal("0.015") # 500 * 0.00003
+        assert usage.total_cost == Decimal("0.025")
+        assert usage.input_cost + usage.output_cost == usage.total_cost
+        assert usage.user_id == "user-2"
+
+    @pytest.mark.asyncio
+    async def test_no_rates_no_provider_cost_records_all_zero(self):
+        """Local/self-hosted models with NULL rates and no wire cost record all zeros."""
+        from decimal import Decimal
+        local_model = MagicMock()
+        local_model.cost_per_input_unit = None
+        local_model.cost_per_output_unit = None
+        db, service = self._make_service_with_model(local_model)
+
+        await service.record_usage(
+            provider_id="p1",
+            model_id="m1",
+            request_type="chat",
+            input_tokens=1000,
+            output_tokens=500,
+            total_cost=Decimal("0"),
+            user_id="user-3",
+        )
+
+        usage = db.add.call_args[0][0]
+        assert usage.input_cost == Decimal("0")
+        assert usage.output_cost == Decimal("0")
+        assert usage.total_cost == Decimal("0")
+        assert usage.user_id == "user-3"
+
+    @pytest.mark.asyncio
+    async def test_user_id_nullable_on_write(self):
+        """user_id=None is valid; the row still writes cleanly."""
+        from decimal import Decimal
+        db, service = self._make_service_with_model(
+            self._model_with_rates("0.00001", "0.00003")
+        )
+
+        await service.record_usage(
+            provider_id="p1",
+            model_id="m1",
+            request_type="chat",
+            input_tokens=10,
+            output_tokens=5,
+            total_cost=Decimal("0"),
+            # user_id omitted
+        )
+
+        usage = db.add.call_args[0][0]
+        assert usage.user_id is None
+
+
+class TestSafeDecimal:
+    """safe_decimal() coerces untrusted provider values into Decimal defensively."""
+
+    def test_numeric_string_is_coerced(self):
+        from decimal import Decimal
+        from shu.core.safe_decimal import safe_decimal
+        assert safe_decimal("0.042") == Decimal("0.042")
+        assert safe_decimal(0.042) == Decimal(str(0.042))
+        assert safe_decimal(42) == Decimal("42")
+
+    def test_none_returns_zero(self):
+        from decimal import Decimal
+        from shu.core.safe_decimal import safe_decimal
+        assert safe_decimal(None) == Decimal(0)
+
+    def test_malformed_returns_zero_with_warning(self, caplog):
+        import logging
+        from decimal import Decimal
+        from shu.core.safe_decimal import safe_decimal
+
+        with caplog.at_level(logging.WARNING):
+            result = safe_decimal("N/A")
+
+        assert result == Decimal(0)
+        assert any("Malformed" in rec.message for rec in caplog.records)

--- a/backend/src/tests/unit/plugins/host/test_ocr_capability.py
+++ b/backend/src/tests/unit/plugins/host/test_ocr_capability.py
@@ -33,16 +33,33 @@ def _load_module(module_name: str, file_path: Path):
 # Load base (needed by ocr_capability)
 _load_module("shu.plugins.host.base", _HOST_DIR / "base.py")
 
-# Stub out shu.core.ocr_service so ocr_capability's `from ...core.ocr_service import
-# extract_text_with_ocr_fallback` resolves cleanly without loading the full module
-# (which pulls in heavy dependencies via TextExtractor chain).
-if "shu.core.ocr_service" not in sys.modules:
+# Stub out shu.core.ocr_service so ocr_capability's `from ...core.ocr_service
+# import extract_text_with_ocr_fallback` resolves cleanly without loading the
+# real module (which pulls in heavy dependencies via the TextExtractor chain).
+#
+# Scope: the stub only needs to be in sys.modules long enough for _load_module
+# below to import ocr_capability — at which point _ocr_cap_mod has already
+# captured the stub's `extract_text_with_ocr_fallback` attribute into its own
+# namespace. After that, sys.modules["shu.core.ocr_service"] is restored so
+# other test modules that import the real module see it, and our tests use
+# patch.object(_ocr_cap_mod, ...) against the already-captured reference.
+# A module-teardown fixture is NOT sufficient here because pytest imports all
+# test modules during collection before running any tests — a late teardown
+# would leak the stub into every test module collected afterwards.
+_previous_ocr_service = sys.modules.get("shu.core.ocr_service")
+if _previous_ocr_service is None:
     _ocr_service_stub = MagicMock()
     _ocr_service_stub.extract_text_with_ocr_fallback = AsyncMock()
     sys.modules["shu.core.ocr_service"] = _ocr_service_stub
 
 _ocr_cap_mod = _load_module("shu.plugins.host.ocr_capability", _HOST_DIR / "ocr_capability.py")
 OcrCapability = _ocr_cap_mod.OcrCapability
+
+# Restore sys.modules immediately. _ocr_cap_mod has already captured the stub
+# via its `from ... import extract_text_with_ocr_fallback`, so the in-namespace
+# reference survives even after the stub is popped from sys.modules.
+if _previous_ocr_service is None:
+    del sys.modules["shu.core.ocr_service"]
 
 
 def _make_capability(user_id: str = "user-1", plugin_name: str = "test_plugin") -> "OcrCapability":

--- a/backend/src/tests/unit/plugins/host/test_ocr_capability.py
+++ b/backend/src/tests/unit/plugins/host/test_ocr_capability.py
@@ -1,0 +1,96 @@
+"""Unit tests for OcrCapability (host.ocr plugin capability).
+
+Uses the same direct-module-load pattern as test_kb_capability.py to avoid
+triggering the full shu.plugins.host package __init__, which pulls in heavy
+capability dependencies that aren't needed for isolated capability tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_HOST_DIR = Path(__file__).resolve().parents[4] / "shu" / "plugins" / "host"
+
+
+def _load_module(module_name: str, file_path: Path):
+    """Load a module directly from its file path, registering it in sys.modules."""
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, str(file_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module '{module_name}' from '{file_path}'")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Load base (needed by ocr_capability)
+_load_module("shu.plugins.host.base", _HOST_DIR / "base.py")
+
+# Stub out shu.core.ocr_service so ocr_capability's `from ...core.ocr_service import
+# extract_text_with_ocr_fallback` resolves cleanly without loading the full module
+# (which pulls in heavy dependencies via TextExtractor chain).
+if "shu.core.ocr_service" not in sys.modules:
+    _ocr_service_stub = MagicMock()
+    _ocr_service_stub.extract_text_with_ocr_fallback = AsyncMock()
+    sys.modules["shu.core.ocr_service"] = _ocr_service_stub
+
+_ocr_cap_mod = _load_module("shu.plugins.host.ocr_capability", _HOST_DIR / "ocr_capability.py")
+OcrCapability = _ocr_cap_mod.OcrCapability
+
+
+def _make_capability(user_id: str = "user-1", plugin_name: str = "test_plugin") -> "OcrCapability":
+    return OcrCapability(
+        plugin_name=plugin_name,
+        user_id=user_id,
+        config_manager=MagicMock(),
+        ocr_mode=None,
+    )
+
+
+class TestUserIdThreading:
+    """SHU-700 regression guard: host.ocr.extract_text must forward the acting
+    user's ID into the OCR pipeline. Dropping it at this boundary would leave
+    every plugin-initiated OCR row in llm_usage with NULL user_id, breaking
+    per-user billing attribution for plugin-driven OCR workloads.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_id_is_forwarded_to_ocr_fallback(self):
+        cap = _make_capability(user_id="user-abc")
+
+        with patch.object(
+            _ocr_cap_mod,
+            "extract_text_with_ocr_fallback",
+            new_callable=AsyncMock,
+        ) as mock_fallback:
+            mock_fallback.return_value = {"text": "ok", "metadata": {}}
+            await cap.extract_text(file_bytes=b"%PDF-fake", mime_type="application/pdf")
+
+        mock_fallback.assert_awaited_once()
+        assert mock_fallback.call_args.kwargs.get("user_id") == "user-abc", (
+            "host.ocr.extract_text must forward user_id to extract_text_with_ocr_fallback"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mode_override_still_forwards_user_id(self):
+        """Caller-supplied mode override must not disturb user_id forwarding."""
+        cap = _make_capability(user_id="user-xyz")
+
+        with patch.object(
+            _ocr_cap_mod,
+            "extract_text_with_ocr_fallback",
+            new_callable=AsyncMock,
+        ) as mock_fallback:
+            mock_fallback.return_value = {"text": "ok", "metadata": {}}
+            await cap.extract_text(file_bytes=b"data", mime_type="image/png", mode="always")
+
+        kwargs = mock_fallback.call_args.kwargs
+        assert kwargs.get("user_id") == "user-xyz"
+        assert kwargs.get("ocr_mode") == "always"

--- a/backend/src/tests/unit/services/providers/test_adapter_base_usage.py
+++ b/backend/src/tests/unit/services/providers/test_adapter_base_usage.py
@@ -1,0 +1,175 @@
+"""Regression tests for BaseProviderAdapter usage-tracking helpers.
+
+Guards the SHU-700 JSON-safety invariant: `self.usage` must round-trip
+cleanly through JSON (for persistence into `Message.message_metadata` and
+SSE event serialization), while preserving Decimal precision for cost.
+
+The fix stores `cost` as a stringified Decimal and special-cases the
+`cost` key in `_aggregate_usage` so cross-cycle accumulation (tool-use
+loops) sums with Decimal precision rather than string concatenation.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+from shu.core.safe_decimal import safe_decimal
+from shu.services.providers.adapter_base import BaseProviderAdapter
+
+
+def _make_adapter() -> BaseProviderAdapter:
+    """Build a bare BaseProviderAdapter instance without running __init__.
+
+    The usage helpers (_get_usage, _update_usage, _aggregate_usage) don't
+    need provider/db/settings state — they just operate on `self.usage`.
+    Skipping __init__ keeps the test free of encryption-key / settings
+    dependencies.
+    """
+    adapter = BaseProviderAdapter.__new__(BaseProviderAdapter)
+    adapter.usage = {}
+    return adapter
+
+
+class TestGetUsageShape:
+    def test_without_cost_omits_cost_key(self):
+        adapter = _make_adapter()
+        usage = adapter._get_usage(10, 20, 0, 0, 30)
+        assert "cost" not in usage
+        assert usage == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "cached_tokens": 0,
+            "reasoning_tokens": 0,
+            "total_tokens": 30,
+        }
+
+    def test_with_cost_stores_string(self):
+        adapter = _make_adapter()
+        usage = adapter._get_usage(10, 20, 0, 0, 30, cost=Decimal("0.042"))
+        assert usage["cost"] == "0.042"
+        assert isinstance(usage["cost"], str), (
+            "cost must be stored as str to stay JSON-serializable; storing "
+            "it as Decimal broke message_metadata persistence in SHU-700"
+        )
+
+    def test_cost_precision_is_preserved_through_round_trip(self):
+        """Small-fraction costs (typical for single-token requests) survive intact.
+
+        Note: ``str(Decimal("0.000000015"))`` is ``"1.5E-8"`` (Python's canonical
+        representation switches to scientific notation for small numbers). Values
+        round-trip losslessly via Decimal() parsing, so only value-equality matters;
+        the exact string form does not.
+        """
+        adapter = _make_adapter()
+        usage = adapter._get_usage(1, 1, 0, 0, 2, cost=Decimal("0.000000015"))
+        assert safe_decimal(usage["cost"]) == Decimal("0.000000015")
+
+
+class TestUsageDictJsonRoundTrip:
+    """The load-bearing invariant: usage dicts must survive json.dumps/loads."""
+
+    def test_usage_with_cost_survives_json_dumps(self):
+        adapter = _make_adapter()
+        usage = adapter._get_usage(100, 50, 10, 0, 150, cost=Decimal("0.00123"))
+
+        # If Decimal ever leaks back in, json.dumps raises TypeError.
+        serialized = json.dumps(usage)
+        deserialized = json.loads(serialized)
+
+        assert deserialized["input_tokens"] == 100
+        assert deserialized["output_tokens"] == 50
+        # Precise round-trip via safe_decimal (the actual path used by callers).
+        assert safe_decimal(deserialized["cost"]) == Decimal("0.00123")
+
+    def test_usage_without_cost_survives_json_dumps(self):
+        adapter = _make_adapter()
+        usage = adapter._get_usage(5, 10, 0, 0, 15)
+        # No cost key → plain int dict, trivially JSON-safe.
+        assert json.loads(json.dumps(usage)) == usage
+
+    def test_aggregated_usage_stays_json_safe(self):
+        """After _aggregate_usage, cost must still be a string — not a Decimal."""
+        adapter = _make_adapter()
+        first = adapter._get_usage(10, 20, 0, 0, 30, cost=Decimal("0.01"))
+        second = adapter._get_usage(5, 15, 0, 0, 20, cost=Decimal("0.02"))
+
+        aggregated = adapter._aggregate_usage(first, second)
+        assert isinstance(aggregated["cost"], str)
+        # json.dumps is the real regression test — it raises on Decimal.
+        serialized = json.dumps(aggregated)
+        deserialized = json.loads(serialized)
+        assert safe_decimal(deserialized["cost"]) == Decimal("0.03")
+
+
+class TestAggregateUsage:
+    def test_tokens_sum_as_ints(self):
+        adapter = _make_adapter()
+        first = adapter._get_usage(10, 20, 5, 0, 30)
+        second = adapter._get_usage(3, 7, 2, 1, 10)
+        result = adapter._aggregate_usage(first, second)
+        assert result["input_tokens"] == 13
+        assert result["output_tokens"] == 27
+        assert result["cached_tokens"] == 7
+        assert result["reasoning_tokens"] == 1
+        assert result["total_tokens"] == 40
+
+    def test_cost_sums_with_decimal_precision(self):
+        """Critical: two cost-bearing cycles (tool-use loop) must sum losslessly."""
+        adapter = _make_adapter()
+        first = adapter._get_usage(10, 20, 0, 0, 30, cost=Decimal("0.000000015"))
+        second = adapter._get_usage(10, 20, 0, 0, 30, cost=Decimal("0.000000020"))
+
+        result = adapter._aggregate_usage(first, second)
+        # If the aggregator concatenated strings instead of summing, this'd be
+        # "0.0000000150.000000020". If it used float, we'd drift.
+        assert safe_decimal(result["cost"]) == Decimal("0.000000035")
+
+    def test_cost_in_only_one_dict_still_sums(self):
+        """Missing cost on one side defaults to 0 — doesn't lose the other side's value."""
+        adapter = _make_adapter()
+        first = adapter._get_usage(10, 20, 0, 0, 30, cost=Decimal("0.042"))
+        second = adapter._get_usage(5, 5, 0, 0, 10)  # no cost
+
+        result = adapter._aggregate_usage(first, second)
+        assert safe_decimal(result["cost"]) == Decimal("0.042")
+
+
+class TestUpdateUsageStatefulAccumulation:
+    """_update_usage mutates self.usage — verify the aggregation lands correctly."""
+
+    def test_first_update_seeds_dict(self):
+        adapter = _make_adapter()
+        adapter._update_usage(100, 50, 0, 0, 150, cost=Decimal("0.01"))
+        assert adapter.usage["input_tokens"] == 100
+        assert safe_decimal(adapter.usage["cost"]) == Decimal("0.01")
+
+    def test_second_update_aggregates(self):
+        adapter = _make_adapter()
+        adapter._update_usage(100, 50, 0, 0, 150, cost=Decimal("0.01"))
+        adapter._update_usage(200, 75, 0, 0, 275, cost=Decimal("0.02"))
+
+        assert adapter.usage["input_tokens"] == 300
+        assert adapter.usage["output_tokens"] == 125
+        assert adapter.usage["total_tokens"] == 425
+        assert safe_decimal(adapter.usage["cost"]) == Decimal("0.03")
+
+        # Regression: the accumulated dict must still be JSON-safe.
+        json.dumps(adapter.usage)
+
+    @pytest.mark.parametrize(
+        ("first_cost", "second_cost", "expected"),
+        [
+            # Common accumulation patterns from real OpenRouter responses.
+            (Decimal("0.000001"), Decimal("0.000002"), Decimal("0.000003")),
+            (Decimal("1.5"), Decimal("0.5"), Decimal("2.0")),
+            # Zero cost on either side.
+            (Decimal("0"), Decimal("0.042"), Decimal("0.042")),
+            (Decimal("0.042"), Decimal("0"), Decimal("0.042")),
+        ],
+    )
+    def test_cost_accumulation_parametrized(self, first_cost, second_cost, expected):
+        adapter = _make_adapter()
+        adapter._update_usage(1, 1, 0, 0, 2, cost=first_cost)
+        adapter._update_usage(1, 1, 0, 0, 2, cost=second_cost)
+        assert safe_decimal(adapter.usage["cost"]) == expected

--- a/backend/src/tests/unit/services/test_chat_service.py
+++ b/backend/src/tests/unit/services/test_chat_service.py
@@ -1503,3 +1503,66 @@ class TestChatServiceExplicitKnowledgeBaseAccess:
 
             mock_kb_service.check_kb_read_access.assert_not_called()
             assert ctx.knowledge_base_ids == []
+
+
+class TestHandleExceptionUserIdThreading:
+    """SHU-700 regression tests: _handle_exception must forward user_id to record_usage.
+
+    Streaming callers pass ``conversation.user_id`` (via ``conversation_owner_id``)
+    into ``_handle_exception``; the method must thread it to ``LLMService.record_usage``
+    so failed-chat rows in ``llm_usage`` still attribute to the originating user.
+    Dropping it at this boundary would leave every failed chat attempt with a
+    NULL ``user_id`` despite the caller supplying one — symmetric to the OCR
+    auto/fallback bug caught mid-ticket.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_id_forwarded_to_record_usage(self):
+        from shu.core.exceptions import LLMProviderError
+
+        chat_service = ChatService.__new__(ChatService)
+        chat_service.db_session = AsyncMock()
+        chat_service.llm_service = MagicMock()
+        chat_service.llm_service.record_usage = AsyncMock()
+        chat_service.add_message = AsyncMock()
+
+        model = MagicMock()
+        model.id = "model-1"
+        model.provider_id = "provider-1"
+
+        await chat_service._handle_exception(
+            conversation_id="conv-1",
+            model=model,
+            e=LLMProviderError("boom"),
+            user_id="user-42",
+        )
+
+        chat_service.llm_service.record_usage.assert_awaited_once()
+        kwargs = chat_service.llm_service.record_usage.call_args.kwargs
+        assert kwargs["user_id"] == "user-42"
+        assert kwargs["success"] is False
+        assert kwargs["request_type"] == "chat"
+
+    @pytest.mark.asyncio
+    async def test_user_id_defaults_to_none_when_not_provided(self):
+        """Backwards compat: legacy callers that don't pass user_id still work."""
+        from shu.core.exceptions import LLMProviderError
+
+        chat_service = ChatService.__new__(ChatService)
+        chat_service.db_session = AsyncMock()
+        chat_service.llm_service = MagicMock()
+        chat_service.llm_service.record_usage = AsyncMock()
+        chat_service.add_message = AsyncMock()
+
+        model = MagicMock()
+        model.id = "model-1"
+        model.provider_id = "provider-1"
+
+        await chat_service._handle_exception(
+            conversation_id="conv-1",
+            model=model,
+            e=LLMProviderError("boom"),
+        )
+
+        kwargs = chat_service.llm_service.record_usage.call_args.kwargs
+        assert kwargs["user_id"] is None

--- a/backend/src/tests/unit/services/test_external_embedding_service.py
+++ b/backend/src/tests/unit/services/test_external_embedding_service.py
@@ -287,3 +287,56 @@ class TestErrorHandling:
             svc = _make_service()
             with pytest.raises(httpx.HTTPStatusError):
                 await svc.embed_texts(["test"])
+
+
+class TestRecordUsageCostContract:
+    """SHU-700: provider-authoritative cost contract — embedding rows must match
+    the chat-path shape so downstream aggregators can identify wire-reported
+    rows uniformly by `input_cost == 0 AND output_cost == 0 AND total_cost > 0`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_wire_cost_recorded_on_total_only(self):
+        """Provider-reported `usage.cost` lands on `total_cost`; input/output stay 0."""
+        from decimal import Decimal
+
+        svc = _make_service()
+
+        with patch("shu.services.usage_recording.record_llm_usage", new_callable=AsyncMock) as mock_record:
+            await svc._record_usage(
+                {"prompt_tokens": 100, "total_tokens": 100, "cost": "0.00042"},
+                user_id="user-7",
+            )
+
+        mock_record.assert_awaited_once()
+        kwargs = mock_record.call_args.kwargs
+        assert kwargs["total_cost"] == Decimal("0.00042")
+        assert kwargs["input_cost"] == Decimal(0)
+        assert kwargs["output_cost"] == Decimal(0)
+        assert kwargs["user_id"] == "user-7"
+        assert kwargs["request_type"] == "embedding"
+
+    @pytest.mark.asyncio
+    async def test_missing_wire_cost_records_zero(self):
+        """Response without `cost` field (local provider) records all-zero costs, not NULL."""
+        from decimal import Decimal
+
+        svc = _make_service()
+
+        with patch("shu.services.usage_recording.record_llm_usage", new_callable=AsyncMock) as mock_record:
+            await svc._record_usage({"prompt_tokens": 50, "total_tokens": 50})
+
+        kwargs = mock_record.call_args.kwargs
+        assert kwargs["total_cost"] == Decimal(0)
+        assert kwargs["input_cost"] == Decimal(0)
+        assert kwargs["output_cost"] == Decimal(0)
+
+    @pytest.mark.asyncio
+    async def test_empty_usage_skips_record(self):
+        """No usage block at all (early return path) must not call record_llm_usage."""
+        svc = _make_service()
+
+        with patch("shu.services.usage_recording.record_llm_usage", new_callable=AsyncMock) as mock_record:
+            await svc._record_usage(None)
+
+        mock_record.assert_not_called()

--- a/backend/src/tests/unit/services/test_external_ocr_service.py
+++ b/backend/src/tests/unit/services/test_external_ocr_service.py
@@ -206,6 +206,10 @@ class TestUsageRecording:
         mock_savepoint.__aenter__ = AsyncMock()
         mock_savepoint.__aexit__ = AsyncMock(return_value=False)
         mock_session.begin_nested = MagicMock(return_value=mock_savepoint)
+        # session.add() is SYNC in SQLAlchemy. AsyncMock's default would return
+        # a coroutine that record_llm_usage never awaits, producing a
+        # RuntimeWarning that masks real unawaited-coroutine regressions.
+        mock_session.add = MagicMock()
 
         mock_session_factory = MagicMock()
         mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
@@ -232,7 +236,17 @@ class TestUsageRecording:
 
     @pytest.mark.asyncio
     async def test_record_usage_calls_ensure_provider(self):
-        """_record_usage should call _resolve_provider_and_model on first use."""
+        """_record_usage should call _resolve_provider_and_model on first use.
+
+        Resolver is stubbed to return False so the method returns early via the
+        "provider/model not seeded" branch. Without that, the downstream
+        `async with session.begin_nested()` call would fire against AsyncMock's
+        default — begin_nested would return a coroutine instead of an async
+        context manager, raising AttributeError inside the try/except and
+        producing a "coroutine never awaited" RuntimeWarning. The test's only
+        contract is "resolver gets called on first use"; exercising the DB
+        write path isn't part of that contract.
+        """
         svc = _make_service()
         assert svc._provider_id is None
 
@@ -244,7 +258,9 @@ class TestUsageRecording:
         with patch(
             "shu.core.database.get_async_session_local",
             return_value=mock_session_factory,
-        ), patch.object(svc, "_resolve_provider_and_model", new_callable=AsyncMock) as mock_ensure:
+        ), patch.object(
+            svc, "_resolve_provider_and_model", new_callable=AsyncMock, return_value=False
+        ) as mock_ensure:
             await svc._record_usage(page_count=1)
 
         mock_ensure.assert_called_once()

--- a/backend/src/tests/unit/services/test_external_ocr_service.py
+++ b/backend/src/tests/unit/services/test_external_ocr_service.py
@@ -37,8 +37,18 @@ def _mock_ocr_response(pages: list[dict]) -> httpx.Response:
 
 @contextmanager
 def _patched_httpx(response):
-    """Patch httpx.AsyncClient to return a mock that yields `response` on post."""
-    with patch("shu.services.external_ocr_service.httpx.AsyncClient") as mock_client_cls:
+    """Patch httpx.AsyncClient AND ExternalOCRService._record_usage for full DB isolation.
+
+    Previously only httpx was mocked, which let the real `_record_usage` method run
+    and write rows to whatever database the host env pointed at (a live dev Postgres
+    in typical setups). Tests that exercise the extract_text control flow don't need
+    to verify usage persistence — that is covered separately in TestUsageRecording —
+    so a blanket mock on `_record_usage` keeps these tests hermetic.
+    """
+    with (
+        patch("shu.services.external_ocr_service.httpx.AsyncClient") as mock_client_cls,
+        patch.object(ExternalOCRService, "_record_usage", new_callable=AsyncMock),
+    ):
         mock_client = AsyncMock()
         mock_client.post.return_value = response
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)

--- a/backend/src/tests/unit/services/test_external_ocr_service.py
+++ b/backend/src/tests/unit/services/test_external_ocr_service.py
@@ -9,7 +9,11 @@ import httpx
 import pytest
 
 from shu.core.ocr_service import OCRResult
-from shu.services.external_ocr_service import ExternalOCRService, _COST_PER_PAGE
+from shu.services.external_ocr_service import ExternalOCRService
+
+# OCR cost is now DB-sourced (cost_per_input_unit on the llm_models row, seeded from
+# model_pricing.py). Tests that assert on total cost stub a model row with this rate.
+_OCR_PER_PAGE_RATE = Decimal("0.002")
 
 
 def _make_service(**kwargs) -> ExternalOCRService:
@@ -176,12 +180,17 @@ class TestUsageRecording:
 
     @pytest.mark.asyncio
     async def test_record_usage_inserts_correct_cost(self):
-        """_record_usage should record via shared helper with per-page cost."""
+        """_record_usage should record with per-page cost sourced from the DB model row."""
         svc = _make_service()
         svc._provider_id = "provider-123"
         svc._model_id = "model-456"
 
+        # Fake LLMModel row that session.get(...) will return.
+        fake_model = MagicMock()
+        fake_model.cost_per_input_unit = _OCR_PER_PAGE_RATE
+
         mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=fake_model)
         # begin_nested() is sync, returns an async context manager (AsyncSessionTransaction)
         mock_savepoint = MagicMock()
         mock_savepoint.__aenter__ = AsyncMock()
@@ -195,16 +204,17 @@ class TestUsageRecording:
         with patch(
             "shu.core.database.get_async_session_local",
             return_value=mock_session_factory,
-        ):
-            await svc._record_usage(page_count=5)
+        ), patch.object(svc, "_resolve_provider_and_model", new_callable=AsyncMock, return_value=True):
+            await svc._record_usage(page_count=5, user_id="user-789")
 
         mock_session.add.assert_called_once()
         record = mock_session.add.call_args[0][0]
         assert record.provider_id == "provider-123"
         assert record.model_id == "model-456"
+        assert record.user_id == "user-789"
         assert record.request_type == "ocr"
-        assert record.total_cost == _COST_PER_PAGE * 5
-        assert record.input_cost == _COST_PER_PAGE * 5
+        assert record.total_cost == _OCR_PER_PAGE_RATE * 5
+        assert record.input_cost == _OCR_PER_PAGE_RATE * 5
         assert record.output_cost == Decimal("0")
         assert record.request_metadata == {"page_count": 5}
         assert record.success is True
@@ -256,7 +266,7 @@ class TestUsageRecording:
             with patch.object(svc, "_record_usage", new_callable=AsyncMock) as mock_record:
                 await svc.extract_text(b"%PDF-content", "application/pdf")
 
-        mock_record.assert_called_once_with(3, usage_info={}, observed_page_count=3)
+        mock_record.assert_called_once_with(3, usage_info={}, observed_page_count=3, user_id=None)
 
 
 class TestResolveProviderAndModel:

--- a/backend/src/tests/unit/services/test_ingestion_service_properties.py
+++ b/backend/src/tests/unit/services/test_ingestion_service_properties.py
@@ -306,3 +306,67 @@ class TestAPIImmediateReturnProperty:
             assert "status" in result
             assert result["status"] == DocumentStatus.EMBEDDING.value
             assert result["skipped"] is False
+
+
+class TestIngestEmailUserIdThreading:
+    """SHU-700 regression: ingest_email must forward user_id into
+    DocumentService.process_and_update_chunks so the embedding API calls
+    generated during chunk processing land in llm_usage with the correct
+    user attribution. Without the forward, Gmail-style plugin feeds ingest
+    emails and produce NULL user_id embedding rows despite the plugin having
+    user_id on self at the call site — same class of bug as the OCR
+    auto/fallback drop caught earlier in SHU-700.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_id_reaches_process_and_update_chunks(self):
+        from shu.services.ingestion_service import UpsertResult, ingest_email
+
+        mock_db = AsyncMock()
+
+        mock_document = MagicMock()
+        mock_document.id = "doc-1"
+        mock_document.mark_error = MagicMock()
+        mock_document.update_status = MagicMock()
+
+        # upsert returns a not-skipped result so we reach process_and_update_chunks
+        upsert_result = UpsertResult(
+            document=mock_document,
+            extraction={"method": "text"},
+            skipped=False,
+        )
+
+        mock_doc_service = MagicMock()
+        mock_doc_service.process_and_update_chunks = AsyncMock(return_value=(10, 50, 2))
+
+        with (
+            patch("shu.services.ingestion_service.DocumentService", return_value=mock_doc_service),
+            patch(
+                "shu.services.ingestion_service._upsert_document_record",
+                new_callable=AsyncMock,
+                return_value=upsert_result,
+            ),
+            patch(
+                "shu.services.ingestion_service._trigger_profiling_if_enabled",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await ingest_email(
+                mock_db,
+                "kb-1",
+                plugin_name="gmail",
+                user_id="user-42",
+                subject="Test",
+                sender="alice@example.com",
+                recipients={"to": ["bob@example.com"]},
+                date=None,
+                message_id="msg-1",
+                thread_id=None,
+                body_text="hello",
+            )
+
+        mock_doc_service.process_and_update_chunks.assert_awaited_once()
+        assert mock_doc_service.process_and_update_chunks.call_args.kwargs.get("user_id") == "user-42", (
+            "ingest_email must forward user_id to process_and_update_chunks so embedding "
+            "llm_usage rows attribute to the originating user"
+        )

--- a/backend/src/tests/unit/workers/test_text_extractor_edge_cases.py
+++ b/backend/src/tests/unit/workers/test_text_extractor_edge_cases.py
@@ -357,6 +357,7 @@ class TestOcrCapabilityIntegration:
             "application/pdf",
             cap._config_manager,
             ocr_mode="fallback",
+            user_id="user-123",
         )
         assert result == mock_result
 
@@ -383,6 +384,7 @@ class TestOcrCapabilityIntegration:
             "text/plain",
             cap._config_manager,
             ocr_mode="never",
+            user_id="user-123",
         )
 
     @pytest.mark.asyncio

--- a/docs/deployment/STRIPE_SETUP.md
+++ b/docs/deployment/STRIPE_SETUP.md
@@ -17,7 +17,7 @@ Architecture reference: [stripe-architecture.mermaid](../diagrams/stripe-archite
 
 ### Where LLM cost values come from (`llm_usage.total_cost`)
 
-The `usage_cost` meter aggregates `llm_usage.total_cost` across the billing period and pushes it to Stripe. Each row's `total_cost` is resolved by a two-tier hierarchy, in order:
+The `usage_cost` meter sums dollar-denominated `llm_usage.total_cost` across the billing period, converts the delta since the last report to microdollars (1 microdollar = $0.000001), and pushes that integer value to Stripe — which aggregates meter events with SUM to produce the period total. The DB stores dollars as `numeric(16,9)`; the reporter multiplies by 1,000,000 and rounds up (`math.ceil`) before pushing, so sub-microdollar precision loss never causes under-billing. Each row's `total_cost` is resolved by a two-tier hierarchy, in order:
 
 1. **Provider-reported cost (authoritative).** If the upstream provider returns `usage.cost` on the wire (OpenRouter does; OpenAI direct does not), the value is recorded verbatim. Under this path `llm_usage.input_cost` and `llm_usage.output_cost` are both `0` — the provider returns a single total, not a split.
 2. **DB-rate fallback.** If the caller passed `total_cost = Decimal(0)` (the sentinel for "no wire-reported cost"), cost is computed as `input_tokens × cost_per_input_unit + output_tokens × cost_per_output_unit` from the `llm_models` row. These rates are synced at application startup from [`backend/src/shu/core/model_pricing.py`](../../backend/src/shu/core/model_pricing.py), which is the editable source of truth. Under this path `input_cost + output_cost == total_cost`.

--- a/docs/deployment/STRIPE_SETUP.md
+++ b/docs/deployment/STRIPE_SETUP.md
@@ -15,6 +15,20 @@ This guide walks through configuring Stripe and each Shu instance for billing. I
 
 Architecture reference: [stripe-architecture.mermaid](../diagrams/stripe-architecture.mermaid)
 
+### Where LLM cost values come from (`llm_usage.total_cost`)
+
+The `usage_cost` meter aggregates `llm_usage.total_cost` across the billing period and pushes it to Stripe. Each row's `total_cost` is resolved by a two-tier hierarchy, in order:
+
+1. **Provider-reported cost (authoritative).** If the upstream provider returns `usage.cost` on the wire (OpenRouter does; OpenAI direct does not), the value is recorded verbatim. Under this path `llm_usage.input_cost` and `llm_usage.output_cost` are both `0` — the provider returns a single total, not a split.
+2. **DB-rate fallback.** If the caller passed `total_cost = Decimal(0)` (the sentinel for "no wire-reported cost"), cost is computed as `input_tokens × cost_per_input_unit + output_tokens × cost_per_output_unit` from the `llm_models` row. These rates are synced at application startup from [`backend/src/shu/core/model_pricing.py`](../../backend/src/shu/core/model_pricing.py), which is the editable source of truth. Under this path `input_cost + output_cost == total_cost`.
+3. **No rates, no wire cost.** A local/self-hosted model with no `model_pricing.py` entry records `0` for all three cost columns — appropriate because no external billing occurred.
+
+To reprice a model, edit `model_pricing.py` and restart. To cover a model whose provider doesn't return `cost`, add it to the same file. `llm_models.cost_per_input_unit` and `cost_per_output_unit` carry per-token rates for `chat`/`embedding` models and per-page rates for `ocr` models; `llm_models.model_type` disambiguates the unit.
+
+### Per-user attribution (`llm_usage.user_id`)
+
+Every `llm_usage` row whose originating user is identifiable populates `user_id`: chat from `conversation_owner_id`, side-call and ingestion (OCR + embedding) from the user who initiated the job. This is the basis for future per-user invoicing and per-user quota enforcement. Rows with `user_id IS NULL` indicate genuinely user-less surfaces (currently: side-calls emitted during document profiling — a known limitation flagged for follow-up).
+
 ## Table of Contents
 
 1. [Prerequisites](#prerequisites)


### PR DESCRIPTION
## Description
Billing correctness depends on llm_usage.total_cost, which the Stripe meter push aggregates and sends for invoicing. Today three of the four usage surfaces get cost wrong, and three of four surfaces also fail to attribute usage to a user:


Chat and side-call paths discard any provider-returned cost and recompute from hardcoded token rates synced from core/model_pricing.py — any OpenRouter price change or newly routed model immediately drifts from reality.

OCR path ignores the DB entirely and uses a module-level _COST_PER_PAGE = Decimal("0.002") constant.

Chat, OCR, and embedding paths all record llm_usage rows with user_id = NULL, even though the originating user is in scope at the call site (conversation owner for chat; ingestion job user for OCR/embedding). Side-call already passes user_id correctly.

The embedding path already does the right thing for cost: it reads usage.cost from the OpenRouter response and records it verbatim via services/usage_recording.py:record_llm_usage. This ticket brings the other three paths to that same standard for cost, and separately threads user_id through every llm_usage write so billing can attribute usage per user. Unified pricing mechanism: prefer provider-reported cost when the wire returns it; otherwise fall back to a per-unit rate sourced from model_pricing.py → synced into the llm_models row at startup → read at request time. No special cases, no module-level constants, no divergent OCR path.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Refactoring (no functional changes)
- [ ] Performance improvement
- [X] Test coverage improvement

## Related Issues
Has verifications in #SHU-699

## Changes Made

- Migration: use Alembic to rename the two columns in place (Postgres supports ALTER TABLE ... RENAME COLUMN). No data transformation needed. Downgrade path renames back. New migration sits on top of 008_0008_widen_llm_usage_cost_precision.
- model_pricing.py: add OCR entries and a module docstring clarifying the unit is model-type-dependent. Keep the $/MTok table (_PRICING_PER_MTOK) for chat/embedding and add a sibling per-unit table (_PRICING_PER_UNIT) for OCR; merge both into the public MODEL_PRICING. sync_pricing_to_db's core logic doesn't change — only the column names it writes.
- LLMService.record_usage: interpret the existing total_cost parameter as authoritative when non-zero; treat Decimal("0") as the sentinel meaning "caller did not supply, fall back to DB math". On the provider-authoritative path, set input_cost and output_cost to Decimal(0) (the provider gives a single total, not a split). Document this contract in the method docstring. Update the column references to the new names.
- In chat_streaming.py line 512, the usage_from_event dict already surfaces the provider's usage block — extract cost alongside input_tokens / output_tokens, and also pass user_id=str(conversation_owner_id) (already in local scope at line 417). Do the same extraction at chat_service._handle_exception (add a user_id: str parameter to the method and thread conversation.user_id from callers) and at all side_call_service.py call sites.
- In external_ocr_service._record_usage, after _resolve_provider_and_model, read the rate from the resolved LLMModel row (which is already available at that point). Delete _COST_PER_PAGE from module scope.
- Add a defensive coerce helper — lift _safe_decimal from external_embedding_service.py into core/safe_decimal.py for reuse across chat streaming, side-call, OCR, and embedding paths.
- For OpenRouter chat, confirm usage.cost is surfaced in both non-streaming and streaming final events — streaming may require reading the final chunk.usage block rather than per-chunk deltas. Investigate before editing chat_streaming.py: if the streaming pipeline strips cost out of metadata["usage"] before it reaches the record_usage call site, the chat streaming fix requires a pipeline change upstream, not just a one-line extraction.
- User attribution plumbing (Problem 4):
-- services/usage_recording.record_llm_usage: add user_id: str | None = None parameter; write to the LLMUsage.user_id column.
-- services/external_ocr_service.ExternalOCRService.extract_text and _record_usage: add user_id: str | None and pass it to record_llm_usage.
-- services/external_embedding_service.ExternalEmbeddingService.* embed call paths and _record_usage: same pattern.
-- core/ocr_service.run_ocr_on_bytes (and similar embedding entry points) and their callers in the ingestion pipeline: thread user_id down from ingestion_service.py, which already has it in scope. Plugin-feed ingestion uses the owner's user_id (same value already used for deterministic_ko_id).

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing locally

## Manual testing walkthrough (condensed)

### Chat Open Router
- Sent real chats through OpenRouter — verified llm_usage rows showed total_cost matching usage.cost from the wire response, with input_cost == 0 == output_cost (provider-authoritative contract), and user_id populated from the conversation owner.
- 
### Side-call (OpenRouter)
- Title generation / RAG query rewrites fired real side-calls — verified rows had request_type='side_call', user_id populated, and total_cost matching wire cost.

### OCR (Mistral)
- Uploaded 1-page and 2-page image PDFs through the KB upload UI.
- First upload wrote NULL user_id (caught the auto/fallback drop mid-test); fixed, re-uploaded, confirmed user_id populated.
- Verified total_cost = 0.002 × pages_billed using the DB-sourced cost_per_input_unit (not the old _COST_PER_PAGE constant).

### Embedding
- Ingestion after each upload triggered embed calls through OpenRouter's /embeddings endpoint — verified rows had request_type='embedding', user_id populated from the ingestion job, and provider-reported cost on total_cost.

### Direct OpenAI (DB-rate fallback, just now)
- Chatted against direct-OpenAI gpt-5.4-nano (no wire cost returned). Verified three rows where input_tokens × 0.0000002 + output_tokens × 0.00000125 == total_cost bit-for-bit, and input_cost + output_cost == total_cost.
Negative / seed issues caught along the way

## Code Quality Checklist
<!-- All items must be checked before merging -->

### Backend (Python)

- [x] Type hints added to all new functions/classes
- [x] Docstrings added to all public functions/classes
- [x] Unit tests written for new code
- [x] ConfigurationManager used (no hardcoded values)
- [x] Dependency injection used (no direct instantiation)
- [x] Timezone-aware datetimes used
- [x] No breaking migration changes
- [x] Files end with trailing newlines

### Frontend (React/JavaScript)
N/A

### API
N/A

### Linting

- [x] Pre-commit hooks pass
- [x] CI linting checks pass
- [x] No linting warnings ignored without justification

### Documentation

- [x] Code comments added where needed
- [x] README updated (if applicable) -- STRIPE readme was updated
- [N/A] API docs updated (if applicable)
- [x] Migration guide provided (if breaking change) -- Migration file and new version created

### Security

- [x] No hardcoded secrets or credentials
- [x] No sensitive data in logs
- [x] Input validation added
- [x] Authentication/authorization checked

## Screenshots (if applicable)
N/A

## Deployment Notes
<!-- Any special deployment considerations? -->
- [x] Database migrations required - Column renames so DB migration is most definitely required!
- [ ] Environment variables added/changed
- [ ] Dependencies added/updated
- [ ] Configuration changes needed

## Reviewer Notes
Since this covered many use cases, please keep an eye on the llm_usage table especially to see if there are any NULL user_id entries, or if billing looks suspicious.
We also need a way to differentiate our billing vs a user key they are handling on their own. This will be addressed in another ticket

## Post-Merge Tasks
- [ ] Update documentation
- [ ] Notify stakeholders
- [ ] Monitor logs/metrics
- [ ] Update related issues

---

**By submitting this PR, I confirm that:**

- [x] I have run `make lint-fix` and all linting checks pass
- [x] I have tested my changes locally
- [x] I have followed the coding standards in `docs/policies/DEVELOPMENT_STANDARDS.md`
- [x] I have read and followed the linting policy in `docs/policies/LINTING_POLICY.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User attribution threaded into OCR, embedding, profiling, ingestion, and usage recording so LLM/embedding/OCR usage can include a user ID.
  * Provider-reported costs are accepted and stored as authoritative when provided.

* **Refactor**
  * Pricing moved to unit-based rates (unit meaning depends on model type); API request/response fields renamed to reflect "per unit" semantics.

* **Chore**
  * Idempotent database migration added to rename pricing columns.

* **Tests**
  * Expanded unit and integration tests covering pricing, cost handling, user-id threading, and safe-decimal parsing.

* **Documentation**
  * Billing and user-attribution rules clarified in deployment docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->