### PR TITLE
[SHU-690][SHU-691] Redis tenant prefix & PGBounder support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@
 # Format: postgresql://username:password@host:port/database             # pragma: allowlist secret
 SHU_DATABASE_URL="postgresql+asyncpg://shu:password@localhost:5432/shu" # pragma: allowlist secret
 
+# Set to "true" when connecting through PgBouncer in transaction pooling mode
+# (e.g. DO Managed Postgres on port 6543). Disables asyncpg's prepared
+# statement cache, which is incompatible with transaction-level connection
+# reuse. Leave unset (default false) for local dev connecting directly to Postgres.
+# SHU_USE_PGBOUNCER="true"
+
 
 # =============================================================================
 # REDIS CONFIGURATION
@@ -25,6 +31,12 @@ SHU_REDIS_URL="redis://localhost:6379"
 # Redis client timeouts in seconds
 SHU_REDIS_CONNECTION_TIMEOUT=5
 SHU_REDIS_SOCKET_TIMEOUT=5
+
+# Tenant identifier prefixed to every Redis key for multi-tenant isolation on
+# shared Redis deployments. Set to the tenant's control-plane UUID in hosted
+# mode. Leave unset for local dev and self-hosted deployments (keys are not
+# prefixed). Startup fails if set to an empty or whitespace-only value.
+# SHU_TENANT_ID="<tenant-uuid>"
 
 # =============================================================================
 # API SERVER CONFIGURATION

--- a/backend/src/shu/core/cache_backend.py
+++ b/backend/src/shu/core/cache_backend.py
@@ -44,6 +44,8 @@ from typing import Any, Optional, Protocol, runtime_checkable
 
 import redis.asyncio as redis
 
+from .tenant import warn_tenant_without_redis
+
 logger = logging.getLogger(__name__)
 
 # Global cache backend instance (singleton)
@@ -909,7 +911,13 @@ class RedisCacheBackend:
 
     """
 
-    def __init__(self, redis_client: Any, redis_binary_client: Any | None = None) -> None:
+    def __init__(
+        self,
+        redis_client: Any,
+        redis_binary_client: Any | None = None,
+        *,
+        tenant_prefix: str | None = None,
+    ) -> None:
         """Initialize with an existing Redis client.
 
         Args:
@@ -919,10 +927,23 @@ class RedisCacheBackend:
                 instead of constructing this class directly.
             redis_binary_client: An async Redis client instance with decode_responses=False
                 for binary operations. If None, binary operations will not be available.
+            tenant_prefix: Optional tenant identifier prepended as `{prefix}:` to
+                every Redis key for shared-deployment isolation. None = no prefix.
+
+        Raises:
+            ValueError: If ``tenant_prefix`` is provided but empty/whitespace.
+                Empty would silently disable prefixing — dangerous in a hosted
+                context where callers expect structural isolation.
 
         """
+        if tenant_prefix is not None and not tenant_prefix.strip():
+            raise ValueError("tenant_prefix must be None or a non-empty string")
         self._client = redis_client
         self._binary_client = redis_binary_client
+        self._prefix = f"{tenant_prefix}:" if tenant_prefix else ""
+
+    def _key(self, key: str) -> str:
+        return f"{self._prefix}{key}"
 
     async def get(self, key: str) -> str | None:
         """Retrieve a value by key.
@@ -943,7 +964,7 @@ class RedisCacheBackend:
             raise CacheKeyError("Cache key cannot be empty")
 
         try:
