### PR TITLE
[SHU-743] Tenant cp billing state poll

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,12 +32,6 @@ SHU_REDIS_URL="redis://localhost:6379"
 SHU_REDIS_CONNECTION_TIMEOUT=5
 SHU_REDIS_SOCKET_TIMEOUT=5
 
-# Tenant identifier prefixed to every Redis key for multi-tenant isolation on
-# shared Redis deployments. Set to the tenant's control-plane UUID in hosted
-# mode. Leave unset for local dev and self-hosted deployments (keys are not
-# prefixed). Startup fails if set to an empty or whitespace-only value.
-# SHU_TENANT_ID="<tenant-uuid>"
-
 # =============================================================================
 # API SERVER CONFIGURATION
 # =============================================================================
@@ -730,11 +724,29 @@ SHU_STRIPE_PUBLISHABLE_KEY=""
 SHU_STRIPE_CUSTOMER_ID=""
 SHU_STRIPE_SUBSCRIPTION_ID=""
 
-# Router HMAC shared secret. Stripe webhook ingress runs through the Shu
-# Control Plane; this tenant verifies the forwarded-envelope HMAC with this
-# secret. Must match the tenant row's shared_secret in the control-plane
-# registry (64 lowercase hex chars — secrets.token_hex(32)).
-SHU_ROUTER_SHARED_SECRET=""
+# --- Control-plane communication -------------------------------------------
+
+# Tenant's CP-side UUID. Used in the path of CP polls
+# (/api/v1/tenants/{SHU_TENANT_ID}/billing-state) and as a Redis-key prefix
+# on shared Redis deployments. Startup fails if set to an empty or
+# whitespace-only value.
+# SHU_TENANT_ID="<tenant-uuid>"
+
+# HMAC shared secret used for both directions of CP↔tenant traffic: CP signs
+# forwarded webhooks with it; the tenant signs CP polls with it. Must match
+# the tenant row's shared_secret in the control-plane registry
+# (64 lowercase hex chars — secrets.token_hex(32)).
+# SHU_ROUTER_SHARED_SECRET=""
+
+# Base URL for the Shu Control Plane. Required in hosted mode whenever
+# SHU_ROUTER_SHARED_SECRET is set.
+# SHU_CP_BASE_URL="https://cp.shu.example"
+
+# In-process TTL for the cached CP billing-state response, in seconds.
+# The cache uses stale-while-error on top of this — outage windows are
+# absorbed by serving the previous value.
+# SHU_BILLING_STATE_CACHE_TTL_SECONDS=500
+# ---------------------------------------------------------------------------
 
 # Product and Price IDs (create in Stripe Dashboard > Products)
 # Product: "Shu Pro" or similar

--- a/backend/src/shu/billing/billing_state_cache.py
+++ b/backend/src/shu/billing/billing_state_cache.py
@@ -3,10 +3,12 @@
 The cache is the single value consumers see. Policy lives entirely here:
     - Fresh hit (within TTL): return cached value, no fetch.
     - Stale or empty + CP success: update both fields, return new value.
-    - Stale + CP failure: keep the last successful value, leave
-      `_last_success_at` untouched (so the next call retries on the next
-      TTL boundary, not a delayed one), log a warning, return the stale
-      value to the caller. No exceptions propagated.
+    - Stale + CP failure: serve cached (or HEALTHY_DEFAULT on cold start),
+      and arm a one-TTL backoff window. While the backoff is armed, no
+      further CP fetches happen — every get() short-circuits to the
+      cached value or default. Without this, every call past the
+      success-TTL would re-enter the fetch branch and serialize 5s
+      timeouts under the lock during a CP outage.
     - Cold start (no prior success) + CP failure: return HEALTHY_DEFAULT.
 
 The fail-open trade-off is deliberate (see SHU-743 Notes): CP outages
@@ -17,9 +19,8 @@ is gated at OpenRouter, so the leak window is OCR-only.
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from fastapi import FastAPI
@@ -47,15 +48,19 @@ class BillingStateCache:
         self,
         client: CpClient,
         ttl_seconds: int,
-        logger: logging.Logger,
         clock: Callable[[], datetime] = _utc_now,
     ) -> None:
         self._client = client
         self._ttl_seconds = ttl_seconds
-        self._logger = logger
         self._clock = clock
         self._value: BillingState | None = None
         self._last_success_at: datetime | None = None
+        # Set on every failed fetch attempt to `now + ttl`. While the clock
+        # is before this deadline, get() short-circuits without hitting CP —
+        # capping the failure-retry rate at one CP attempt per TTL during
+        # an outage. Without it, every call past the success-TTL would
+        # re-enter the fetch branch and serialize 5s timeouts under the lock.
+        self._next_retry_after: datetime | None = None
         # Single-flight: concurrent get() callers wait on this lock instead
         # of stampeding CP. The freshness re-check inside the lock prevents
         # waiters from triggering a redundant fetch after the holder succeeds.
@@ -67,10 +72,13 @@ class BillingStateCache:
                 # type-narrowed: _is_fresh implies a prior success, so _value is set.
                 assert self._value is not None
                 return self._value
+            if self._is_in_failure_backoff():
+                return self._value if self._value is not None else HEALTHY_DEFAULT
 
             try:
                 value = await self._client.fetch_billing_state()
             except CpClientError as exc:
+                self._next_retry_after = self._clock() + timedelta(seconds=self._ttl_seconds)
                 return self._serve_stale_or_default(exc)
 
             self._value = value
@@ -83,13 +91,14 @@ class BillingStateCache:
         age = (self._clock() - self._last_success_at).total_seconds()
         return age < self._ttl_seconds
 
+    def _is_in_failure_backoff(self) -> bool:
+        return self._next_retry_after is not None and self._clock() < self._next_retry_after
+
     def _serve_stale_or_default(self, exc: CpClientError) -> BillingState:
-        # Note: _last_success_at is deliberately NOT advanced here. Advancing
-        # it would push the next retry out by another full TTL window even
-        # though we never got fresh state — the goal is to retry on the next
-        # boundary based on the LAST successful fetch, not the last attempt.
+        # _last_success_at is deliberately NOT advanced on failure; the retry
+        # cadence is bounded by _next_retry_after instead.
         if self._value is not None:
