### PR TITLE
SHU-718 thread user_id through RAG query embedding paths

### DIFF
--- a/backend/src/shu/api/query.py
+++ b/backend/src/shu/api/query.py
@@ -94,6 +94,7 @@ async def query_documents(
             request_builder=build_request,
             prior_messages=None,
             rag_rewrite_mode=request.rag_rewrite_mode,
+            user_id=str(current_user.id),
         )
 
         if query_results:

--- a/backend/src/shu/services/experience_executor.py
+++ b/backend/src/shu/services/experience_executor.py
@@ -804,7 +804,14 @@ class ExperienceExecutor:
 
         query_service = QueryService(self.db, self.config_manager)
         _, _, responses = await execute_rag_queries(
-            self.db, self.config_manager, query_service, current_user, query_text, [kb_id], _builder
+            self.db,
+            self.config_manager,
+            query_service,
+            current_user,
+            query_text,
+            [kb_id],
+            _builder,
+            user_id=str(current_user.id),
         )
 
         if not responses:

--- a/backend/src/shu/services/message_context_builder.py
+++ b/backend/src/shu/services/message_context_builder.py
@@ -289,6 +289,7 @@ class MessageContextBuilder:
             request_builder=build_query_request,
             prior_messages=conversation_messages,
             rag_rewrite_mode=rag_rewrite_mode,
+            user_id=str(current_user.id),
         )
 
         if rewrite_diagnostics:

--- a/backend/src/shu/services/query/hybrid.py
+++ b/backend/src/shu/services/query/hybrid.py
@@ -34,6 +34,7 @@ class HybridSearchMixin:
         *,
         title_weighting_enabled: bool | None = None,
         title_weight_multiplier: float | None = None,
+        user_id: str | None = None,
     ) -> dict[str, Any]:
         """Perform hybrid search (combination of similarity and keyword).
 
@@ -46,6 +47,9 @@ class HybridSearchMixin:
             query: Search query
             limit: Maximum number of results to return
             threshold: Similarity threshold for filtering results
+            user_id: Optional user attribution forwarded to both sub-searches
+                so the resulting embedding llm_usage rows attribute to the
+                originating user (SHU-718).
 
         Returns:
             Dictionary with search results
@@ -73,7 +77,9 @@ class HybridSearchMixin:
                     created_after=None,
                     created_before=None,
                 )
-                similarity_response = await self.similarity_search(knowledge_base_id, similarity_request)
+                similarity_response = await self.similarity_search(
+                    knowledge_base_id, similarity_request, user_id=user_id
+                )
             except ShuException as e:
                 if e.error_code == "KNOWLEDGE_BASE_STALE_EMBEDDINGS":
                     logger.warning(
@@ -89,6 +95,7 @@ class HybridSearchMixin:
                 limit,
                 title_weighting_enabled=title_weighting_enabled,
                 title_weight_multiplier=title_weight_multiplier,
+                user_id=user_id,
             )
 
             # Log keyword search results for debugging

--- a/backend/src/shu/services/query/keyword.py
+++ b/backend/src/shu/services/query/keyword.py
@@ -37,8 +37,15 @@ class KeywordSearchMixin:
         *,
         title_weighting_enabled: bool | None = None,
         title_weight_multiplier: float | None = None,
+        user_id: str | None = None,
     ) -> dict[str, Any]:
-        """Perform keyword search on document chunks with improved term extraction."""
+        """Perform keyword search on document chunks with improved term extraction.
+
+        ``user_id`` is threaded into the title-match precompute ``embed_query``
+        and forwarded on into ``_get_title_match_chunks`` (whose own fallback
+        ``embed_query`` call picks it up if reached) so any resulting
+        llm_usage row attributes to the originating user (SHU-718).
+        """
         try:
             # Verify knowledge base exists
             knowledge_base = await self._verify_knowledge_base(knowledge_base_id)
@@ -162,7 +169,7 @@ class KeywordSearchMixin:
                     from ...core.embedding_service import get_embedding_service
 
                     embedding_service = await get_embedding_service()
-                    precomputed_query_embedding = await embedding_service.embed_query(query)
+                    precomputed_query_embedding = await embedding_service.embed_query(query, user_id=user_id)
 
                     for title_match in title_matches:
                         doc_chunks = await self._get_title_match_chunks(
@@ -171,6 +178,7 @@ class KeywordSearchMixin:
                             max_chunks=max_chunks_per_doc,
                             knowledge_base_id=knowledge_base_id,
                             query_embedding=precomputed_query_embedding,
+                            user_id=user_id,
                         )
 
                         # Convert to the expected format and apply title boost
@@ -341,6 +349,8 @@ class KeywordSearchMixin:
         max_chunks: int,
         knowledge_base_id: str,
         query_embedding: list[float] | None = None,
+        *,
+        user_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """For title-matched documents, find the most relevant chunks within that document.
         Uses the original query to find semantically and keyword relevant chunks.
@@ -385,7 +395,7 @@ class KeywordSearchMixin:
                 from ...core.embedding_service import get_embedding_service
 
                 embedding_service = await get_embedding_service()
-                query_embedding = await embedding_service.embed_query(query)
+                query_embedding = await embedding_service.embed_query(query, user_id=user_id)
 
             # Preprocess query and get weights once (loop-invariant)
             processed = self.preprocess_query(query)

--- a/backend/src/shu/services/query/multi_surface.py
+++ b/backend/src/shu/services/query/multi_surface.py
@@ -71,6 +71,7 @@ class MultiSurfaceSearchMixin:
         bm25_weight: float | None = None,
         chunk_summary_weight: float | None = None,
         fusion_formula: str | None = None,