-            return await self._client.get(key)
+            return await self._client.get(self._key(key))
         except Exception as e:
             logger.error(f"Redis GET failed for key '{key}': {e}")
             raise CacheConnectionError(
@@ -977,16 +998,17 @@ class RedisCacheBackend:
             raise CacheKeyError("Cache key cannot be empty")
 
         try:
+            namespaced_key = self._key(key)
             # Handle immediate deletion for non-positive TTL
             if ttl_seconds is not None and ttl_seconds <= 0:
-                await self._client.delete(key)
+                await self._client.delete(namespaced_key)
                 return True
 
             if ttl_seconds is not None:
                 # Use setex for atomic set with expiration
-                await self._client.setex(key, ttl_seconds, value)
+                await self._client.setex(namespaced_key, ttl_seconds, value)
             else:
-                await self._client.set(key, value)
+                await self._client.set(namespaced_key, value)
 
             return True
         except Exception as e:
@@ -1013,7 +1035,7 @@ class RedisCacheBackend:
             raise CacheKeyError("Cache key cannot be empty")
 
         try:
-            result = await self._client.delete(key)
+            result = await self._client.delete(self._key(key))
             # Redis delete returns the number of keys deleted
             return result > 0
         except Exception as e:
@@ -1041,12 +1063,12 @@ class RedisCacheBackend:
 
         try:
             # Redis exists returns the count of existing keys
-            result = await self._client.exists(key)
+            result = await self._client.exists(self._key(key))
             return result > 0
         except AttributeError:
             # Fallback for clients that don't have exists method
             try:
-                result = await self._client.get(key)
+                result = await self._client.get(self._key(key))
                 return result is not None
             except Exception as inner_e:
                 logger.error(f"Redis EXISTS fallback failed for key '{key}': {inner_e}")
@@ -1084,7 +1106,7 @@ class RedisCacheBackend:
             raise ValueError("ttl_seconds must be positive")
 
         try:
-            result = await self._client.expire(key, ttl_seconds)
+            result = await self._client.expire(self._key(key), ttl_seconds)
             # Redis expire returns True if the timeout was set, False if key doesn't exist
             return bool(result)
         except Exception as e:
@@ -1117,10 +1139,11 @@ class RedisCacheBackend:
             raise CacheKeyError("Cache key cannot be empty")
 
         try:
+            namespaced_key = self._key(key)
             if amount == 1:
-                result = await self._client.incr(key)
+                result = await self._client.incr(namespaced_key)
             else:
-                result = await self._client.incrby(key, amount)
+                result = await self._client.incrby(namespaced_key, amount)
             return int(result)
         except ValueError as e:
             # Redis returns an error if the value is not an integer
@@ -1164,10 +1187,11 @@ class RedisCacheBackend:
             raise CacheKeyError("Cache key cannot be empty")
 
         try:
+            namespaced_key = self._key(key)
             if amount == 1:
-                result = await self._client.decr(key)
+                result = await self._client.decr(namespaced_key)
             else:
-                result = await self._client.decrby(key, amount)
+                result = await self._client.decrby(namespaced_key, amount)
             return int(result)
         except ValueError as e:
             # Redis returns an error if the value is not an integer
@@ -1214,7 +1238,7 @@ class RedisCacheBackend:
             )
 
         try:
-            return await self._binary_client.get(key)
+            return await self._binary_client.get(self._key(key))
         except Exception as e:
             logger.error(f"Redis GET (binary) failed for key '{key}': {e}")
             raise CacheConnectionError(
@@ -1255,16 +1279,17 @@ class RedisCacheBackend:
             )
 
         try:
+            namespaced_key = self._key(key)
             # Handle immediate deletion for non-positive TTL
             if ttl_seconds is not None and ttl_seconds <= 0:
-                await self._binary_client.delete(key)
+                await self._binary_client.delete(namespaced_key)
                 return True
 
             if ttl_seconds is not None:
                 # Use setex for atomic set with expiration
-                await self._binary_client.setex(key, ttl_seconds, value)
+                await self._binary_client.setex(namespaced_key, ttl_seconds, value)
             else:
-                await self._binary_client.set(key, value)
+                await self._binary_client.set(namespaced_key, value)
 
             return True
         except Exception as e:
@@ -1452,8 +1477,15 @@ async def get_cache_backend() -> CacheBackend:
     from .config import get_settings_instance
 
     settings = get_settings_instance()
+    tenant_id = settings.tenant_id
 
     if not settings.redis_enabled:
+        if tenant_id:
+            # Tenant-scoped without Redis means per-pod in-memory state no other
+            # pod can see — almost certainly a misconfigured hosted deploy. We
+            # warn loudly but continue so local dev (tenant_id set, no Redis)
+            # still works; raising here would break that workflow.
+            warn_tenant_without_redis(logger, "cache", tenant_id)
         logger.info("SHU_REDIS_URL not configured, using InMemoryCacheBackend")
         _cache_backend = InMemoryCacheBackend()
         return _cache_backend
@@ -1472,7 +1504,7 @@ async def get_cache_backend() -> CacheBackend:
         )
         logger.info("Using RedisCacheBackend without binary support")
 
-    _cache_backend = RedisCacheBackend(redis_client, redis_binary_client)
+    _cache_backend = RedisCacheBackend(redis_client, redis_binary_client, tenant_prefix=tenant_id)
     return _cache_backend
 
 

--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -42,12 +42,19 @@ class Settings(BaseSettings):
     database_max_overflow: int = 30
     database_pool_timeout: int = 30
     database_pool_recycle: int = 3600