-            self._logger.warning(
+            _logger.warning(
                 "CP unreachable, serving stale billing state",
                 extra={
                     "last_success_at": self._last_success_at.isoformat() if self._last_success_at else None,
@@ -97,7 +106,7 @@ class BillingStateCache:
                 },
             )
             return self._value
-        self._logger.warning(
+        _logger.warning(
             "CP unreachable on cold start, serving healthy default",
             extra={"exc_type": type(exc).__name__},
         )
@@ -111,6 +120,11 @@ async def initialize_billing_state_cache(app: FastAPI) -> None:
     Skipped on self-hosted / dev deployments where CP isn't configured —
     presence of all three of `tenant_id`, `router_shared_secret`, and
     `cp_base_url` is the signal that the tenant is meant to talk to CP.
+
+    `app.state.billing_state_cache` is always set after this returns —
+    either to a `BillingStateCache` instance or to `None`. Consumers can
+    then check for `None` deterministically rather than handling
+    AttributeError.
     """
     settings = get_settings_instance()
     billing_settings = get_billing_settings()
@@ -119,27 +133,28 @@ async def initialize_billing_state_cache(app: FastAPI) -> None:
             "CP billing-state cache disabled — tenant_id, router secret, or "
             "CP base URL not configured (self-hosted / dev)"
         )
+        app.state.billing_state_cache = None
         return
 
+    # Set None up-front so any failure below still leaves a discoverable attr.
+    app.state.billing_state_cache = None
     try:
         http_client = await get_http_client()
-        client = CpClient(
-            base_url=billing_settings.cp_base_url,
-            tenant_id=UUID(settings.tenant_id),
-            shared_secret=billing_settings.router_shared_secret,
-            http_client=http_client,
-            logger=get_logger("shu.billing.cp_client"),
-        )
         cache = BillingStateCache(
-            client=client,
+            client=CpClient(
+                base_url=billing_settings.cp_base_url,
+                tenant_id=UUID(settings.tenant_id),
+                shared_secret=billing_settings.router_shared_secret,
+                http_client=http_client,
+                logger=get_logger("shu.billing.cp_client"),
+            ),
             ttl_seconds=billing_settings.billing_state_cache_ttl_seconds,
-            logger=get_logger("shu.billing.billing_state_cache"),
         )
-        # Eager fetch absorbs CP unreachability via stale-while-error, so this
-        # never raises a CpClientError. Any exception here is a misconfiguration
-        # (bad UUID, broken httpx, etc.) caught by the outer try/except.
-        await cache.get()
+        # Assign before the eager fetch so a programmer error in get() still
+        # leaves the cache reachable. CpClientError is absorbed inside get();
+        # only programmer errors (bad UUID, broken httpx, etc.) reach here.
         app.state.billing_state_cache = cache
-        _logger.info("CP billing-state cache initialized: %s", await cache.get())
+        cache = await cache.get()
+        _logger.info("CP billing-state cache initialized: %s", cache)
     except Exception as e:
         _logger.warning(f"CP billing-state cache initialization failed: {e}")

--- a/backend/src/shu/billing/billing_state_cache.py
+++ b/backend/src/shu/billing/billing_state_cache.py
@@ -1,0 +1,145 @@
+"""TTL'd cache for the tenant→CP billing-state poll, with stale-while-error.
+
+The cache is the single value consumers see. Policy lives entirely here:
+    - Fresh hit (within TTL): return cached value, no fetch.
+    - Stale or empty + CP success: update both fields, return new value.
+    - Stale + CP failure: keep the last successful value, leave
+      `_last_success_at` untouched (so the next call retries on the next
+      TTL boundary, not a delayed one), log a warning, return the stale
+      value to the caller. No exceptions propagated.
+    - Cold start (no prior success) + CP failure: return HEALTHY_DEFAULT.
+
+The fail-open trade-off is deliberate (see SHU-743 Notes): CP outages
+should not lock customers out of OCR. Bounded — chat / embedding cost
+is gated at OpenRouter, so the leak window is OCR-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import FastAPI
+
+from shu.billing.config import get_billing_settings
+from shu.billing.cp_client import (
+    HEALTHY_DEFAULT,
+    BillingState,
+    CpClient,
+    CpClientError,
+)
+from shu.core.config import get_settings_instance
+from shu.core.http_client import get_http_client
+from shu.core.logging import get_logger
+
+_logger = get_logger(__name__)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class BillingStateCache:
+    def __init__(
+        self,
+        client: CpClient,
+        ttl_seconds: int,
+        logger: logging.Logger,
+        clock: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._client = client
+        self._ttl_seconds = ttl_seconds
+        self._logger = logger
+        self._clock = clock
+        self._value: BillingState | None = None
+        self._last_success_at: datetime | None = None
+        # Single-flight: concurrent get() callers wait on this lock instead
+        # of stampeding CP. The freshness re-check inside the lock prevents
+        # waiters from triggering a redundant fetch after the holder succeeds.
+        self._lock = asyncio.Lock()
+
+    async def get(self) -> BillingState:
+        async with self._lock:
+            if self._is_fresh():
+                # type-narrowed: _is_fresh implies a prior success, so _value is set.
+                assert self._value is not None
+                return self._value
+
+            try:
+                value = await self._client.fetch_billing_state()
+            except CpClientError as exc:
+                return self._serve_stale_or_default(exc)
+
+            self._value = value
+            self._last_success_at = self._clock()
+            return value
+
+    def _is_fresh(self) -> bool:
+        if self._value is None or self._last_success_at is None:
+            return False
+        age = (self._clock() - self._last_success_at).total_seconds()
+        return age < self._ttl_seconds
+
+    def _serve_stale_or_default(self, exc: CpClientError) -> BillingState:
+        # Note: _last_success_at is deliberately NOT advanced here. Advancing
+        # it would push the next retry out by another full TTL window even
+        # though we never got fresh state — the goal is to retry on the next
+        # boundary based on the LAST successful fetch, not the last attempt.
+        if self._value is not None:
+            self._logger.warning(
+                "CP unreachable, serving stale billing state",
+                extra={
+                    "last_success_at": self._last_success_at.isoformat() if self._last_success_at else None,
+                    "exc_type": type(exc).__name__,
+                },
+            )
+            return self._value
+        self._logger.warning(
+            "CP unreachable on cold start, serving healthy default",
+            extra={"exc_type": type(exc).__name__},
+        )
+        return HEALTHY_DEFAULT
+
+
+async def initialize_billing_state_cache(app: FastAPI) -> None:
+    """Eager-load the cache so SHU-703 enforcement (when it lands) sees a
+    fresh value on the first request rather than the cold-start fallback.
+
+    Skipped on self-hosted / dev deployments where CP isn't configured —
+    presence of all three of `tenant_id`, `router_shared_secret`, and
+    `cp_base_url` is the signal that the tenant is meant to talk to CP.
+    """
+    settings = get_settings_instance()
+    billing_settings = get_billing_settings()
+    if not (settings.tenant_id and billing_settings.router_shared_secret and billing_settings.cp_base_url):
+        _logger.info(
+            "CP billing-state cache disabled — tenant_id, router secret, or "
+            "CP base URL not configured (self-hosted / dev)"
+        )
+        return
+
+    try:
+        http_client = await get_http_client()
+        client = CpClient(
+            base_url=billing_settings.cp_base_url,
+            tenant_id=UUID(settings.tenant_id),
+            shared_secret=billing_settings.router_shared_secret,
+            http_client=http_client,
+            logger=get_logger("shu.billing.cp_client"),
+        )
+        cache = BillingStateCache(
+            client=client,
+            ttl_seconds=billing_settings.billing_state_cache_ttl_seconds,
+            logger=get_logger("shu.billing.billing_state_cache"),
+        )
+        # Eager fetch absorbs CP unreachability via stale-while-error, so this
+        # never raises a CpClientError. Any exception here is a misconfiguration
+        # (bad UUID, broken httpx, etc.) caught by the outer try/except.
+        await cache.get()
+        app.state.billing_state_cache = cache
+        _logger.info("CP billing-state cache initialized: %s", await cache.get())
+    except Exception as e:
+        _logger.warning(f"CP billing-state cache initialization failed: {e}")

--- a/backend/src/shu/billing/config.py
+++ b/backend/src/shu/billing/config.py
@@ -9,8 +9,14 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Floor on the cache TTL guards against an operator setting a near-zero value
+# that would have every enforcement check hit CP. 10s is loose enough not to be
+# accidentally tripped, tight enough that emergency cache flushes are still
+# possible without code changes.
+_MIN_BILLING_STATE_CACHE_TTL_SECONDS = 10
 
 
 class BillingSettings(BaseSettings):
@@ -31,6 +37,17 @@ class BillingSettings(BaseSettings):
     # /api/v1/billing/webhooks. Must match the tenant row's `shared_secret` in
     # the control-plane registry (64 lowercase hex chars from secrets.token_hex(32)).
     router_shared_secret: str | None = Field(None, alias="SHU_ROUTER_SHARED_SECRET")
+
+    # Base URL for tenant→CP polls (e.g. /api/v1/tenants/{id}/billing-state).
+    # Required in hosted mode whenever router_shared_secret is set; absence is
+    # surfaced through validate_configuration rather than failing model init so
+    # self-hosted deployments without billing can still load BillingSettings.
+    cp_base_url: str | None = Field(None, alias="SHU_CP_BASE_URL")
+
+    # In-process TTL for the cached BillingState polled from CP. The cache uses
+    # stale-while-error on top of this — TTL governs successful-refresh cadence;
+    # outage windows are absorbed by serving the previous value.
+    billing_state_cache_ttl_seconds: int = Field(500, alias="SHU_BILLING_STATE_CACHE_TTL_SECONDS")
 
     # Tenant identifiers — set by the operator at deploy time.
     # These seed billing_state on first boot so webhook handlers and
@@ -73,6 +90,16 @@ class BillingSettings(BaseSettings):
         populate_by_name=True,  # Allow both field names and aliases
     )
 
+    @field_validator("billing_state_cache_ttl_seconds", mode="after")
+    @classmethod
+    def _enforce_min_cache_ttl(cls, value: int) -> int:
+        if value < _MIN_BILLING_STATE_CACHE_TTL_SECONDS:
+            raise ValueError(
+                f"SHU_BILLING_STATE_CACHE_TTL_SECONDS must be >= "
+                f"{_MIN_BILLING_STATE_CACHE_TTL_SECONDS} (got {value})"
+            )
+        return value
+
     @property
     def is_configured(self) -> bool:
         """Check if billing is fully configured for this instance.
@@ -113,6 +140,12 @@ class BillingSettings(BaseSettings):
 
         if not self.router_shared_secret:
             issues.append("SHU_ROUTER_SHARED_SECRET is required for router-envelope verification")
+
+        # cp_base_url is only meaningful when router_shared_secret is set —
+        # the secret addresses the tenant in CP, the URL is where to reach CP.
+        # Either both are present (hosted) or both absent (dev / self-hosted).
+        if self.router_shared_secret and not self.cp_base_url:
+            issues.append("SHU_CP_BASE_URL is required when SHU_ROUTER_SHARED_SECRET is set")
 
         if not self.price_id_monthly:
             issues.append("SHU_STRIPE_PRICE_ID_MONTHLY is required for subscriptions")

--- a/backend/src/shu/billing/cp_client.py
+++ b/backend/src/shu/billing/cp_client.py
@@ -8,18 +8,28 @@ wrong value sees it during deploy verification, not during a payment
 failure).
 
 This module owns transport classification only. Stale-while-error policy
-and TTL caching live in `state_cache.py` — the consumer (SHU-703
+and TTL caching live in `billing_state_cache.py` — the consumer (SHU-703
 enforcement) talks to the cache, never directly to this client.
 """
 
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from datetime import datetime
+from typing import Annotated, Any
 from uuid import UUID
 
 import httpx
+from pydantic import (
+    AwareDatetime,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictInt,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
+from pydantic.dataclasses import dataclass
 
 from shu.billing.router_envelope import (
     SIGNATURE_HEADER,
@@ -28,11 +38,35 @@ from shu.billing.router_envelope import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, config=ConfigDict(extra="ignore"))
 class BillingState:
-    openrouter_key_disabled: bool
-    payment_failed_at: datetime | None
-    payment_grace_days: int
+    """Frozen CP billing-state record — also the wire-validation schema.
+
+    The strict field types are load-bearing: a CP version-skew that sends
+    `"false"` (string) for openrouter_key_disabled would otherwise flow
+    through as truthy and lock healthy users out of OCR. AwareDatetime +
+    the validator below reject Unix timestamps and naive datetimes —
+    downstream tz-aware arithmetic would crash on naive values.
+    """
+
+    openrouter_key_disabled: StrictBool
+    payment_failed_at: AwareDatetime | None
+    payment_grace_days: Annotated[StrictInt, Field(ge=0)]
+
+    @field_validator("payment_failed_at", mode="before")
+    @classmethod
+    def _reject_unix_timestamp(cls, v: object) -> object:
+        # AwareDatetime in lax mode coerces Unix timestamps (int/float) to
+        # UTC datetimes — that masks a CP wire-format drift. Strings (parsed
+        # by pydantic) and datetime instances (direct construction) pass
+        # through. bool is a subclass of int, but AwareDatetime rejects it
+        # downstream so no special-casing here.
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            raise TypeError(f"payment_failed_at must be ISO string or datetime, " f"not {type(v).__name__}")
+        return v
+
+
+_BILLING_STATE_ADAPTER = TypeAdapter(BillingState)
 
 
 # Cold-start fallback when the cache has never observed a successful
@@ -64,6 +98,16 @@ class CpUnexpectedStatus(CpClientError):
         super().__init__(f"CP returned status {status}: {body}")
         self.status = status
         self.body = body
+
+
+class CpMalformedResponse(CpClientError):
+    """CP returned 2xx with a body that does not match the expected schema.
+
+    Surfacing this as a CpClientError keeps the cache's stale-while-error
+    fail-open path active when CP misbehaves at the application layer
+    (corrupted JSON, missing fields, type drift) rather than letting the
+    raw parse exception escape to consumers.
+    """
 
 
 class CpClient:
@@ -98,12 +142,16 @@ class CpClient:
         except httpx.RequestError as exc:
             raise CpUnreachable(f"CP unreachable: {exc}") from exc
 
-        if response.status_code == 200:
-            return self._parse(response.json())
         if response.status_code == 401:
             self._log_auth_failure()
             raise CpAuthFailed(f"CP rejected signature for tenant poll at {self._path}")
-        raise CpUnexpectedStatus(response.status_code, response.text)
+        if response.status_code != 200:
+            raise CpUnexpectedStatus(response.status_code, response.text)
+
+        try:
+            return self._parse(response.json())
+        except (ValueError, TypeError, ValidationError) as exc:
+            raise CpMalformedResponse(f"CP returned a malformed billing-state body: {exc}") from exc
 
     def _log_auth_failure(self) -> None:
         if not self._auth_failure_seen:
@@ -118,10 +166,5 @@ class CpClient:
             self._logger.warning("CP returned 401 for billing-state poll", extra={"path": self._path})
 
     @staticmethod
-    def _parse(payload: dict) -> BillingState:
-        raw_failed_at = payload["payment_failed_at"]
-        return BillingState(
-            openrouter_key_disabled=payload["openrouter_key_disabled"],
-            payment_failed_at=(datetime.fromisoformat(raw_failed_at) if raw_failed_at is not None else None),
-            payment_grace_days=payload["payment_grace_days"],
-        )
+    def _parse(payload: Any) -> BillingState:
+        return _BILLING_STATE_ADAPTER.validate_python(payload)

--- a/backend/src/shu/billing/cp_client.py
+++ b/backend/src/shu/billing/cp_client.py
@@ -1,0 +1,127 @@
+"""HTTP client for tenant→CP billing-state polls.
+
+Signs each request with the same `router_shared_secret` CP uses to verify
+inbound webhooks, classifies CP responses into typed exceptions, and
+surfaces a single misconfiguration-shaped log on the first 401 (so an
+operator who set `SHU_TENANT_ID` or `SHU_ROUTER_SHARED_SECRET` to the
+wrong value sees it during deploy verification, not during a payment
+failure).
+
+This module owns transport classification only. Stale-while-error policy
+and TTL caching live in `state_cache.py` — the consumer (SHU-703
+enforcement) talks to the cache, never directly to this client.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from shu.billing.router_envelope import (
+    SIGNATURE_HEADER,
+    TIMESTAMP_HEADER,
+    sign_envelope,
+)
+
+
+@dataclass(frozen=True)
+class BillingState:
+    openrouter_key_disabled: bool
+    payment_failed_at: datetime | None
+    payment_grace_days: int
+
+
+# Cold-start fallback when the cache has never observed a successful
+# response. Once a real value lands the cache hands that out instead;
+# this constant is only reached in the (cold-start ∧ CP-unreachable) corner.
+HEALTHY_DEFAULT = BillingState(
+    openrouter_key_disabled=False,
+    payment_failed_at=None,
+    payment_grace_days=0,
+)
+
+
+class CpClientError(Exception):
+    """Base for tenant→CP transport failures."""
+
+
+class CpUnreachable(CpClientError):
+    """Network error / timeout reaching CP."""
+
+
+class CpAuthFailed(CpClientError):
+    """CP returned 401. Likely SHU_TENANT_ID / SHU_ROUTER_SHARED_SECRET mismatch."""
+
+
+class CpUnexpectedStatus(CpClientError):
+    """CP returned a non-2xx, non-401 response."""
+
+    def __init__(self, status: int, body: str) -> None:
+        super().__init__(f"CP returned status {status}: {body}")
+        self.status = status
+        self.body = body
+
+
+class CpClient:
+    """Async client for the CP /billing-state endpoint."""
+
+    def __init__(
+        self,
+        base_url: str,
+        tenant_id: UUID,
+        shared_secret: str,
+        http_client: httpx.AsyncClient,
+        logger: logging.Logger,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._path = f"/api/v1/tenants/{tenant_id}/billing-state"
+        self._shared_secret = shared_secret
+        self._http_client = http_client
+        self._logger = logger
+        # First-401-per-process ERROR / subsequent WARNING. Instance-scoped
+        # rather than module-global so tests stay isolated and a future
+        # multi-tenant tenant process (if it ever existed) wouldn't share state.
+        self._auth_failure_seen = False
+
+    async def fetch_billing_state(self) -> BillingState:
+        timestamp, signature = sign_envelope(self._shared_secret, "GET", self._path, b"")
+        headers = {
+            TIMESTAMP_HEADER: str(timestamp),
+            SIGNATURE_HEADER: signature,
+        }
+        try:
+            response = await self._http_client.get(f"{self._base_url}{self._path}", headers=headers, timeout=5.0)
+        except httpx.RequestError as exc:
+            raise CpUnreachable(f"CP unreachable: {exc}") from exc
+
+        if response.status_code == 200:
+            return self._parse(response.json())
+        if response.status_code == 401:
+            self._log_auth_failure()
+            raise CpAuthFailed(f"CP rejected signature for tenant poll at {self._path}")
+        raise CpUnexpectedStatus(response.status_code, response.text)
+
+    def _log_auth_failure(self) -> None:
+        if not self._auth_failure_seen:
+            self._auth_failure_seen = True
+            self._logger.error(
+                "CP returned 401 for billing-state poll — likely "
+                "SHU_TENANT_ID or SHU_ROUTER_SHARED_SECRET mismatch with the "
+                "control-plane tenant row",
+                extra={"path": self._path},
+            )
+        else:
+            self._logger.warning("CP returned 401 for billing-state poll", extra={"path": self._path})
+
+    @staticmethod
+    def _parse(payload: dict) -> BillingState:
+        raw_failed_at = payload["payment_failed_at"]
+        return BillingState(
+            openrouter_key_disabled=payload["openrouter_key_disabled"],
+            payment_failed_at=(datetime.fromisoformat(raw_failed_at) if raw_failed_at is not None else None),
+            payment_grace_days=payload["payment_grace_days"],
+        )

--- a/backend/src/shu/billing/router_envelope.py
+++ b/backend/src/shu/billing/router_envelope.py
@@ -61,6 +61,25 @@ def _sign(shared_secret: str, timestamp: int, method: str, path: str, body: byte
     return f"{SIGNATURE_PREFIX}{digest}"
 
 
+def sign_envelope(
+    shared_secret: str,
+    method: str,
+    path: str,
+    body: bytes,
+    *,
+    timestamp: int | None = None,
+) -> tuple[int, str]:
+    """Sign an outbound request to CP, byte-compatible with verify_envelope.
+
+    Returns (timestamp, signature) so callers don't have to capture the clock
+    at sign time and again at header-build time — a 1-second drift between
+    the two would silently land outside the skew window on slow paths.
+    """
+    if timestamp is None:
+        timestamp = int(time.time())
+    return timestamp, _sign(shared_secret, timestamp, method, path, body)
+
+
 def verify_envelope(
     shared_secret: str,
     signature_header: str,
@@ -153,6 +172,7 @@ __all__ = [
     "SIGNATURE_PREFIX",
     "TIMESTAMP_HEADER",
     "RouterSignatureError",
+    "sign_envelope",
     "verify_envelope",
     "verify_router_envelope_dep",
 ]

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -40,6 +40,7 @@ from .api.side_call import router as side_call_router
 from .api.system import router as system_router
 from .api.user_permissions import router as user_permissions_router
 from .api.user_preferences import router as user_preferences_router
+from .billing.billing_state_cache import initialize_billing_state_cache
 from .billing.router import router as billing_router
 from .core.cache_backend import initialize_cache_backend
 from .core.config import get_settings_instance
@@ -431,6 +432,7 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
         logger.warning(f"Plugins startup failed: {e}")
 
     await _initialize_policy_cache()
+    await initialize_billing_state_cache(app)
 
     # Start periodic malloc_trim(0) task (SHU-731). Disabled by default —
     # enable via SHU_MEMORY_TRIM_INTERVAL_SECONDS>0. No-op on non-glibc libc

--- a/backend/src/tests/unit/billing/test_billing_state_cache.py
+++ b/backend/src/tests/unit/billing/test_billing_state_cache.py
@@ -1,0 +1,219 @@
+"""Tests for shu.billing.billing_state_cache — TTL + stale-while-error policy.
+
+The cache is the single value consumers see, so all policy branches need
+explicit coverage: fresh hit, expiry, single-flight, cold-start failure,
+warm-cache failure (stale-while-error), recovery, and the load-bearing
+invariant that `_last_success_at` is NOT advanced on failure (so retries
+land on the next TTL boundary, not a delayed one).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Iterator
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shu.billing.cp_client import (
+    HEALTHY_DEFAULT,
+    BillingState,
+    CpClient,
+    CpUnreachable,
+)
+from shu.billing.billing_state_cache import BillingStateCache
+
+
+_T0 = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+_TTL = 60
+
+
+def _state(disabled: bool = False) -> BillingState:
+    return BillingState(
+        openrouter_key_disabled=disabled,
+        payment_failed_at=None,
+        payment_grace_days=0,
+    )
+
+
+def _stub_client(
+    *,
+    return_values: list[BillingState] | None = None,
+    side_effects: list[BaseException | BillingState] | None = None,
+) -> MagicMock:
+    """Stub CpClient where each call returns / raises the next item in turn."""
+    client = MagicMock(spec=CpClient)
+    if side_effects is not None:
+        client.fetch_billing_state = AsyncMock(side_effect=side_effects)
+    else:
+        assert return_values is not None
+        client.fetch_billing_state = AsyncMock(side_effect=return_values)
+    return client
+
+
+def _stepping_clock(start: datetime, step: timedelta) -> Callable[[], datetime]:
+    """Returns a clock that advances by `step` on each call.
+
+    Used to drive TTL boundaries deterministically without sleeps.
+    """
+    iterator: Iterator[datetime] = iter(
+        start + step * i for i in range(10_000)
+    )
+    return lambda: next(iterator)
+
+
+def _make_cache(
+    client: MagicMock,
+    *,
+    ttl: int = _TTL,
+    clock: Callable[[], datetime] | None = None,
+) -> BillingStateCache:
+    return BillingStateCache(
+        client=client,
+        ttl_seconds=ttl,
+        logger=logging.getLogger("test_state_cache"),
+        clock=clock if clock is not None else lambda: _T0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cold_start_success_caches_value() -> None:
+    expected = _state(disabled=True)
+    client = _stub_client(return_values=[expected])
+
+    result = await _make_cache(client).get()
+
+    assert result == expected
+    client.fetch_billing_state.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fresh_hit_makes_no_http_call() -> None:
+    client = _stub_client(return_values=[_state()])
+    cache = _make_cache(client)
+    await cache.get()
+
+    await cache.get()
+    await cache.get()
+
+    assert client.fetch_billing_state.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_entry_triggers_one_fetch() -> None:
+    first, second = _state(disabled=False), _state(disabled=True)
+    client = _stub_client(return_values=[first, second])
+    # Each clock tick advances by TTL+1, so the freshness check inside the
+    # second get() observes age > TTL and triggers a fetch.
+    cache = _make_cache(client, clock=_stepping_clock(_T0, timedelta(seconds=_TTL + 1)))
+
+    assert await cache.get() == first
+    assert await cache.get() == second
+    assert client.fetch_billing_state.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_coalesce_to_one_fetch() -> None:
+    fetch_count = 0
+    expected = _state(disabled=True)
+
+    async def slow_fetch() -> BillingState:
+        nonlocal fetch_count
+        fetch_count += 1
+        # Yield so the lock holder sleeps and the other 99 callers all queue
+        # behind the lock — without the await the holder would finish before
+        # any contention materialized.
+        await asyncio.sleep(0)
+        return expected
+
+    client = MagicMock(spec=CpClient)
+    client.fetch_billing_state = AsyncMock(side_effect=slow_fetch)
+    cache = _make_cache(client)
+
+    results = await asyncio.gather(*(cache.get() for _ in range(100)))
+
+    assert all(r == expected for r in results)
+    assert fetch_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cold_start_with_cp_failure_returns_healthy_default(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _stub_client(side_effects=[CpUnreachable("down")])
+
+    with caplog.at_level(logging.WARNING, logger="test_state_cache"):
+        result = await _make_cache(client).get()
+
+    assert result == HEALTHY_DEFAULT
+    assert any(
+        "cold start" in record.getMessage() for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_with_cp_failure_serves_stale_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    seeded = _state(disabled=True)
+    client = _stub_client(side_effects=[seeded, CpUnreachable("down")])
+    cache = _make_cache(client, clock=_stepping_clock(_T0, timedelta(seconds=_TTL + 1)))
+
+    await cache.get()  # cold-start success populates the cache.
+
+    with caplog.at_level(logging.WARNING, logger="test_state_cache"):
+        # Second call lands past TTL with CP failing.
+        result = await cache.get()
+
+    assert result == seeded
+    assert any("stale" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_last_success_at_not_advanced_on_failure() -> None:
+    """Failures must leave `_last_success_at` alone so the next retry happens
+    on the next TTL boundary, not deferred a full extra cycle.
+
+    Sequence: cold success at T0 → CP failure at T0+31 → CP success at T0+62.
+    The third call must trigger a fetch (TTL elapsed since the LAST success).
+    Without this invariant, the failure would have moved the retry baseline
+    forward and the third call would still see "fresh" cache.
+    """
+    s1, s2 = _state(disabled=False), _state(disabled=True)
+    client = _stub_client(side_effects=[s1, CpUnreachable("blip"), s2])
+    cache = _make_cache(client, clock=_stepping_clock(_T0, timedelta(seconds=_TTL + 1)))
+
+    assert await cache.get() == s1  # success @ T0
+    assert await cache.get() == s1  # failure @ T0+31, serves stale
+    assert await cache.get() == s2  # success @ T0+62, cache replaced
+
+    assert client.fetch_billing_state.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_recovery_after_failure_replaces_stale_value() -> None:
+    s1, s2 = _state(disabled=True), _state(disabled=False)
+    client = _stub_client(side_effects=[s1, CpUnreachable("blip"), s2])
+    cache = _make_cache(client, clock=_stepping_clock(_T0, timedelta(seconds=_TTL + 1)))
+
+    await cache.get()
+    await cache.get()
+    recovered = await cache.get()
+
+    assert recovered == s2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ttl", [10, 120])
+async def test_configured_ttl_governs_freshness_window(ttl: int) -> None:
+    s1, s2 = _state(disabled=False), _state(disabled=True)
+    client = _stub_client(return_values=[s1, s2])
+    # Step > ttl so the freshness check inside the second get() expires.
+    step = timedelta(seconds=ttl + 1)
+    cache = _make_cache(client, ttl=ttl, clock=_stepping_clock(_T0, step))
+
+    assert await cache.get() == s1
+    assert await cache.get() == s2
+    assert client.fetch_billing_state.await_count == 2

--- a/backend/src/tests/unit/billing/test_billing_state_cache.py
+++ b/backend/src/tests/unit/billing/test_billing_state_cache.py
@@ -17,14 +17,17 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from shu.billing.billing_state_cache import BillingStateCache
 from shu.billing.cp_client import (
     HEALTHY_DEFAULT,
     BillingState,
+    CpAuthFailed,
     CpClient,
     CpUnreachable,
 )
-from shu.billing.billing_state_cache import BillingStateCache
 
+# Module logger name used by BillingStateCache — caplog filters target this.
+_CACHE_LOGGER = "shu.billing.billing_state_cache"
 
 _T0 = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
 _TTL = 60
@@ -64,6 +67,24 @@ def _stepping_clock(start: datetime, step: timedelta) -> Callable[[], datetime]:
     return lambda: next(iterator)
 
 
+class _ManualClock:
+    """Clock controlled explicitly by the test, decoupled from call count.
+
+    Use this when the test needs to reason about TTL/backoff boundaries —
+    `_stepping_clock` advances on every call and breaks when production
+    code adds or removes a clock read.
+    """
+
+    def __init__(self, start: datetime) -> None:
+        self._now = start
+
+    def __call__(self) -> datetime:
+        return self._now
+
+    def advance(self, delta: timedelta) -> None:
+        self._now += delta
+
+
 def _make_cache(
     client: MagicMock,
     *,
@@ -73,7 +94,6 @@ def _make_cache(
     return BillingStateCache(
         client=client,
         ttl_seconds=ttl,
-        logger=logging.getLogger("test_state_cache"),
         clock=clock if clock is not None else lambda: _T0,
     )
 
@@ -144,7 +164,7 @@ async def test_cold_start_with_cp_failure_returns_healthy_default(
 ) -> None:
     client = _stub_client(side_effects=[CpUnreachable("down")])
 
-    with caplog.at_level(logging.WARNING, logger="test_state_cache"):
+    with caplog.at_level(logging.WARNING, logger=_CACHE_LOGGER):
         result = await _make_cache(client).get()
 
     assert result == HEALTHY_DEFAULT
@@ -163,7 +183,7 @@ async def test_warm_cache_with_cp_failure_serves_stale_value(
 
     await cache.get()  # cold-start success populates the cache.
 
-    with caplog.at_level(logging.WARNING, logger="test_state_cache"):
+    with caplog.at_level(logging.WARNING, logger=_CACHE_LOGGER):
         # Second call lands past TTL with CP failing.
         result = await cache.get()
 
@@ -216,4 +236,82 @@ async def test_configured_ttl_governs_freshness_window(ttl: int) -> None:
 
     assert await cache.get() == s1
     assert await cache.get() == s2
+    assert client.fetch_billing_state.await_count == 2
+
+
+# Failure backoff: after a failed fetch attempt, the cache must NOT retry CP
+# until one full TTL has elapsed since the failure. The naive implementation
+# (without _next_retry_after) re-fetches on every call past the success-TTL,
+# turning a CP outage into one serialized 5s timeout per consumer call.
+
+
+@pytest.mark.asyncio
+async def test_cold_start_failure_suppresses_retries_within_backoff_window() -> None:
+    client = _stub_client(side_effects=[CpUnreachable("down"), CpUnreachable("down")])
+    clock = _ManualClock(_T0)
+    cache = _make_cache(client, clock=clock)
+
+    assert await cache.get() == HEALTHY_DEFAULT  # @ T0: first attempt fails
+
+    clock.advance(timedelta(seconds=_TTL // 2))  # well within backoff
+    assert await cache.get() == HEALTHY_DEFAULT  # served without fetch
+
+    assert client.fetch_billing_state.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_failure_suppresses_retries_within_backoff_window() -> None:
+    seeded = _state(disabled=True)
+    client = _stub_client(
+        side_effects=[seeded, CpUnreachable("down"), CpUnreachable("still down")]
+    )
+    clock = _ManualClock(_T0)
+    cache = _make_cache(client, clock=clock)
+
+    assert await cache.get() == seeded  # cold-start success @ T0
+
+    clock.advance(timedelta(seconds=_TTL + 1))  # past success-TTL
+    assert await cache.get() == seeded  # one fetch, fails, serves stale
+
+    clock.advance(timedelta(seconds=_TTL // 2))  # within failure backoff
+    assert await cache.get() == seeded  # served stale, no fetch
+
+    assert client.fetch_billing_state.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_failure_backoff_expires_one_ttl_after_the_failed_attempt() -> None:
+    s1, s2 = _state(disabled=True), _state(disabled=False)
+    client = _stub_client(side_effects=[s1, CpUnreachable("blip"), s2])
+    clock = _ManualClock(_T0)
+    cache = _make_cache(client, clock=clock)
+
+    assert await cache.get() == s1  # success @ T0
+
+    clock.advance(timedelta(seconds=_TTL + 1))  # past success-TTL
+    assert await cache.get() == s1  # fetch fails, serves stale, arms backoff
+
+    clock.advance(timedelta(seconds=_TTL + 1))  # past backoff window
+    assert await cache.get() == s2  # CP recovered, cache replaced
+
+    assert client.fetch_billing_state.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_cp_auth_failed_is_treated_identically_to_unreachable() -> None:
+    """Spec task 10(i): CpAuthFailed must trigger stale-while-error fail-open
+    just like CpUnreachable — CP returning 401 (operator misconfig) must not
+    lock customers out.
+    """
+    seeded = _state(disabled=False)
+    client = _stub_client(side_effects=[seeded, CpAuthFailed("bad sig")])
+    clock = _ManualClock(_T0)
+    cache = _make_cache(client, clock=clock)
+
+    assert await cache.get() == seeded
+    clock.advance(timedelta(seconds=_TTL + 1))
+    assert await cache.get() == seeded  # served stale, not raised
+
+    clock.advance(timedelta(seconds=_TTL // 2))
+    assert await cache.get() == seeded  # within backoff, no fetch
     assert client.fetch_billing_state.await_count == 2

--- a/backend/src/tests/unit/billing/test_config.py
+++ b/backend/src/tests/unit/billing/test_config.py
@@ -1,0 +1,92 @@
+"""Tests for shu.billing.config — validators and validate_configuration logic.
+
+Coverage focus: the rules we actually wrote (TTL minimum, the CP-base-URL
+co-requirement). Pydantic's own type coercion and env-var loading are not
+re-tested here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from shu.billing.config import BillingSettings
+
+
+def test_billing_state_cache_ttl_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Robust to whatever the developer happens to have in their .env / env.
+    monkeypatch.delenv("SHU_BILLING_STATE_CACHE_TTL_SECONDS", raising=False)
+
+    settings = BillingSettings(_env_file=None)  # type: ignore[call-arg]
+    assert settings.billing_state_cache_ttl_seconds == 500
+
+
+def test_billing_state_cache_ttl_validator_rejects_below_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # SHU_BILLING_STATE_CACHE_TTL_SECONDS in env would override the kwarg
+    # (pydantic-settings env priority), so clear it.
+    monkeypatch.setenv("SHU_BILLING_STATE_CACHE_TTL_SECONDS", "5")
+
+    with pytest.raises(ValidationError) as exc_info:
+        BillingSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert "must be >= 10" in str(exc_info.value)
+
+
+def test_billing_state_cache_ttl_validator_accepts_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SHU_BILLING_STATE_CACHE_TTL_SECONDS", "10")
+
+    settings = BillingSettings(_env_file=None)  # type: ignore[call-arg]
+    assert settings.billing_state_cache_ttl_seconds == 10
+
+
+def test_cp_base_url_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Robust to whatever the developer happens to have in .env / env.
+    monkeypatch.delenv("SHU_CP_BASE_URL", raising=False)
+
+    settings = BillingSettings(_env_file=None)  # type: ignore[call-arg]
+    assert settings.cp_base_url is None
+
+
+def test_validate_configuration_flags_missing_cp_base_url_when_secret_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SHU_CP_BASE_URL", raising=False)
+
+    settings = BillingSettings(
+        _env_file=None,  # type: ignore[call-arg]
+        secret_key="sk_test_x",
+        customer_id="cus_x",
+        subscription_id="sub_x",
+        price_id_monthly="price_x",
+        router_shared_secret="r" * 64,
+    )
+
+    assert (
+        "SHU_CP_BASE_URL is required when SHU_ROUTER_SHARED_SECRET is set"
+        in settings.validate_configuration()
+    )
+
+
+def test_validate_configuration_does_not_flag_missing_cp_base_url_without_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Self-hosted / dev — neither router_shared_secret nor cp_base_url set
+    # is valid. _env_file=None bypasses .env loading on top of the env-var
+    # cleanup so the test is robust to whatever .env happens to be on disk.
+    monkeypatch.delenv("SHU_ROUTER_SHARED_SECRET", raising=False)
+    monkeypatch.delenv("SHU_CP_BASE_URL", raising=False)
+
+    settings = BillingSettings(
+        _env_file=None,  # type: ignore[call-arg]
+        secret_key="sk_test_x",
+        customer_id="cus_x",
+        subscription_id="sub_x",
+        price_id_monthly="price_x",
+    )
+
+    issues = settings.validate_configuration()
+    assert all("SHU_CP_BASE_URL" not in issue for issue in issues)

--- a/backend/src/tests/unit/billing/test_cp_client.py
+++ b/backend/src/tests/unit/billing/test_cp_client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
 import logging
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -24,6 +25,7 @@ from shu.billing.cp_client import (
     BillingState,
     CpAuthFailed,
     CpClient,
+    CpMalformedResponse,
     CpUnexpectedStatus,
     CpUnreachable,
 )
@@ -193,4 +195,112 @@ async def test_connect_error_raises_cp_unreachable() -> None:
     http_client = _http_client_raising(httpx.ConnectError("refused"))
 
     with pytest.raises(CpUnreachable):
+        await _make_client(http_client).fetch_billing_state()
+
+
+# Malformed-200 paths: a buggy or version-skewed CP can return 200 with a
+# body that doesn't match the contract. The cache only catches CpClientError,
+# so without the wrap these would escape to consumers and break fail-open.
+
+
+def _malformed_json_response() -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json = MagicMock(side_effect=json.JSONDecodeError("nope", "doc", 0))
+    return response
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_raises_cp_malformed_response() -> None:
+    http_client = _http_client_returning(_malformed_json_response())
+
+    with pytest.raises(CpMalformedResponse):
+        await _make_client(http_client).fetch_billing_state()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Missing payment_failed_at
+        {"openrouter_key_disabled": False, "payment_grace_days": 0},
+        # Missing openrouter_key_disabled
+        {"payment_failed_at": None, "payment_grace_days": 0},
+        # Missing payment_grace_days
+        {"openrouter_key_disabled": False, "payment_failed_at": None},
+    ],
+    ids=["missing-failed-at", "missing-disabled", "missing-grace-days"],
+)
+async def test_missing_field_raises_cp_malformed_response(payload: dict) -> None:
+    http_client = _http_client_returning(_ok_response(payload))
+
+    with pytest.raises(CpMalformedResponse):
+        await _make_client(http_client).fetch_billing_state()
+
+
+@pytest.mark.asyncio
+async def test_bad_iso_datetime_raises_cp_malformed_response() -> None:
+    http_client = _http_client_returning(
+        _ok_response(
+            {
+                "openrouter_key_disabled": False,
+                "payment_failed_at": "not-a-date",
+                "payment_grace_days": 0,
+            }
+        )
+    )
+
+    with pytest.raises(CpMalformedResponse):
+        await _make_client(http_client).fetch_billing_state()
+
+
+@pytest.mark.asyncio
+async def test_list_payload_raises_cp_malformed_response() -> None:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json = MagicMock(return_value=["not", "a", "dict"])
+    http_client = _http_client_returning(response)
+
+    with pytest.raises(CpMalformedResponse):
+        await _make_client(http_client).fetch_billing_state()
+
+
+# Type-drift coverage: the schema is StrictBool / NonNegativeInt /
+# AwareDatetime so a CP version-skew that sends string-encoded booleans /
+# ints, naive datetimes, or negative grace_days surfaces as
+# CpMalformedResponse rather than silently corrupting downstream
+# enforcement (e.g. truthy "false" string locking healthy users out, or
+# naive timestamps crashing tz-aware arithmetic).
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # String for bool → would be truthy if not validated
+        {"openrouter_key_disabled": "false", "payment_failed_at": None, "payment_grace_days": 0},
+        # Int for bool — pydantic StrictBool rejects 0/1 too
+        {"openrouter_key_disabled": 0, "payment_failed_at": None, "payment_grace_days": 0},
+        # String for int → would break int comparison/arithmetic
+        {"openrouter_key_disabled": False, "payment_failed_at": None, "payment_grace_days": "7"},
+        # Negative grace_days → contract violation
+        {"openrouter_key_disabled": False, "payment_failed_at": None, "payment_grace_days": -1},
+        # Naive datetime → would crash tz-aware downstream arithmetic
+        {"openrouter_key_disabled": False, "payment_failed_at": "2026-04-30T12:34:56", "payment_grace_days": 0},
+        # Non-string for the datetime field
+        {"openrouter_key_disabled": False, "payment_failed_at": 1714478096, "payment_grace_days": 0},
+    ],
+    ids=[
+        "string-for-bool",
+        "int-for-bool",
+        "string-for-int",
+        "negative-grace-days",
+        "naive-datetime",
+        "int-for-datetime",
+    ],
+)
+async def test_type_drift_raises_cp_malformed_response(payload: dict) -> None:
+    http_client = _http_client_returning(_ok_response(payload))
+
+    with pytest.raises(CpMalformedResponse):
         await _make_client(http_client).fetch_billing_state()

--- a/backend/src/tests/unit/billing/test_cp_client.py
+++ b/backend/src/tests/unit/billing/test_cp_client.py
@@ -1,0 +1,196 @@
+"""Tests for shu.billing.cp_client — HMAC-signed CP poller.
+
+Coverage focus: response classification (200 / 401 / 5xx / network), wire-
+format correctness of the signed GET, and the first-401-ERROR / subsequent-
+WARNING log policy. Signature byte-correctness is asserted against an
+independently computed HMAC so a regression in `sign_envelope` or the
+canonical-string layout would break this test, not just the round-trip
+unit test in test_router_envelope.py.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import httpx
+import pytest
+
+from shu.billing.cp_client import (
+    BillingState,
+    CpAuthFailed,
+    CpClient,
+    CpUnexpectedStatus,
+    CpUnreachable,
+)
+
+BASE_URL = "https://cp.example.test"
+TENANT_ID = UUID("00000000-0000-0000-0000-000000000001")
+SHARED_SECRET = "a" * 64
+EXPECTED_PATH = f"/api/v1/tenants/{TENANT_ID}/billing-state"
+
+
+def _expected_signature(secret: str, timestamp: int) -> str:
+    canonical = f"{timestamp}.GET.{EXPECTED_PATH}.".encode()
+    digest = hmac.new(secret.encode(), canonical, hashlib.sha256).hexdigest()
+    return f"v1={digest}"
+
+
+def _http_client_returning(response: MagicMock) -> MagicMock:
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(return_value=response)
+    return client
+
+
+def _http_client_raising(exc: Exception) -> MagicMock:
+    client = MagicMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(side_effect=exc)
+    return client
+
+
+def _ok_response(payload: dict) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.json = MagicMock(return_value=payload)
+    return response
+
+
+def _error_response(status: int, body: str = "boom") -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status
+    response.text = body
+    response.json = MagicMock(return_value={"error": body})
+    return response
+
+
+def _make_client(http_client: MagicMock) -> CpClient:
+    return CpClient(
+        base_url=BASE_URL,
+        tenant_id=TENANT_ID,
+        shared_secret=SHARED_SECRET,
+        http_client=http_client,
+        logger=logging.getLogger("test_cp_client"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_signed_get_uses_byte_correct_hmac_and_target_url() -> None:
+    http_client = _http_client_returning(
+        _ok_response(
+            {
+                "openrouter_key_disabled": False,
+                "payment_failed_at": None,
+                "payment_grace_days": 0,
+            }
+        )
+    )
+
+    await _make_client(http_client).fetch_billing_state()
+
+    http_client.get.assert_awaited_once()
+    call = http_client.get.await_args
+    assert call.args[0] == f"{BASE_URL}{EXPECTED_PATH}"
+    headers = call.kwargs["headers"]
+    timestamp = int(headers["X-Shu-Router-Timestamp"])
+    assert headers["X-Shu-Router-Signature"] == _expected_signature(
+        SHARED_SECRET, timestamp
+    )
+
+
+@pytest.mark.asyncio
+async def test_200_with_null_payment_failed_at_returns_billing_state() -> None:
+    http_client = _http_client_returning(
+        _ok_response(
+            {
+                "openrouter_key_disabled": True,
+                "payment_failed_at": None,
+                "payment_grace_days": 7,
+            }
+        )
+    )
+
+    state = await _make_client(http_client).fetch_billing_state()
+
+    assert state == BillingState(
+        openrouter_key_disabled=True,
+        payment_failed_at=None,
+        payment_grace_days=7,
+    )
+
+
+@pytest.mark.asyncio
+async def test_200_parses_iso8601_payment_failed_at_to_tz_aware_datetime() -> None:
+    http_client = _http_client_returning(
+        _ok_response(
+            {
+                "openrouter_key_disabled": True,
+                "payment_failed_at": "2026-04-30T12:34:56Z",
+                "payment_grace_days": 5,
+            }
+        )
+    )
+
+    state = await _make_client(http_client).fetch_billing_state()
+
+    assert state.payment_failed_at == datetime(
+        2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_401_raises_cp_auth_failed_and_logs_error_on_first_call(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    http_client = _http_client_returning(_error_response(401, "signature_invalid"))
+    client = _make_client(http_client)
+
+    with caplog.at_level(logging.ERROR, logger="test_cp_client"):
+        with pytest.raises(CpAuthFailed):
+            await client.fetch_billing_state()
+
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(error_records) == 1
+    msg = error_records[0].getMessage()
+    assert "SHU_TENANT_ID" in msg and "SHU_ROUTER_SHARED_SECRET" in msg
+
+
+@pytest.mark.asyncio
+async def test_401_logs_warning_on_subsequent_calls_per_instance(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    http_client = _http_client_returning(_error_response(401))
+    client = _make_client(http_client)
+
+    with caplog.at_level(logging.DEBUG, logger="test_cp_client"):
+        with pytest.raises(CpAuthFailed):
+            await client.fetch_billing_state()
+        with pytest.raises(CpAuthFailed):
+            await client.fetch_billing_state()
+
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(error_records) == 1, "first 401 should log ERROR exactly once"
+    assert len(warning_records) == 1, "second 401 should log WARNING"
+
+
+@pytest.mark.asyncio
+async def test_500_raises_cp_unexpected_status_with_status_and_body() -> None:
+    http_client = _http_client_returning(_error_response(500, "internal boom"))
+
+    with pytest.raises(CpUnexpectedStatus) as exc_info:
+        await _make_client(http_client).fetch_billing_state()
+
+    assert exc_info.value.status == 500
+    assert exc_info.value.body == "internal boom"
+
+
+@pytest.mark.asyncio
+async def test_connect_error_raises_cp_unreachable() -> None:
+    http_client = _http_client_raising(httpx.ConnectError("refused"))
+
+    with pytest.raises(CpUnreachable):
+        await _make_client(http_client).fetch_billing_state()

--- a/backend/src/tests/unit/billing/test_router_envelope.py
+++ b/backend/src/tests/unit/billing/test_router_envelope.py
@@ -20,6 +20,7 @@ import pytest
 from shu.billing.router_envelope import (
     DEFAULT_SKEW_SECONDS,
     RouterSignatureError,
+    sign_envelope,
     verify_envelope,
 )
 
@@ -180,3 +181,59 @@ class TestVerifyEnvelope:
             body=body,
             now=ts,
         )
+
+
+class TestSignEnvelope:
+    secret = "a" * 64
+
+    def test_sign_then_verify_round_trips(self):
+        ts, sig = sign_envelope(self.secret, "GET", "/api/v1/foo", b"")
+
+        verify_envelope(
+            shared_secret=self.secret,
+            signature_header=sig,
+            timestamp_header=str(ts),
+            method="GET",
+            path="/api/v1/foo",
+            body=b"",
+            now=ts,
+        )
+
+    def test_explicit_timestamp_is_honored(self):
+        ts, sig = sign_envelope(
+            self.secret, "POST", "/x", b"body", timestamp=1_700_000_000
+        )
+
+        assert ts == 1_700_000_000
+        # Body is non-empty here so a timestamp regression would also break
+        # the canonical-string verification path.
+        verify_envelope(
+            shared_secret=self.secret,
+            signature_header=sig,
+            timestamp_header=str(ts),
+            method="POST",
+            path="/x",
+            body=b"body",
+            now=ts,
+        )
+
+    def test_default_timestamp_within_clock_skew(self):
+        before = int(time.time())
+        ts, _sig = sign_envelope(self.secret, "GET", "/x", b"")
+        after = int(time.time())
+
+        assert before <= ts <= after
+
+    def test_signature_matches_independent_hmac_byte_for_byte(self):
+        """Lock the wire format. A drift in canonical-string layout would
+        break interop with CP's signing.sign — the comment block at the top
+        of router_envelope.py promises byte-identical output, so test it."""
+        ts = 1_700_000_000
+        body = b'{"foo":"bar"}'
+        method = "GET"
+        path = "/api/v1/tenants/abc/billing-state"
+
+        _, sig = sign_envelope(self.secret, method, path, body, timestamp=ts)
+
+        expected = _sign_for(self.secret, ts, method, path, body)
+        assert sig == expected


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This comes with a CP piece: [https://github.com/Open-Shu/shu-control-plane.  That one is not up yet, because it depends on the one that is in-flight](https://github.com/Open-Shu/shu-control-plane/pull/3). That PR depends on a previous one though, which needs to be merged first.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Changes Made
<!-- List the main changes made in this PR -->
-
-
-

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests passing locally

## Code Quality Checklist
<!-- All items must be checked before merging -->

### Backend (Python)

- [ ] Type hints added to all new functions/classes
- [ ] Docstrings added to all public functions/classes
- [ ] Unit tests written for new code
- [ ] ConfigurationManager used (no hardcoded values)
- [ ] Dependency injection used (no direct instantiation)
- [ ] Timezone-aware datetimes used
- [ ] No breaking migration changes
- [ ] Files end with trailing newlines

### Frontend (React/JavaScript)

- [ ] Functional components with hooks used
- [ ] log.js used instead of console.*
- [ ] React Query used for server state
- [ ] Envelope utilities used (extractDataFromResponse)
- [ ] Material-UI components used
- [ ] Components < 500 LOC
- [ ] Custom hooks for complex logic

### API

- [ ] ShuResponse helper used
- [ ] Envelope format followed
- [ ] Proper HTTP status codes
- [ ] Pydantic schemas defined in schemas/

### Linting

- [ ] Pre-commit hooks pass
- [ ] CI linting checks pass
- [ ] No linting warnings ignored without justification

### Documentation

- [ ] Code comments added where needed
- [ ] README updated (if applicable)
- [ ] API docs updated (if applicable)
- [ ] Migration guide provided (if breaking change)

### Security

- [ ] No hardcoded secrets or credentials
- [ ] No sensitive data in logs
- [ ] Input validation added
- [ ] Authentication/authorization checked

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Deployment Notes
<!-- Any special deployment considerations? -->
- [ ] Database migrations required
- [ ] Environment variables added/changed
- [ ] Dependencies added/updated
- [ ] Configuration changes needed

## Reviewer Notes
<!-- Anything specific you want reviewers to focus on? -->

## Post-Merge Tasks
<!-- Tasks to complete after merging -->
- [ ] Update documentation
- [ ] Notify stakeholders
- [ ] Monitor logs/metrics
- [ ] Update related issues

---

**By submitting this PR, I confirm that:**

- [ ] I have run `make lint-fix` and all linting checks pass
- [ ] I have tested my changes locally
- [ ] I have followed the coding standards in `docs/policies/DEVELOPMENT_STANDARDS.md`
- [ ] I have read and followed the linting policy in `docs/policies/LINTING_POLICY.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control-plane integration for monitoring billing state with automatic periodic refresh and stale-while-error fallback, ensuring service resilience during control-plane unavailability.

* **Configuration**
  * Introduced new environment variables (`SHU_CP_BASE_URL`, `SHU_BILLING_STATE_CACHE_TTL_SECONDS`, `SHU_ROUTER_SHARED_SECRET`) to enable control-plane communication setup and customize cache refresh intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->