+        user_id: str | None = None,
     ) -> dict[str, Any]:
         """Perform multi-surface search across multiple retrieval strategies.
 
@@ -87,6 +88,9 @@ class MultiSurfaceSearchMixin:
             synopsis_match_weight: Weight for synopsis match surface (None = use config default)
             bm25_weight: Weight for BM25 surface (None = use config default)
             chunk_summary_weight: Weight for chunk summary surface (None = use config default)
+            user_id: Optional user attribution forwarded into the orchestrator's
+                ``embed_query`` call so the resulting llm_usage row attributes
+                to the originating user (SHU-718).
 
         Returns:
             Dictionary with search results in QueryResponse format
@@ -173,6 +177,7 @@ class MultiSurfaceSearchMixin:
                 threshold=threshold,
                 max_chunks_per_document=max_chunks_per_doc,
                 session_factory=get_async_session_local(),
+                user_id=user_id,
             )
 
             # Convert FusedResult to QueryResult format

--- a/backend/src/shu/services/query/similarity.py
+++ b/backend/src/shu/services/query/similarity.py
@@ -21,12 +21,21 @@ class SimilaritySearchMixin:
     """Mixin providing vector similarity search."""
 
     @measure_execution_time
-    async def similarity_search(self, knowledge_base_id: str, request: "SimilaritySearchRequest") -> dict[str, Any]:
+    async def similarity_search(
+        self,
+        knowledge_base_id: str,
+        request: "SimilaritySearchRequest",
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
         """Perform vector similarity search on document chunks.
 
         Args:
             knowledge_base_id: ID of the knowledge base to search
             request: Similarity search request
+            user_id: Optional user attribution for the embedding llm_usage row.
+                Threaded down to ``embedding_service.embed_query`` so the row
+                lands with the originating user. See SHU-718.
 
         Returns:
             Dictionary with search results
@@ -62,7 +71,7 @@ class SimilaritySearchMixin:
             from ...core.embedding_service import get_embedding_service
 
             embedding_service = await get_embedding_service()
-            query_embedding = await embedding_service.embed_query(processed["similarity_query"])
+            query_embedding = await embedding_service.embed_query(processed["similarity_query"], user_id=user_id)
 
             # Perform vector similarity search via VectorStore
             from ...core.vector_store import get_vector_store