+    # Set true when connecting through PgBouncer in transaction mode (e.g. DO
+    # Managed Postgres on port 6543). Disables asyncpg's prepared statement
+    # cache, which is incompatible with transaction-level connection reuse.
+    use_pgbouncer: bool = Field(False, alias="SHU_USE_PGBOUNCER")
 
     # Redis configuration
     # Set SHU_REDIS_URL to enable Redis-backed caching/queues; omit for in-memory.
     redis_url: str | None = Field(None, alias="SHU_REDIS_URL")
     redis_connection_timeout: int = Field(5, alias="SHU_REDIS_CONNECTION_TIMEOUT")
     redis_socket_timeout: int = Field(5, alias="SHU_REDIS_SOCKET_TIMEOUT")
+    # Tenant identifier prefixed to every Redis key for multi-tenant isolation
+    # on shared Redis. Unset in dev/self-hosted deployments (no prefix applied).
+    tenant_id: str | None = Field(None, alias="SHU_TENANT_ID")
 
     @property
     def redis_enabled(self) -> bool:
@@ -535,6 +542,18 @@ class Settings(BaseSettings):
         if not v.startswith(("postgresql://", "postgresql+psycopg2://", "postgresql+asyncpg://")):
             raise ValueError("Database URL must be PostgreSQL")
         return v
+
+    @field_validator("tenant_id")
+    @classmethod
+    def validate_tenant_id(cls, v: str | None) -> str | None:
+        # Silent fallthrough to no-prefix in a hosted context would cause
+        # cross-tenant key contamination — reject empty/whitespace explicitly.
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("SHU_TENANT_ID must not be empty or whitespace")
+        return stripped
 
     @field_validator("log_level")
     @classmethod

--- a/backend/src/shu/core/database.py
+++ b/backend/src/shu/core/database.py
@@ -67,6 +67,7 @@ def get_settings():
             database_pool_timeout = 30
             database_pool_recycle = 3600
             debug = False
+            use_pgbouncer = False
 
         return MinimalSettings()
 
@@ -100,6 +101,11 @@ def get_async_engine():
             else:
                 logger.debug(f"Database configuration: URL={parsed_url}")
 
+            # PgBouncer in transaction mode reassigns connections between transactions. That means any new request may
+            # end up on another host and then fail to load the cache. statement_cache_size=0 disables client-side caching
+            # so each query falls back to unnamed statements.
+            connect_args = {"statement_cache_size": 0} if settings.use_pgbouncer else {}
+
             _async_engine = create_async_engine(
                 database_url,
                 pool_size=settings.database_pool_size,
@@ -108,6 +114,7 @@ def get_async_engine():
                 pool_recycle=settings.database_pool_recycle,
                 pool_pre_ping=True,
                 echo=False,
+                connect_args=connect_args,
             )
         except Exception as e:
             logger.error(f"Failed to create async database engine: {e!s}")

--- a/backend/src/shu/core/queue_backend.py
+++ b/backend/src/shu/core/queue_backend.py
@@ -37,6 +37,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Optional, Protocol, runtime_checkable
 
+from .tenant import warn_tenant_without_redis
+
 logger = logging.getLogger(__name__)
 
 
@@ -1160,7 +1162,7 @@ class RedisQueueBackend:
 
     """
 
-    def __init__(self, redis_client: Any) -> None:
+    def __init__(self, redis_client: Any, *, tenant_prefix: str | None = None) -> None:
         """Initialize with an existing Redis client.
 
         Args:
@@ -1168,25 +1170,35 @@ class RedisQueueBackend:
                 created internally by `get_queue_backend()`. External code
                 should use the factory function instead of constructing
                 this class directly.
+            tenant_prefix: Optional tenant identifier prepended as `{prefix}:` to
+                every Redis key for shared-deployment isolation. None = no prefix.
+
+        Raises:
+            ValueError: If ``tenant_prefix`` is provided but empty/whitespace.
+                Empty would silently disable prefixing — dangerous in a hosted
+                context where callers expect structural isolation.
 
         """
+        if tenant_prefix is not None and not tenant_prefix.strip():
+            raise ValueError("tenant_prefix must be None or a non-empty string")
         self._client = redis_client
+        self._prefix = f"{tenant_prefix}:" if tenant_prefix else ""
 
     def _queue_key(self, queue_name: str) -> str:
         """Get the Redis key for the main queue list."""
-        return f"queue:{queue_name}"
+        return f"{self._prefix}queue:{queue_name}"
 
     def _processing_key(self, queue_name: str) -> str:
         """Get the Redis key for the processing sorted set."""
-        return f"queue:{queue_name}:processing"
+        return f"{self._prefix}queue:{queue_name}:processing"
 
     def _scheduled_key(self, queue_name: str) -> str:
         """Get the Redis key for the scheduled sorted set."""
-        return f"queue:{queue_name}:scheduled"
+        return f"{self._prefix}queue:{queue_name}:scheduled"
 
     def _job_key(self, queue_name: str, job_id: str) -> str:
         """Get the Redis key for storing job data while in processing."""
-        return f"queue:{queue_name}:job:{job_id}"
+        return f"{self._prefix}queue:{queue_name}:job:{job_id}"
 
     async def _restore_expired_jobs(self, queue_name: str) -> int:
         """Move expired processing jobs back to the queue.
@@ -1833,15 +1845,22 @@ async def get_queue_backend() -> QueueBackend:
     from .config import get_settings_instance
 
     settings = get_settings_instance()
+    tenant_id = settings.tenant_id
 
     if not settings.redis_enabled:
+        if tenant_id:
+            # Tenant-scoped without Redis means per-pod in-memory jobs no other
+            # pod can see — almost certainly a misconfigured hosted deploy. We
+            # warn loudly but continue so local dev (tenant_id set, no Redis)
+            # still works; raising here would break that workflow.
+            warn_tenant_without_redis(logger, "queue", tenant_id)
         logger.info("SHU_REDIS_URL not configured, using InMemoryQueueBackend")
         _queue_backend = InMemoryQueueBackend()
         return _queue_backend
 
     # Redis is enabled — connection failure is fatal
     redis_client = await _get_shared_redis_client()
-    _queue_backend = RedisQueueBackend(redis_client)
+    _queue_backend = RedisQueueBackend(redis_client, tenant_prefix=tenant_id)
     logger.info("Using RedisQueueBackend")
     return _queue_backend
 

--- a/backend/src/shu/core/tenant.py
+++ b/backend/src/shu/core/tenant.py
@@ -1,0 +1,18 @@
+"""Tenant-isolation helpers shared across the cache and queue backends.
+
+Both Redis-backed factories need to warn when SHU_TENANT_ID is configured
+without SHU_REDIS_URL — that combination would silently land tenant state
+in a per-pod in-memory backend other pods cannot see. The message shape
+must stay in lockstep across factories; centralising it here prevents
+drift.
+"""
+
+from logging import Logger
+
+
+def warn_tenant_without_redis(logger: Logger, backend_kind: str, tenant_id: str) -> None:
+    logger.warning(
+        "SHU_TENANT_ID is set (tenant=%s) but SHU_REDIS_URL is not — " "falling back to in-memory %s backend.",
+        tenant_id,
+        backend_kind,
+    )

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -41,6 +41,7 @@ from .api.system import router as system_router
 from .api.user_permissions import router as user_permissions_router
 from .api.user_preferences import router as user_preferences_router
 from .billing.router import router as billing_router
+from .core.cache_backend import initialize_cache_backend
 from .core.config import get_settings_instance
 from .core.database import init_db
 from .core.exceptions import ShuException
@@ -54,6 +55,7 @@ from .core.middleware import (
     SecurityHeadersMiddleware,
     TimingMiddleware,
 )
+from .core.queue_backend import initialize_queue_backend
 from .plugins.request_limits import RequestSizeLimitMiddleware
 
 logger = get_logger(__name__)
@@ -225,6 +227,19 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
         # Do not crash the app if DB is unavailable; log and continue. Health/readiness will reflect DB status.
         logger.error(f"Failed to initialize database: {e}", exc_info=True)
         # continue without raising to allow the app to start
+
+    # Hosted pods expect cache state shared via Redis. Without populating the
+    # singleton here, get_cache_backend_dependency() falls back to a
+    # per-request InMemoryCacheBackend, fragmenting state across pods.
+    await initialize_cache_backend()
+    logger.info("Cache backend initialized")
+
+    # Hosted API pods run with SHU_WORKERS_ENABLED=false, so the workers
+    # block below never populates the queue singleton. Without this call,
+    # get_queue_backend_dependency() returns a per-request InMemoryQueueBackend
+    # and jobs enqueued from handlers are unreachable to worker pods.
+    await initialize_queue_backend()
+    logger.info("Queue backend initialized")
 
     # Source types are initialized via database migrations
 

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -228,16 +228,11 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
         logger.error(f"Failed to initialize database: {e}", exc_info=True)
         # continue without raising to allow the app to start
 
-    # Hosted pods expect cache state shared via Redis. Without populating the
-    # singleton here, get_cache_backend_dependency() falls back to a
-    # per-request InMemoryCacheBackend, fragmenting state across pods.
+    # Initialize eagerly so backend connection errors surface at startup, not on first request.
     await initialize_cache_backend()
     logger.info("Cache backend initialized")
 