--- a/backend/src/shu/services/query_service.py
+++ b/backend/src/shu/services/query_service.py
@@ -47,7 +47,13 @@ class QueryService(
     def __init__(self, db: AsyncSession, config_manager: ConfigurationManager) -> None:
         super().__init__(db, config_manager)
 
-    async def query_documents(self, knowledge_base_id: str, request: "QueryRequest") -> dict[str, Any]:
+    async def query_documents(
+        self,
+        knowledge_base_id: str,
+        request: "QueryRequest",
+        *,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
         """Unified query method supporting all search types.
 
         This is the primary entry point for all document queries, consolidating
@@ -57,6 +63,9 @@ class QueryService(
         Args:
             knowledge_base_id: ID of the knowledge base to search
             request: Query request (supports backward compatibility fields)
+            user_id: Optional user attribution forwarded to the underlying
+                retrieval strategy so the embedding llm_usage row lands with
+                the originating user (SHU-718).
 
         Returns:
             Dictionary with search results and RAG configuration
@@ -90,7 +99,9 @@ class QueryService(
                     created_after=getattr(request, "created_after", None),
                     created_before=getattr(request, "created_before", None),
                 )
-                similarity_response = await self.similarity_search(knowledge_base_id, similarity_request)
+                similarity_response = await self.similarity_search(
+                    knowledge_base_id, similarity_request, user_id=user_id
+                )
 
                 # Convert SimilaritySearchResponse to QueryResponse format
                 query_results = []
@@ -128,6 +139,7 @@ class QueryService(
                     limit,
                     title_weighting_enabled=request.title_weighting_enabled,
                     title_weight_multiplier=request.title_weight_multiplier,
+                    user_id=user_id,
                 )
             elif search_type == "hybrid":
                 query_response = await self.hybrid_search(
@@ -137,6 +149,7 @@ class QueryService(
                     request.similarity_threshold or 0.0,
                     title_weighting_enabled=request.title_weighting_enabled,
                     title_weight_multiplier=request.title_weight_multiplier,
+                    user_id=user_id,
                 )
             elif search_type == "multi_surface":
                 query_response = await self._multi_surface_search(
@@ -150,6 +163,7 @@ class QueryService(
                     bm25_weight=request.bm25_weight,
                     chunk_summary_weight=request.chunk_summary_weight,
                     fusion_formula=request.fusion_formula,
+                    user_id=user_id,
                 )
             else:
                 raise ShuException(f"Unsupported search type: {search_type}", "UNSUPPORTED_SEARCH_TYPE")

--- a/backend/src/shu/services/rag_query_processing.py
+++ b/backend/src/shu/services/rag_query_processing.py
@@ -98,8 +98,15 @@ async def execute_rag_queries(
     prior_messages: Sequence[Message] | None = None,
     timeout_ms: int = 5000,
     rag_rewrite_mode: RagRewriteMode = RagRewriteMode.RAW_QUERY,
+    *,
+    user_id: str | None = None,
 ) -> tuple[str, dict[str, Any] | None, list[dict[str, Any]]]:
-    """Process a query, enforce minimum word checks, and execute queries for KBs."""
+    """Process a query, enforce minimum word checks, and execute queries for KBs.
+
+    ``user_id`` is forwarded to ``QueryService.query_documents`` so any
+    embedding ``llm_usage`` rows written during retrieval attribute to the
+    originating user (SHU-718).
+    """
     rewritten_query, rewrite_diagnostics = await process_query_for_rag(
         db_session=db_session,
         config_manager=config_manager,
@@ -146,7 +153,7 @@ async def execute_rag_queries(
             continue
 
         try:
-            response = await query_service.query_documents(kb_id, query_request)
+            response = await query_service.query_documents(kb_id, query_request, user_id=user_id)
             if hasattr(response, "model_dump"):
                 response = response.model_dump(mode="json")
             responses.append(

--- a/backend/src/shu/services/rag_query_rewrite.py
+++ b/backend/src/shu/services/rag_query_rewrite.py
@@ -87,11 +87,17 @@ async def execute_rag_queries(
     prior_messages: Sequence[Message] | None = None,
     timeout_ms: int = 5000,
     apply_rewrite: bool = True,
+    *,
+    user_id: str | None = None,
 ) -> tuple[str, dict[str, Any] | None, list[dict[str, Any]]]:
     """Rewrite a query, enforce minimum word checks, and execute queries for KBs.
 
     Returns the rewritten query, diagnostics, and per-KB results containing
     the query response (if executed), associated RAG config, and skip metadata.
+
+    ``user_id`` is forwarded to ``QueryService.query_documents`` so any
+    embedding ``llm_usage`` rows written during retrieval attribute to the
+    originating user (SHU-718).
     """
     if apply_rewrite:
         rewritten_query, rewrite_diagnostics = await rewrite_query_for_rag(
@@ -139,7 +145,7 @@ async def execute_rag_queries(
             continue
 
         try:
-            response = await query_service.query_documents(kb_id, query_request)
+            response = await query_service.query_documents(kb_id, query_request, user_id=user_id)
             if hasattr(response, "model_dump"):
                 response = response.model_dump()
             responses.append(

--- a/backend/src/shu/services/retrieval/multi_surface_search.py
+++ b/backend/src/shu/services/retrieval/multi_surface_search.py
@@ -73,6 +73,7 @@ class MultiSurfaceSearchService:
         threshold: float = 0.0,
         max_chunks_per_document: int = 2,
         session_factory: async_sessionmaker,
+        user_id: str | None = None,
     ) -> tuple[list[FusedResult], dict[str, dict[str, float]], list[FormattedDocument]]:
         """Execute multi-surface search and return fused results.
 
@@ -83,6 +84,9 @@ class MultiSurfaceSearchService:
             threshold: Minimum final score threshold.
             session_factory: Factory for creating database sessions. Each surface
                 gets its own session to allow safe parallel execution.
+            user_id: Optional user attribution forwarded to
+                ``embedding_service.embed_query`` so the resulting llm_usage
+                row attributes to the originating user (SHU-718).
 
         Returns:
             Tuple of (fused_results, all_surface_scores, formatted_docs) where
@@ -94,7 +98,7 @@ class MultiSurfaceSearchService:
         start_time = time.perf_counter()
 
         # Step 1: Generate query embedding
-        query_vector = await self._embedding_service.embed_query(query)
+        query_vector = await self._embedding_service.embed_query(query, user_id=user_id)
 
         # Step 2: Execute all surfaces in parallel (each gets its own session)
         # NOTE: Each surface checks out a connection from the pool. With N surfaces + 1 fusion,

--- a/backend/src/tests/unit/services/query/test_query_service_user_id_threading.py
+++ b/backend/src/tests/unit/services/query/test_query_service_user_id_threading.py
@@ -1,0 +1,303 @@
+"""SHU-718 regression tests: user_id must reach the embedding service on
+every RAG retrieval path.
+
+Before SHU-718, similarity / keyword / hybrid / multi_surface all called
+``embedding_service.embed_query(...)`` without forwarding ``user_id``, so the
+resulting ``llm_usage`` row for request_type='embedding' landed with NULL
+user_id despite ``conversation.user_id`` being in scope at the chat boundary.
+
+These tests guard both the explicit forward (``user_id="u-1"`` reaches
+``embed_query``) and the default-None behaviour (legacy callers don't
+break).
+
+Test structure mirrors SHU-700's ``TestUserIdThreading`` pattern in
+``test_extract_text_with_ocr_fallback.py`` and
+``test_ingestion_service_properties.py::TestIngestEmailUserIdThreading``.
+
+Patch note: the mixin modules re-import ``get_embedding_service`` /
+``get_vector_store`` inside function bodies (deferred imports to avoid
+loading sentence-transformers at module load). Patches therefore target the
+source modules (``shu.core.embedding_service``, ``shu.core.vector_store``)
+rather than the mixin modules themselves.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shu.schemas.query import QueryRequest, SimilaritySearchRequest
+from shu.services.query_service import QueryService
+
+
+def _make_kb_mock(status: str = "current", embedding_model: str = "test-model") -> MagicMock:
+    kb = MagicMock()
+    kb.embedding_status = status
+    kb.embedding_model = embedding_model
+    kb.get_rag_config = MagicMock(return_value={"max_chunks_per_document": 2})
+    return kb
+
+
+def _make_query_service() -> QueryService:
+    config_manager = MagicMock()
+    config_manager.get_rag_max_chunks.return_value = 10
+    config_manager.get_rag_search_type.return_value = "hybrid"
+    config_manager.get_rag_search_threshold.return_value = 0.0
+    config_manager.get_title_weighting_enabled.return_value = True
+    config_manager.get_title_weight_multiplier.return_value = 1.0
+    config_manager.get_hybrid_similarity_weight.return_value = 0.7
+    config_manager.get_hybrid_keyword_weight.return_value = 0.3
+
+    db = AsyncMock()
+    qs = QueryService(db=db, config_manager=config_manager)
+
+    qs._verify_knowledge_base = AsyncMock(return_value=_make_kb_mock())
+    qs._get_rag_config = AsyncMock(return_value={"max_chunks_per_document": 2, "max_chunks": 5})
+    qs._maybe_escalate_full_documents = AsyncMock(return_value=None)
+    return qs
+
+
+def _make_embedding_service() -> MagicMock:
+    svc = MagicMock()
+    svc.embed_query = AsyncMock(return_value=[0.1] * 1024)
+    return svc
+
+
+def _stub_similarity_response() -> dict:
+    """Minimum shape the dispatcher reads for the similarity branch."""
+    return {
+        "results": [],
+        "total_results": 0,
+        "query": "hello",
+        "execution_time": 0.0,
+        "threshold": 0.0,
+        "embedding_model": "test-model",
+    }
+
+
+class TestUserIdThreadingRagQueryEmbed:
+    """SHU-718 regression: user_id must reach embed_query on every retrieval
+    path that fires for a RAG-enabled chat turn.
+    """
+
+    @pytest.mark.asyncio
+    async def test_similarity_search_forwards_user_id(self):
+        """similarity_search must forward user_id to embed_query."""
+        qs = _make_query_service()
+        embed_svc = _make_embedding_service()
+
+        # Empty vector store result → fast-path return after embed_query fires.
+        vector_store = MagicMock()
+        vector_store.search = AsyncMock(return_value=[])
+
+        req = SimilaritySearchRequest(query="hello world", limit=10, threshold=0.0)
+
+        with (
+            patch("shu.core.embedding_service.get_embedding_service", AsyncMock(return_value=embed_svc)),
+            patch("shu.core.vector_store.get_vector_store", AsyncMock(return_value=vector_store)),
+        ):
+            await qs.similarity_search("kb-1", req, user_id="u-1")
+
+        embed_svc.embed_query.assert_awaited_once()
+        assert embed_svc.embed_query.call_args.kwargs.get("user_id") == "u-1"
+
+    @pytest.mark.asyncio
+    async def test_similarity_search_defaults_to_none(self):
+        """similarity_search called without user_id must pass user_id=None."""
+        qs = _make_query_service()
+        embed_svc = _make_embedding_service()
+        vector_store = MagicMock()
+        vector_store.search = AsyncMock(return_value=[])
+
+        req = SimilaritySearchRequest(query="hello world", limit=10, threshold=0.0)
+
+        with (
+            patch("shu.core.embedding_service.get_embedding_service", AsyncMock(return_value=embed_svc)),
+            patch("shu.core.vector_store.get_vector_store", AsyncMock(return_value=vector_store)),
+        ):
+            await qs.similarity_search("kb-1", req)
+
+        assert embed_svc.embed_query.call_args.kwargs.get("user_id") is None
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_title_match_precompute_forwards_user_id(self):
+        """When title weighting is enabled and the query matches a document
+        title, keyword_search precomputes the query embedding once for all
+        title-match chunk lookups — user_id must reach that precompute call
+        and forward into _get_title_match_chunks.
+        """
+        qs = _make_query_service()
+        embed_svc = _make_embedding_service()
+
+        # Simulate a single title match row and empty content chunks.
+        title_match_row = MagicMock()
+        title_match_row.document_id = "doc-1"
+        title_match_row.document_title = "Widget spec"
+        title_match_row.title_score = 8.0
+
+        title_result = MagicMock()
+        title_result.fetchall = MagicMock(return_value=[title_match_row])
+
+        empty_result = MagicMock()
+        empty_result.fetchall = MagicMock(return_value=[])
+
+        # First db.execute() is the title-match SELECT, subsequent are content search.
+        qs.db.execute = AsyncMock(side_effect=[title_result, empty_result, empty_result])
+        # Short-circuit the inner chunk lookup so we only assert the precompute path.
+        qs._get_title_match_chunks = AsyncMock(return_value=[])
+
+        with patch("shu.core.embedding_service.get_embedding_service", AsyncMock(return_value=embed_svc)):
+            await qs.keyword_search("kb-1", "widget spec report", limit=10, user_id="u-1")
+
+        embed_svc.embed_query.assert_awaited_once()
+        assert embed_svc.embed_query.call_args.kwargs.get("user_id") == "u-1"
+        assert qs._get_title_match_chunks.call_args.kwargs.get("user_id") == "u-1"
+
+    @pytest.mark.asyncio
+    async def test_get_title_match_chunks_fallback_forwards_user_id(self):
+        """When _get_title_match_chunks is called without a precomputed
+        query_embedding, it falls back to embedding the query itself. That
+        fallback path must forward user_id — guards a sleeper bug, since no
+        production caller triggers this branch today.
+        """
+        qs = _make_query_service()
+        embed_svc = _make_embedding_service()
+
+        # Minimal chunk row carrying an embedding so cosine scoring runs.
+        chunk_row = MagicMock()
+        chunk_row.id = "c-1"
+        chunk_row.document_id = "doc-1"
+        chunk_row.knowledge_base_id = "kb-1"
+        chunk_row.chunk_index = 0
+        chunk_row.content = "widget specification"
+        chunk_row.char_count = 20
+        chunk_row.word_count = 2
+        chunk_row.token_count = 2
+        chunk_row.start_char = 0
+        chunk_row.end_char = 20
+        chunk_row.embedding_model = "test-model"
+        chunk_row.embedding_created_at = None
+        chunk_row.created_at = None
+        chunk_row.document_title = "Widget"
+        chunk_row.source_id = "s-1"
+        chunk_row.source_url = None
+        chunk_row.file_type = "md"
+        chunk_row.source_type = None
+        chunk_row.chunk_metadata = None
+        chunk_row.embedding = [0.1] * 1024
+        chunk_row.total_content_chunks = 1
+
+        chunks_result = MagicMock()
+        chunks_result.fetchall = MagicMock(return_value=[chunk_row])
+        qs.db.execute = AsyncMock(return_value=chunks_result)
+
+        with patch("shu.core.embedding_service.get_embedding_service", AsyncMock(return_value=embed_svc)):
+            await qs._get_title_match_chunks(
+                document_id="doc-1",
+                query="widget spec",
+                max_chunks=3,
+                knowledge_base_id="kb-1",
+                query_embedding=None,
+                user_id="u-1",
+            )
+
+        embed_svc.embed_query.assert_awaited_once()
+        assert embed_svc.embed_query.call_args.kwargs.get("user_id") == "u-1"
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_forwards_user_id_to_both_subsearches(self):
+        """hybrid_search must forward user_id to both similarity_search and
+        keyword_search. Guards against a hybrid call producing a NULL-user_id
+        row via either sub-search.
+        """
+        qs = _make_query_service()
+
+        qs.similarity_search = AsyncMock(
+            return_value={"results": [], "total_results": 0}
+        )
+        qs.keyword_search = AsyncMock(
+            return_value={"results": [], "total_results": 0}
+        )
+
+        await qs.hybrid_search("kb-1", "hello world", limit=10, user_id="u-1")
+
+        assert qs.similarity_search.call_args.kwargs.get("user_id") == "u-1"
+        assert qs.keyword_search.call_args.kwargs.get("user_id") == "u-1"
+
+    @pytest.mark.asyncio
+    async def test_multi_surface_search_mixin_forwards_user_id_to_orchestrator(self):
+        """_multi_surface_search mixin must forward user_id into the
+        MultiSurfaceSearchService orchestrator's .search() call.
+        """
+        qs = _make_query_service()
+
+        fake_search_service = MagicMock()
+        fake_search_service.search = AsyncMock(return_value=([], {}, []))
+
+        with (
+            patch("shu.core.embedding_service.get_embedding_service", AsyncMock()),
+            patch("shu.core.vector_store.get_vector_store", AsyncMock()),
+            patch("shu.core.database.get_async_session_local", MagicMock()),
+            patch(
+                "shu.services.retrieval.MultiSurfaceSearchService",
+                return_value=fake_search_service,
+            ),
+            patch("shu.services.retrieval.ScoreFusionService", MagicMock()),
+        ):
+            await qs._multi_surface_search(
+                "00000000-0000-0000-0000-000000000001",
+                "hello world",
+                limit=10,
+                user_id="u-1",
+            )
+
+        fake_search_service.search.assert_awaited_once()
+        assert fake_search_service.search.call_args.kwargs.get("user_id") == "u-1"
+
+    @pytest.mark.parametrize(
+        "search_type,method_name",
+        [
+            ("keyword", "keyword_search"),
+            ("hybrid", "hybrid_search"),
+            ("multi_surface", "_multi_surface_search"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_query_documents_dispatches_user_id_per_strategy(
+        self, search_type, method_name
+    ):
+        """The query_documents dispatcher must forward user_id to whichever
+        strategy method it selects based on ``request.query_type``. Similarity
+        is covered separately because its response shape differs.
+        """
+        qs = _make_query_service()
+
+        # QueryResponse-shape stub covers keyword/hybrid/multi_surface branches.
+        stub = {
+            "results": [],
+            "total_results": 0,
+            "query": "hello",
+            "query_type": search_type,
+            "execution_time": 0.0,
+            "similarity_threshold": 0.0,
+            "embedding_model": "test-model",
+        }
+        setattr(qs, method_name, AsyncMock(return_value=stub))
+
+        req = QueryRequest(query="hello world", query_type=search_type, limit=10)
+        await qs.query_documents("kb-1", req, user_id="u-1")
+
+        called = getattr(qs, method_name)
+        called.assert_awaited_once()
+        assert called.call_args.kwargs.get("user_id") == "u-1"
+
+    @pytest.mark.asyncio
+    async def test_query_documents_dispatches_user_id_to_similarity(self):
+        """Similarity branch has a distinct response shape; covered separately."""
+        qs = _make_query_service()
+        qs.similarity_search = AsyncMock(return_value=_stub_similarity_response())
+
+        req = QueryRequest(query="hello world", query_type="similarity", limit=10)
+        await qs.query_documents("kb-1", req, user_id="u-1")
+
+        qs.similarity_search.assert_awaited_once()
+        assert qs.similarity_search.call_args.kwargs.get("user_id") == "u-1"

--- a/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
+++ b/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
@@ -93,6 +93,25 @@ class TestMultiSurfaceSearchService:
         mock_embedding.embed_query.assert_called_once_with("test query", user_id=None)
 
     @pytest.mark.asyncio
+    async def test_search_forwards_user_id_to_embed_query(self):
+        """SHU-718: when user_id is passed to search(), it must reach
+        embed_query so the embedding llm_usage row attributes to the
+        originating user. Guards against a hardcoded-None regression
+        that the default-user_id test at test_search_embeds_query
+        would not catch.
+        """
+        mock_embedding = MagicMock()
+        mock_embedding.embed_query = AsyncMock(return_value=[0.1] * 1024)
+        service = self._make_service(embedding_service=mock_embedding)
+        mock_session_factory = _make_mock_session_factory()
+
+        await service.search(
+            "test query", uuid4(), session_factory=mock_session_factory, user_id="user-42"
+        )
+
+        mock_embedding.embed_query.assert_called_once_with("test query", user_id="user-42")
+
+    @pytest.mark.asyncio
     async def test_search_passes_results_to_fusion(self):
         """search() should pass surface results to fusion service."""
         doc_id = uuid4()

--- a/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
+++ b/backend/src/tests/unit/services/retrieval/test_multi_surface_search.py
@@ -90,7 +90,7 @@ class TestMultiSurfaceSearchService:
             "test query", uuid4(), session_factory=mock_session_factory
         )
 
-        mock_embedding.embed_query.assert_called_once_with("test query")
+        mock_embedding.embed_query.assert_called_once_with("test query", user_id=None)
 
     @pytest.mark.asyncio
     async def test_search_passes_results_to_fusion(self):

--- a/backend/src/tests/unit/services/test_message_context_builder.py
+++ b/backend/src/tests/unit/services/test_message_context_builder.py
@@ -149,3 +149,43 @@ class TestGetRagSectionsKBIds:
             mock_exec.assert_not_awaited()
             assert sections == []
             assert metadata == []
+
+
+class TestUserIdThreadingFromMessageContext:
+    """SHU-718 regression: _get_rag_sections must forward the acting user's
+    ID into ``execute_rag_queries`` so retrieval-time embedding ``llm_usage``
+    rows attribute to the originating user.
+
+    Dropping ``user_id`` at this boundary would leave every RAG-enabled chat
+    turn producing NULL-user_id embedding rows despite ``current_user`` being
+    in scope at the chat layer — the exact bug SHU-718 closes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_rag_sections_forwards_user_id_to_execute_rag_queries(self):
+        builder = _make_builder()
+        conversation = _mock_conversation()
+        current_user = _mock_user(user_id="user-42")
+        model = MagicMock()
+
+        with patch(
+            "shu.services.message_context_builder.execute_rag_queries",
+            new_callable=AsyncMock,
+            return_value=("rewritten", None, []),
+        ) as mock_exec:
+            await builder._get_rag_sections(
+                conversation=conversation,
+                user_message="test query",
+                current_user=current_user,
+                knowledge_base_ids=["kb-1"],
+                rag_rewrite_mode=RagRewriteMode.RAW_QUERY,
+                model=model,
+                conversation_messages=[],
+            )
+
+        mock_exec.assert_awaited_once()
+        assert mock_exec.call_args.kwargs.get("user_id") == "user-42", (
+            "MessageContextBuilder must forward str(current_user.id) into "
+            "execute_rag_queries so retrieval-side embedding llm_usage rows "
+            "attribute to the originating user (SHU-718)."
+        )

--- a/backend/src/tests/unit/services/test_rag_query_wrappers_user_id_threading.py
+++ b/backend/src/tests/unit/services/test_rag_query_wrappers_user_id_threading.py
@@ -16,10 +16,6 @@ from shu.schemas.query import QueryRequest, RagRewriteMode
 from shu.services import rag_query_processing, rag_query_rewrite
 
 
-def _make_query_request() -> QueryRequest:
-    return QueryRequest(query="hello world how are you", query_type="hybrid", limit=10)
-
-
 def _build_request(_kb_id, _rag_config, query_text):
     return QueryRequest(query=query_text, query_type="hybrid", limit=10)
 

--- a/backend/src/tests/unit/services/test_rag_query_wrappers_user_id_threading.py
+++ b/backend/src/tests/unit/services/test_rag_query_wrappers_user_id_threading.py
@@ -1,0 +1,136 @@
+"""SHU-718 regression tests: the ``execute_rag_queries`` helpers in both
+``rag_query_processing.py`` and ``rag_query_rewrite.py`` must forward
+``user_id`` down into ``QueryService.query_documents``.
+
+Two copies of this helper exist today (the ticket discussion flagged that
+both live in the codebase and both reach ``query_documents``). Each needs
+its own regression test so neither silently regresses user attribution on
+retrieval-side embedding ``llm_usage`` rows.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from shu.schemas.query import QueryRequest, RagRewriteMode
+from shu.services import rag_query_processing, rag_query_rewrite
+
+
+def _make_query_request() -> QueryRequest:
+    return QueryRequest(query="hello world how are you", query_type="hybrid", limit=10)
+
+
+def _build_request(_kb_id, _rag_config, query_text):
+    return QueryRequest(query=query_text, query_type="hybrid", limit=10)
+
+
+def _rag_config_response() -> MagicMock:
+    cfg = MagicMock()
+    cfg.model_dump = MagicMock(return_value={"minimum_query_words": 1, "search_type": "hybrid"})
+    return cfg
+
+
+class TestExecuteRagQueriesUserIdThreading:
+    """Both ``execute_rag_queries`` helpers must forward user_id into
+    ``QueryService.query_documents`` so the embedding llm_usage row
+    attributes to the originating user (SHU-718).
+    """
+
+    @pytest.mark.asyncio
+    async def test_rag_query_processing_forwards_user_id_to_query_documents(self):
+        db_session = AsyncMock()
+        config_manager = MagicMock()
+        current_user = MagicMock()
+        current_user.id = "user-42"
+
+        query_service = MagicMock()
+        query_service.query_documents = AsyncMock(return_value={"results": []})
+
+        kb_service = MagicMock()
+        kb_service.get_rag_config = AsyncMock(return_value=_rag_config_response())
+
+        with patch.object(
+            rag_query_processing, "KnowledgeBaseService", return_value=kb_service
+        ):
+            await rag_query_processing.execute_rag_queries(
+                db_session=db_session,
+                config_manager=config_manager,
+                query_service=query_service,
+                current_user=current_user,
+                query_text="hello world how are you",
+                knowledge_base_ids=["kb-1"],
+                request_builder=_build_request,
+                rag_rewrite_mode=RagRewriteMode.RAW_QUERY,
+                user_id="user-42",
+            )
+
+        query_service.query_documents.assert_awaited_once()
+        assert query_service.query_documents.call_args.kwargs.get("user_id") == "user-42"
+
+    @pytest.mark.asyncio
+    async def test_rag_query_processing_defaults_user_id_to_none(self):
+        """Legacy callers that don't pass user_id must still work and
+        propagate ``user_id=None`` — guards against the signature change
+        accidentally requiring the kwarg.
+        """
+        db_session = AsyncMock()
+        config_manager = MagicMock()
+        current_user = MagicMock()
+        current_user.id = "user-42"
+
+        query_service = MagicMock()
+        query_service.query_documents = AsyncMock(return_value={"results": []})
+
+        kb_service = MagicMock()
+        kb_service.get_rag_config = AsyncMock(return_value=_rag_config_response())
+
+        with patch.object(
+            rag_query_processing, "KnowledgeBaseService", return_value=kb_service
+        ):
+            await rag_query_processing.execute_rag_queries(
+                db_session=db_session,
+                config_manager=config_manager,
+                query_service=query_service,
+                current_user=current_user,
+                query_text="hello world how are you",
+                knowledge_base_ids=["kb-1"],
+                request_builder=_build_request,
+                rag_rewrite_mode=RagRewriteMode.RAW_QUERY,
+            )
+
+        assert query_service.query_documents.call_args.kwargs.get("user_id") is None
+
+    @pytest.mark.asyncio
+    async def test_rag_query_rewrite_forwards_user_id_to_query_documents(self):
+        """Second copy of execute_rag_queries (rag_query_rewrite.py) must
+        also thread user_id — this is the one the ticket's "intermediate
+        rag_query_* wrapper" clause covers.
+        """
+        db_session = AsyncMock()
+        config_manager = MagicMock()
+        current_user = MagicMock()
+        current_user.id = "user-42"
+
+        query_service = MagicMock()
+        query_service.query_documents = AsyncMock(return_value={"results": []})
+
+        kb_service = MagicMock()
+        kb_service.get_rag_config = AsyncMock(return_value=_rag_config_response())
+
+        with patch.object(
+            rag_query_rewrite, "KnowledgeBaseService", return_value=kb_service
+        ):
+            await rag_query_rewrite.execute_rag_queries(
+                db_session=db_session,
+                config_manager=config_manager,
+                query_service=query_service,
+                current_user=current_user,
+                query_text="hello world how are you",
+                knowledge_base_ids=["kb-1"],
+                request_builder=_build_request,
+                apply_rewrite=False,  # skip the side-call rewrite path
+                user_id="user-42",
+            )
+
+        query_service.query_documents.assert_awaited_once()
+        assert query_service.query_documents.call_args.kwargs.get("user_id") == "user-42"


### PR DESCRIPTION
RAG-enabled chat turns were producing llm_usage rows with NULL user_id on every retrieval-time embed_query call. SHU-700 closed the ingestion side of this gap (embedding on chunk upload) but missed the retrieval side — similarity/keyword/hybrid/multi_surface all dropped user_id between the chat boundary and the embedding service. Stripe invoices stayed correct (cost math unchanged), but per-user usage dashboards undercounted RAG activity for every hosted chat.

Threads user_id from current_user down through:
  QueryService.query_documents → {similarity,keyword,hybrid,
  _multi_surface}_search → embedding_service.embed_query

Entry points updated: MessageContextBuilder (chat + regenerate), api/query endpoint, ExperienceExecutor._execute_kb_step, and both rag_query_processing + rag_query_rewrite execute_rag_queries wrappers.

Beyond the literal AC, also threaded user_id through hybrid_search (dispatcher composes it) and _get_title_match_chunks fallback (sleeper-bug guard — no production caller reaches its embed branch today but future ones would drop user_id).

re_embedding_handler bulk-reembed path stays out of scope (no single identifiable user at the invoking surface), per SHU-700 AC #8.

Regression tests mirror SHU-700's TestUserIdThreading pattern:
  - TestUserIdThreadingRagQueryEmbed (10 tests, all 4 retrieval surfaces + dispatcher + _get_title_match_chunks fallback)
  - TestUserIdThreadingFromMessageContext (MessageContextBuilder)
  - TestExecuteRagQueriesUserIdThreading (both wrapper copies)

Manual testing confirmed the flip from NULL → populated on similarity, keyword+title-match, hybrid, REWRITE_ENHANCED, regenerate, and stop-words (zero-embed) paths. SHU-700 ingestion attribution verified untouched.

## Description
Four call sites under services/query/ and services/retrieval/ invoke embedding_service.embed_query(...) without forwarding user_id:
- [services/query/similarity.py:65](../../../backend/src/shu/services/query/similarity.py#L65) — similarity search
- [services/query/keyword.py:165](../../../backend/src/shu/services/query/keyword.py#L165) — hybrid keyword precompute
- [services/query/keyword.py:388](../../../backend/src/shu/services/query/keyword.py#L388) — keyword search
- [services/retrieval/multi_surface_search.py:97](../../../backend/src/shu/services/retrieval/multi_surface_search.py#L97) — multi-surface RAG search
Each of these fires on a RAG-enabled chat turn (frequency depends on which retrieval strategy is active; hybrid search can fire two of them per turn). The resulting embedding llm_usage row lands with NULL user_id, despite conversation.user_id being available at the chat boundary.
The call chain to fix, from outer to inner:

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Related to #SHU-700

## Changes Made
- Extend signatures in QueryService and its mixins
- Forward at every embed_query / embed_queries call site in similarity.py, keyword.py (both lines), and multi_surface_search.py.
- Thread from caller: MessageContextBuilder is the natural source — conversation.user_id (or conversation_owner_id if the builder sees it) should flow into QueryService.query_documents. Check rag_query_processing.py and rag_query_rewrite.py — both call query_service.query_documents(...) and will need the same forward.
- Regression test: add a TestUserIdThreadingRagQueryEmbed class (or equivalent) to the query-service test suite. Mock get_embedding_service → a service whose embed_query / embed_queries records calls. Invoke QueryService.query_documents(..., user_id="test-user") with each retrieval path (similarity / keyword / hybrid / multi-surface) and assert the embedding service receives user_id="test-user" on every call.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing locally

### Manual Testing
<html>
<body>
<!--StartFragment-->
# | Scenario | Expected | Status | Verified
-- | -- | -- | -- | --
1 | RAG chat, search_type=similarity | 1 embed row with user_id = conversation owner | ✅ PASS | 19:06:53 — user_id populated, 18 tokens
2 | RAG chat, search_type=keyword, title_weighting OFF | Zero embed rows (keyword-only SQL path, no embed fires) | ✅ PASS | Chat fired at 19:19:50 (3040 tokens), no new embed row appeared
3 | RAG chat, search_type=keyword, title_weighting ON, query matches a doc title | 1 embed row with user_id (title-match precompute fires) | ✅ PASS | 19:15:43 — user_id populated, 16 tokens
4 | RAG chat, search_type=hybrid | 1–2 embed rows with user_id (similarity always, keyword-title if match) | ✅ PASS | 19:22:16 — 1 embed (similarity only, no title match)
5 | RAG chat, search_type=multi_surface | 1 embed row with user_id | Covered by unit test | test_multi_surface_search_mixin_forwards_user_id_to_orchestrator (UI does not currently expose this mode)
6 | Direct POST /api/v1/query/{kb_id}/search | Embed row with user_id = authenticated caller | Covered by unit test | Same code path as #1–4 via rag_query_processing.execute_rag_queries
7 | Experience KB step, user-owned run | Embed row with user_id = run owner | Covered by unit test | TestExecuteRagQueriesUserIdThreading
8 | Experience KB step, shared/scheduled run | Embed row with user_id = experience creator | Covered by unit test | Same path as #7; current_user resolved to creator via _load_and_resolve_identity
9 | Chat with rag_rewrite_mode=REWRITE_ENHANCED | All rows (side_call rewrite + embed rows) carry user_id | ✅ PASS | 19:35:58 – 19:36:33 — 2 side_calls + 2 embeds + 1 chat + 2 post-chat side_calls, all attributed. 41-token embed confirms rewritten query fed RAG
10 | Regenerate assistant message on existing conversation | Embed row with user_id matches conversation owner | ✅ PASS | 19:27:10 and 19:27:28 — two regenerate clicks, each produced a correctly-attributed embed
11 | Chat against KB with embedding_status='stale', hybrid | At most 1 embed (keyword-title only, similarity skipped) with user_id | Covered by unit test | KnowledgeBaseStaleEmbeddingsError fallback path; hybrid_search forwards user_id to keyword_search in the fallback branch
12 | Stop-words-only query | Zero embed rows (skipped at insufficient_meaningful_words) | ✅ PASS | Tested in both existing and new chat — 19:28:54 and 19:29:12 chats with 362 / 10 tokens, no embed rows appeared
13 | SHU-700 regression: document ingestion | Ingestion embed row still carries user_id | ✅ PASS | 19:32:11 — PDF uploaded, 209-token chunk embed row with correct user_id (document-chunk batch signature distinguishes from query-side)

<!--EndFragment-->
</body>
</html>

## Code Quality Checklist
<!-- All items must be checked before merging -->

### Backend (Python)

- [x] Type hints added to all new functions/classes
- [x] Docstrings added to all public functions/classes
- [x] Unit tests written for new code
- [x] ConfigurationManager used (no hardcoded values)
- [x] Dependency injection used (no direct instantiation)
- [x] Timezone-aware datetimes used
- [x] No breaking migration changes
- [x] Files end with trailing newlines

### Frontend (React/JavaScript)

N/A

### API

N/A

### Linting

- [x] Pre-commit hooks pass
- [x] CI linting checks pass
- [x] No linting warnings ignored without justification

### Documentation

- [x] Code comments added where needed
- [N/A] README updated (if applicable)
- [N/A] API docs updated (if applicable)
- [N/A] Migration guide provided (if breaking change)

### Security

- [x] No hardcoded secrets or credentials
- [x] No sensitive data in logs
- [x] Input validation added
- [x] Authentication/authorization checked

## Screenshots (if applicable)
N/A

## Deployment Notes
<!-- Any special deployment considerations? -->
- [N/A] Database migrations required
- [N/A] Environment variables added/changed
- [N/A] Dependencies added/updated
- [N/A] Configuration changes needed

## Reviewer Notes
Really just keep an eye on the llm_usage table! Now pretty much everything that goes into that table will have a uder_id associated with it, which will be great for organizations that want to see which users are doing what. Can definitely have some some screens in the Admin Panel to visualize this as well!


---

**By submitting this PR, I confirm that:**

- [x] I have run `make lint-fix` and all linting checks pass
- [x] I have tested my changes locally
- [x] I have followed the coding standards in `docs/policies/DEVELOPMENT_STANDARDS.md`
- [x] I have read and followed the linting policy in `docs/policies/LINTING_POLICY.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced query and RAG processing pipeline to properly thread user context through all retrieval operations, ensuring accurate user attribution during query execution.

* **Tests**
  * Added comprehensive test coverage validating user ID is correctly propagated through query services, similarity search, keyword search, hybrid search, and multi-surface search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->