-    # Hosted API pods run with SHU_WORKERS_ENABLED=false, so the workers
-    # block below never populates the queue singleton. Without this call,
-    # get_queue_backend_dependency() returns a per-request InMemoryQueueBackend
-    # and jobs enqueued from handlers are unreachable to worker pods.
+    # Initialize eagerly so backend connection errors surface at startup, not on first enqueue.
     await initialize_queue_backend()
     logger.info("Queue backend initialized")
 

--- a/backend/src/tests/unit/core/test_cache_backend.py
+++ b/backend/src/tests/unit/core/test_cache_backend.py
@@ -8,14 +8,23 @@ Feature: unified-cache-interface
 """
 
 import asyncio
+import logging
 import time
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from shu.core.cache_backend import CacheBackend, InMemoryCacheBackend, RedisCacheBackend
+from shu.core import cache_backend as cache_backend_module
+from shu.core.cache_backend import (
+    CacheBackend,
+    InMemoryCacheBackend,
+    RedisCacheBackend,
+    get_cache_backend,
+)
 
 
 class MockRedisClient:
@@ -1431,3 +1440,171 @@ class TestBinaryBackendSubstitutability:
         assert await binary_backend.get(key) != string_val
         # Binary read should return the last-written value (both backends agree)
         assert await binary_backend.get_bytes(key) == binary_val
+
+
+class TestRedisCacheBackendTenantPrefix:
+    """Verify every key-bearing method of RedisCacheBackend routes through the tenant prefix.
+
+    The risk we are guarding against is missing a single method in the wrapper —
+    that would silently leak a write to a non-namespaced key, contaminating the
+    shared Redis deployment across tenants.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_reads_prefixed_key(self) -> None:
+        mock = MockRedisClient()
+        mock._data["t1:foo"] = "v"
+        backend = RedisCacheBackend(mock, tenant_prefix="t1")
+        assert await backend.get("foo") == "v"
+
+    @pytest.mark.asyncio
+    async def test_set_writes_prefixed_key(self) -> None:
+        mock = MockRedisClient()
+        backend = RedisCacheBackend(mock, tenant_prefix="t1")
+        await backend.set("foo", "v")
+        assert mock._data == {"t1:foo": "v"}
+
+    @pytest.mark.asyncio
+    async def test_delete_targets_prefixed_key_only(self) -> None:
+        mock = MockRedisClient()
+        mock._data["t1:foo"] = "v"
+        mock._data["foo"] = "other-tenant"
+        backend = RedisCacheBackend(mock, tenant_prefix="t1")
+        await backend.delete("foo")
+        assert "t1:foo" not in mock._data
+        assert mock._data["foo"] == "other-tenant"
+
+    @pytest.mark.asyncio
+    async def test_exists_checks_prefixed_key(self) -> None:
+        mock = MockRedisClient()
+        mock._data["foo"] = "other-tenant"  # Unprefixed key must not be seen
+        backend = RedisCacheBackend(mock, tenant_prefix="t1")
+        assert await backend.exists("foo") is False
+        mock._data["t1:foo"] = "v"
+        assert await backend.exists("foo") is True
+
+    @pytest.mark.asyncio
+    async def test_expire_targets_prefixed_key(self) -> None:
+        mock = MockRedisClient()
+        mock._data["t1:foo"] = "v"
+        backend = RedisCacheBackend(mock, tenant_prefix="t1")
+        assert await backend.expire("foo", 60) is True
+        assert "t1:foo" in mock._expiry
+
+    @pytest.mark.asyncio
+    async def test_incr_writes_prefixed_key(self) -> None:
+        mock = MockRedisClient()
+        backend = RedisCacheBackend(mock, tenant_prefix="t1")
+        await backend.incr("counter")
+        assert mock._data == {"t1:counter": "1"}
+
+    @pytest.mark.asyncio
+    async def test_decr_writes_prefixed_key(self) -> None:
+        mock = MockRedisClient()
+        backend = RedisCacheBackend(mock, tenant_prefix="t1")
+        await backend.decr("counter")
+        assert mock._data == {"t1:counter": "-1"}
+
+    @pytest.mark.asyncio
+    async def test_get_bytes_reads_prefixed_key(self) -> None:
+        binary = MockRedisClient(decode_responses=False)
+        binary._data["t1:blob"] = b"bytes-val"
+        backend = RedisCacheBackend(MockRedisClient(), binary, tenant_prefix="t1")
+        assert await backend.get_bytes("blob") == b"bytes-val"
+
+    @pytest.mark.asyncio
+    async def test_set_bytes_writes_prefixed_key(self) -> None:
+        binary = MockRedisClient(decode_responses=False)
+        backend = RedisCacheBackend(MockRedisClient(), binary, tenant_prefix="t1")
+        await backend.set_bytes("blob", b"bytes-val")
+        assert binary._data == {"t1:blob": b"bytes-val"}
+
+    @pytest.mark.asyncio
+    async def test_no_prefix_uses_raw_keys(self) -> None:
+        mock = MockRedisClient()
+        backend = RedisCacheBackend(mock)
+        await backend.set("foo", "v")
+        assert mock._data == {"foo": "v"}
+
+    @pytest.mark.asyncio
+    async def test_two_tenants_sharing_redis_have_isolated_keys(self) -> None:
+        mock = MockRedisClient()
+        tenant_a = RedisCacheBackend(mock, tenant_prefix="a")
+        tenant_b = RedisCacheBackend(mock, tenant_prefix="b")
+
+        await tenant_a.set("k", "v1")
+        await tenant_b.set("k", "v2")
+
+        assert mock._data == {"a:k": "v1", "b:k": "v2"}
+        assert await tenant_a.get("k") == "v1"
+        assert await tenant_b.get("k") == "v2"
+
+
+def _factory_settings(*, redis_url: str | None, tenant_id: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        redis_url=redis_url,
+        redis_enabled=bool(redis_url),
+        tenant_id=tenant_id,
+    )
+
+
+class TestGetCacheBackendFactory:
+    """Verifies factory wiring: tenant_id propagates to Redis backend, and the
+    hosted-without-Redis misconfig surfaces as a WARNING."""
+
+    def setup_method(self) -> None:
+        cache_backend_module._cache_backend = None
+
+    def teardown_method(self) -> None:
+        cache_backend_module._cache_backend = None
+
+    @pytest.mark.asyncio
+    async def test_redis_enabled_with_tenant_id_propagates_prefix(self) -> None:
+        settings = _factory_settings(redis_url="redis://localhost", tenant_id="t1")
+        string_client = MockRedisClient(decode_responses=True)
+        binary_client = MockRedisClient(decode_responses=False)
+
+        with (
+            patch("shu.core.config.get_settings_instance", return_value=settings),
+            patch.object(cache_backend_module, "_get_redis_client", return_value=string_client),
+            patch.object(cache_backend_module, "_get_redis_binary_client", return_value=binary_client),
+        ):
+            backend = await get_cache_backend()
+
+        assert isinstance(backend, RedisCacheBackend)
+        assert backend._prefix == "t1:"
+
+    @pytest.mark.asyncio
+    async def test_redis_disabled_with_tenant_id_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        settings = _factory_settings(redis_url=None, tenant_id="t1")
+
+        with (
+            patch("shu.core.config.get_settings_instance", return_value=settings),
+            caplog.at_level(logging.WARNING, logger=cache_backend_module.logger.name),
+        ):
+            backend = await get_cache_backend()
+
+        assert isinstance(backend, InMemoryCacheBackend)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "SHU_TENANT_ID" in message
+        assert "SHU_REDIS_URL" in message
+        assert "t1" in message
+
+    @pytest.mark.asyncio
+    async def test_redis_disabled_without_tenant_id_no_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        settings = _factory_settings(redis_url=None, tenant_id=None)
+
+        with (
+            patch("shu.core.config.get_settings_instance", return_value=settings),
+            caplog.at_level(logging.WARNING, logger=cache_backend_module.logger.name),
+        ):
+            backend = await get_cache_backend()
+
+        assert isinstance(backend, InMemoryCacheBackend)
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []

--- a/backend/src/tests/unit/core/test_config.py
+++ b/backend/src/tests/unit/core/test_config.py
@@ -1,7 +1,4 @@
-"""Unit tests for Settings field validators.
-
-Validates the password_policy validator added for the password-change feature.
-"""
+"""Unit tests for Settings field validators."""
 
 import pytest
 from pydantic import ValidationError
@@ -31,3 +28,20 @@ class TestValidatePasswordPolicy:
         """An unrecognised policy value should raise a ValidationError."""
         with pytest.raises(ValidationError, match="Password policy must be one of"):
             Settings(SHU_PASSWORD_POLICY="extreme")
+
+
+class TestValidateTenantId:
+    """Tests for Settings.validate_tenant_id field validator."""
+
+    def test_empty_or_whitespace_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Silent fallthrough to no-prefix in a hosted context would cause
+        # cross-tenant key contamination — must fail hard.
+        for value in ("", "   "):
+            monkeypatch.setenv("SHU_TENANT_ID", value)
+            with pytest.raises(ValidationError, match="SHU_TENANT_ID must not be empty or whitespace"):
+                Settings()
+
+    def test_value_is_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SHU_TENANT_ID", " tenant-abc ")
+        settings = Settings()
+        assert settings.tenant_id == "tenant-abc"

--- a/backend/src/tests/unit/core/test_database.py
+++ b/backend/src/tests/unit/core/test_database.py
@@ -1,0 +1,48 @@
+"""Unit tests for database engine construction."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from shu.core import database
+
+
+def _stub_settings(*, use_pgbouncer: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        database_pool_size=20,
+        database_max_overflow=30,
+        database_pool_timeout=30,
+        database_pool_recycle=3600,
+        debug=False,
+        use_pgbouncer=use_pgbouncer,
+    )
+
+
+class TestGetAsyncEnginePgBouncer:
+    """Verifies the PgBouncer flag routes through to asyncpg's connect_args."""
+
+    def setup_method(self) -> None:
+        # Reset the module-level singleton so each test constructs a fresh engine.
+        database._async_engine = None
+
+    def teardown_method(self) -> None:
+        database._async_engine = None
+
+    def test_pgbouncer_enabled_disables_statement_cache(self) -> None:
+        with (
+            patch.object(database, "create_async_engine", return_value=MagicMock()) as mock_engine,
+            patch.object(database, "get_database_url", return_value="postgresql+asyncpg://u:p@h/db"),
+            patch.object(database, "get_settings", return_value=_stub_settings(use_pgbouncer=True)),
+        ):
+            database.get_async_engine()
+
+        assert mock_engine.call_args.kwargs["connect_args"] == {"statement_cache_size": 0}
+
+    def test_pgbouncer_disabled_passes_empty_connect_args(self) -> None:
+        with (
+            patch.object(database, "create_async_engine", return_value=MagicMock()) as mock_engine,
+            patch.object(database, "get_database_url", return_value="postgresql+asyncpg://u:p@h/db"),
+            patch.object(database, "get_settings", return_value=_stub_settings(use_pgbouncer=False)),
+        ):
+            database.get_async_engine()
+
+        assert mock_engine.call_args.kwargs["connect_args"] == {}

--- a/backend/src/tests/unit/core/test_queue_backend.py
+++ b/backend/src/tests/unit/core/test_queue_backend.py
@@ -8,14 +8,18 @@ Feature: queue-backend-interface
 """
 
 import asyncio
+import logging
 import time
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from shu.core import queue_backend as queue_backend_module
 from shu.core.queue_backend import (
     InMemoryQueueBackend,
     Job,
@@ -25,6 +29,7 @@ from shu.core.queue_backend import (
     QueueError,
     QueueOperationError,
     RedisQueueBackend,
+    get_queue_backend,
 )
 
 # =============================================================================
@@ -2163,3 +2168,112 @@ class TestInitializeQueueBackend:
             assert initialized is subsequent
         finally:
             reset_queue_backend()
+
+
+class TestRedisQueueBackendTenantPrefix:
+    """Verify every queue key flows through the tenant prefix.
+
+    The queue backend routes all Redis access through four centralized key
+    helpers (`_queue_key`, `_processing_key`, `_scheduled_key`, `_job_key`).
+    If the prefix is missing from any of them, tenant jobs could collide on
+    the shared Redis deployment.
+    """
+
+    def test_prefix_applied_to_all_four_key_helpers(self) -> None:
+        backend = RedisQueueBackend(MockRedisClientForQueue(), tenant_prefix="t1")
+        assert backend._queue_key("tasks") == "t1:queue:tasks"
+        assert backend._processing_key("tasks") == "t1:queue:tasks:processing"
+        assert backend._scheduled_key("tasks") == "t1:queue:tasks:scheduled"
+        assert backend._job_key("tasks", "abc") == "t1:queue:tasks:job:abc"
+
+    def test_no_prefix_preserves_legacy_key_shape(self) -> None:
+        backend = RedisQueueBackend(MockRedisClientForQueue())
+        assert backend._queue_key("tasks") == "queue:tasks"
+        assert backend._processing_key("tasks") == "queue:tasks:processing"
+        assert backend._scheduled_key("tasks") == "queue:tasks:scheduled"
+        assert backend._job_key("tasks", "abc") == "queue:tasks:job:abc"
+
+    @pytest.mark.asyncio
+    async def test_two_tenants_sharing_redis_cannot_see_each_others_jobs(self) -> None:
+        shared_client = MockRedisClientForQueue()
+        tenant_a = RedisQueueBackend(shared_client, tenant_prefix="a")
+        tenant_b = RedisQueueBackend(shared_client, tenant_prefix="b")
+
+        await tenant_a.enqueue(Job(queue_name="tasks", payload={"for": "a"}))
+
+        assert await tenant_b.dequeue("tasks") is None
+        dequeued = await tenant_a.dequeue("tasks")
+        assert dequeued is not None
+        assert dequeued.payload == {"for": "a"}
+
+
+def _factory_settings(*, redis_url: str | None, tenant_id: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        redis_url=redis_url,
+        redis_enabled=bool(redis_url),
+        tenant_id=tenant_id,
+    )
+
+
+class TestGetQueueBackendFactory:
+    """Verifies queue factory wiring: tenant_id propagates into RedisQueueBackend,
+    and the hosted-without-Redis misconfig surfaces as a WARNING. Mirrors the
+    cache factory tests so the two selection paths stay in lockstep."""
+
+    def setup_method(self) -> None:
+        queue_backend_module._queue_backend = None
+
+    def teardown_method(self) -> None:
+        queue_backend_module._queue_backend = None
+
+    @pytest.mark.asyncio
+    async def test_redis_enabled_with_tenant_id_propagates_prefix(self) -> None:
+        settings = _factory_settings(redis_url="redis://localhost", tenant_id="t1")
+        mock_client = MockRedisClientForQueue()
+
+        async def _fake_shared_client() -> Any:
+            return mock_client
+
+        with (
+            patch("shu.core.config.get_settings_instance", return_value=settings),
+            patch.object(queue_backend_module, "_get_shared_redis_client", _fake_shared_client),
+        ):
+            backend = await get_queue_backend()
+
+        assert isinstance(backend, RedisQueueBackend)
+        assert backend._prefix == "t1:"
+
+    @pytest.mark.asyncio
+    async def test_redis_disabled_with_tenant_id_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        settings = _factory_settings(redis_url=None, tenant_id="t1")
+
+        with (
+            patch("shu.core.config.get_settings_instance", return_value=settings),
+            caplog.at_level(logging.WARNING, logger=queue_backend_module.logger.name),
+        ):
+            backend = await get_queue_backend()
+
+        assert isinstance(backend, InMemoryQueueBackend)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "SHU_TENANT_ID" in message
+        assert "SHU_REDIS_URL" in message
+        assert "t1" in message
+
+    @pytest.mark.asyncio
+    async def test_redis_disabled_without_tenant_id_no_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        settings = _factory_settings(redis_url=None, tenant_id=None)
+
+        with (
+            patch("shu.core.config.get_settings_instance", return_value=settings),
+            caplog.at_level(logging.WARNING, logger=queue_backend_module.logger.name),
+        ):
+            backend = await get_queue_backend()
+
+        assert isinstance(backend, InMemoryQueueBackend)
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -354,7 +354,9 @@ For more sophisticated health checks, consider adding a sidecar that monitors qu
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SHU_DATABASE_URL` | *required* | PostgreSQL connection string (asyncpg driver) |
+| `SHU_USE_PGBOUNCER` | `false` | Set `true` when Postgres sits behind PgBouncer in transaction-pooling mode (e.g. DigitalOcean Managed Postgres). Disables asyncpg's prepared-statement cache (`statement_cache_size=0`), which is incompatible with transaction pooling. Hosted deployments set `true`; dev/self-hosted omit it. |
 | `SHU_REDIS_URL` | *none* | Redis URL; if unset, uses in-memory backends |
+| `SHU_TENANT_ID` | *unset* | Tenant identifier. When set, every Redis key is namespaced `{tenant_id}:{key}` so multiple tenants can safely share a Redis instance. Required for hosted deployments; omit for dev/self-hosted single-tenant runs. Empty-string values are rejected at startup. |
 | `SHU_ENVIRONMENT` | `production` | Environment name (production, development, staging) |
 | `SHU_LOG_LEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR) |
 | `SHU_LOG_FORMAT` | `json` | Log format (json, text) |


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Additional: https://github.com/Open-Shu/shu-deploy/pull/3

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes # [SHU-690][SHU-691] 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PgBouncer transaction pooling mode is now supported via new optional configuration.
  * Multi-tenant deployment capability with automatic isolation between tenants.

* **Improvements**
  * Enhanced startup initialization for improved state consistency in distributed deployments.

* **Documentation**
  * Added configuration documentation for new optional environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->