### PR TITLE
feat(billing): [SHU-701] surface billing config issues at startup

### DIFF
--- a/backend/src/shu/billing/config.py
+++ b/backend/src/shu/billing/config.py
@@ -6,11 +6,18 @@ integrate with the main Shu Settings class.
 
 from __future__ import annotations
 
+import re
 from functools import lru_cache
 from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from shu.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_FIELD_RE = re.compile(r"^(SHU_[A-Z0-9_]+)")
 
 
 class BillingSettings(BaseSettings):
@@ -138,3 +145,40 @@ def get_billing_settings_dependency() -> BillingSettings:
     Unlike the cached version, this can be overridden in tests.
     """
     return get_billing_settings()
+
+
+def log_billing_validation(settings: BillingSettings) -> list[str]:
+    """Run startup billing-config validation and emit log lines.
+
+    Behaviour matches SHU-701:
+
+    - Not configured → single INFO line ("self-hosted mode"); no warnings.
+    - Configured + no issues → single INFO success line.
+    - Configured + issues → one WARNING per issue, with structured ``extra``
+      so log parsers can aggregate by field name.
+
+    Never raises. If ``validate_configuration`` itself raises, log a single
+    ERROR and return an empty list — startup must continue regardless.
+    """
+    if not settings.is_configured:
+        logger.info("Billing module not configured — self-hosted mode")
+        return []
+
+    try:
+        issues = settings.validate_configuration()
+    except Exception as e:
+        logger.error("Billing configuration validation failed to run", exc_info=e)
+        return []
+
+    if not issues:
+        logger.info("Billing configuration validated successfully")
+        return []
+
+    for issue in issues:
+        match = _FIELD_RE.match(issue)
+        extra: dict[str, str] = {"issue": issue}
+        if match:
+            extra["field"] = match.group(1)
+        logger.warning("Billing configuration issue", extra=extra)
+
+    return issues

--- a/backend/src/shu/billing/router.py
+++ b/backend/src/shu/billing/router.py
@@ -346,16 +346,23 @@ async def handle_webhook(
 )
 async def get_billing_config_endpoint(
     settings: Annotated[BillingSettings, Depends(get_billing_settings_dependency)],
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> JSONResponse:
     """Get public billing configuration.
 
     Returns configuration that's safe to expose to the frontend,
-    such as the Stripe publishable key.
+    such as the Stripe publishable key. Admins additionally get a live
+    ``validation_issues`` list — same shape as the startup log lines —
+    so they can re-inspect after env-var changes without scraping logs.
     """
-    return ShuResponse.success(
-        {
-            "configured": settings.is_configured,
-            "publishable_key": settings.publishable_key,
-            "mode": settings.mode,
-        }
-    )
+    payload: dict[str, object] = {
+        "configured": settings.is_configured,
+        "publishable_key": settings.publishable_key,
+        "mode": settings.mode,
+    }
+    if current_user.can_manage_users():
+        try:
+            payload["validation_issues"] = settings.validate_configuration() if settings.is_configured else []
+        except Exception:
+            payload["validation_issues"] = []
+    return ShuResponse.success(payload)

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -258,12 +258,23 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
     except Exception as e:
         logger.warning(f"Model pricing sync failed: {e}")
 
+    # Surface billing-config issues (or self-hosted state) at boot — silent
+    # misconfig used to take until first request to manifest. This runs in its
+    # own try/except so a downstream DB-seed failure can't suppress the config
+    # diagnostics; validation is pure and DB-independent.
+    try:
+        from .billing.config import get_billing_settings, log_billing_validation
+
+        log_billing_validation(get_billing_settings())
+    except Exception as e:
+        logger.warning(f"billing config validation failed: {e}")
+
     # Ensure the billing_state singleton row exists, then seed from env vars.
     # These run in separate transaction scopes: ensure_singleton commits via
     # session.begin() context exit; seed_from_config → BillingStateService.update()
     # always commits its own transaction and must not run inside an outer begin().
     try:
-        from .billing.config import get_billing_settings, log_billing_validation
+        from .billing.config import get_billing_settings
         from .billing.state_service import BillingStateService
         from .core.database import get_async_session_local
 
@@ -273,9 +284,6 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
             async with session.begin():
                 await BillingStateService.ensure_singleton(session)
             await BillingStateService.seed_from_config(session, billing_settings)
-        # Surface configuration issues (or self-hosted state) at boot — silent
-        # misconfig used to take until first request to manifest.
-        log_billing_validation(billing_settings)
     except Exception as e:
         logger.warning(f"billing_state init failed: {e}")
 

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -263,7 +263,7 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
     # session.begin() context exit; seed_from_config → BillingStateService.update()
     # always commits its own transaction and must not run inside an outer begin().
     try:
-        from .billing.config import get_billing_settings
+        from .billing.config import get_billing_settings, log_billing_validation
         from .billing.state_service import BillingStateService
         from .core.database import get_async_session_local
 
@@ -273,6 +273,9 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
             async with session.begin():
                 await BillingStateService.ensure_singleton(session)
             await BillingStateService.seed_from_config(session, billing_settings)
+        # Surface configuration issues (or self-hosted state) at boot — silent
+        # misconfig used to take until first request to manifest.
+        log_billing_validation(billing_settings)
     except Exception as e:
         logger.warning(f"billing_state init failed: {e}")
 

--- a/backend/src/tests/unit/billing/test_config.py
+++ b/backend/src/tests/unit/billing/test_config.py
@@ -1,0 +1,192 @@
+"""Tests for billing config validation logging (SHU-701) and the
+``/billing/config`` admin-only ``validation_issues`` field."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from shu.billing.config import BillingSettings, log_billing_validation
+from shu.billing.router import get_billing_config_endpoint
+
+
+# Keep BillingSettings construction deterministic regardless of dev/CI env: clear
+# any SHU_STRIPE_*/SHU_ROUTER_* OS env vars and skip the .env file. Without this
+# a developer with a populated .env (or CI with billing secrets) would get
+# different values bleeding into the "not configured" tests.
+@pytest.fixture(autouse=True)
+def _isolate_billing_env(monkeypatch):
+    import os
+
+    for key in [k for k in os.environ if k.startswith(("SHU_STRIPE_", "SHU_ROUTER_"))]:
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+def _make_settings(**overrides) -> BillingSettings:
+    """Build a BillingSettings with .env disabled, then apply any overrides.
+
+    Use this everywhere instead of calling ``BillingSettings(...)`` directly —
+    raw construction would still read the repo's .env file.
+    """
+    return BillingSettings(_env_file=None, **overrides)  # type: ignore[call-arg]
+
+
+def _settings(**overrides) -> BillingSettings:
+    """Build a fully-configured BillingSettings; override fields as needed."""
+    base = {
+        "SHU_STRIPE_SECRET_KEY": "sk_test_abc",
+        "SHU_STRIPE_CUSTOMER_ID": "cus_test_123",
+        "SHU_STRIPE_SUBSCRIPTION_ID": "sub_test_123",
+        "SHU_ROUTER_SHARED_SECRET": "a" * 64,
+        "SHU_STRIPE_PRICE_ID_MONTHLY": "price_test_123",
+        "SHU_STRIPE_MODE": "test",
+    }
+    base.update(overrides)
+    return _make_settings(**base)
+
+
+def _user(*, admin: bool) -> MagicMock:
+    user = MagicMock()
+    user.can_manage_users.return_value = admin
+    return user
+
+
+# ---------------------------------------------------------------------------
+# log_billing_validation — helper invoked from main.py lifespan
+# ---------------------------------------------------------------------------
+
+
+class TestLogBillingValidation:
+    def test_fully_configured_no_issues_logs_success(self, caplog):
+        """(a) Fully configured + no issues → INFO success, no warnings."""
+        caplog.set_level(logging.INFO, logger="shu.billing.config")
+        issues = log_billing_validation(_settings())
+
+        assert issues == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+        infos = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("validated successfully" in r.getMessage() for r in infos)
+
+    def test_not_configured_logs_self_hosted_info(self, caplog):
+        """(b) Not configured → INFO "self-hosted mode", no warnings, no validation."""
+        caplog.set_level(logging.INFO, logger="shu.billing.config")
+        # Drop the required tenant identifiers — is_configured becomes False.
+        unconfigured = _make_settings(SHU_STRIPE_MODE="test")
+        assert unconfigured.is_configured is False
+
+        issues = log_billing_validation(unconfigured)
+
+        assert issues == []
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+        infos = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("not configured" in r.getMessage() for r in infos)
+
+    def test_partial_config_warns_with_field_name(self, caplog):
+        """(c) is_configured + missing price → WARNING naming the field."""
+        caplog.set_level(logging.WARNING, logger="shu.billing.config")
+        # is_configured needs secret_key + customer_id + subscription_id; drop
+        # price_id_monthly to surface a single targeted issue.
+        settings = _settings(SHU_STRIPE_PRICE_ID_MONTHLY="")
+        issues = log_billing_validation(settings)
+
+        assert any("PRICE_ID_MONTHLY" in i for i in issues)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert getattr(warnings[0], "field", None) == "SHU_STRIPE_PRICE_ID_MONTHLY"
+        assert "PRICE_ID_MONTHLY" in getattr(warnings[0], "issue", "")
+
+    def test_mode_key_mismatch_warns(self, caplog):
+        """(d) mode=live but secret_key starts with sk_test_ → WARNING."""
+        caplog.set_level(logging.WARNING, logger="shu.billing.config")
+        settings = _settings(SHU_STRIPE_MODE="live", SHU_STRIPE_SECRET_KEY="sk_test_abc")
+        issues = log_billing_validation(settings)
+
+        # Validate_configuration emits the message with SHU_STRIPE_MODE as the
+        # leading field; that's what the structured extra picks up.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        mode_warnings = [w for w in warnings if getattr(w, "field", None) == "SHU_STRIPE_MODE"]
+        assert mode_warnings, f"expected SHU_STRIPE_MODE warning, got {issues}"
+
+    def test_validate_raises_logs_error_no_crash(self, caplog):
+        """(e) validate_configuration raises → ERROR logged, helper returns []."""
+        caplog.set_level(logging.ERROR, logger="shu.billing.config")
+
+        # BillingSettings is a frozen-ish pydantic model — subclass instead of
+        # monkey-patching the instance.
+        class RaisingSettings(BillingSettings):
+            def validate_configuration(self) -> list[str]:
+                raise RuntimeError("boom")
+
+        settings = RaisingSettings(
+            _env_file=None,
+            SHU_STRIPE_SECRET_KEY="sk_test_abc",
+            SHU_STRIPE_CUSTOMER_ID="cus_test_123",
+            SHU_STRIPE_SUBSCRIPTION_ID="sub_test_123",
+        )
+        issues = log_billing_validation(settings)
+
+        assert issues == []
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("validation failed to run" in r.getMessage() for r in errors)
+
+
+# ---------------------------------------------------------------------------
+# /billing/config endpoint — admin-only validation_issues field
+# ---------------------------------------------------------------------------
+
+
+def _decode(response) -> dict:
+    return json.loads(response.body)["data"]
+
+
+class TestBillingConfigEndpoint:
+    @pytest.mark.asyncio
+    async def test_admin_sees_validation_issues_field(self):
+        settings = _settings(SHU_STRIPE_PRICE_ID_MONTHLY="")  # one issue
+        response = await get_billing_config_endpoint(settings=settings, current_user=_user(admin=True))
+
+        body = _decode(response)
+        assert "validation_issues" in body
+        assert any("PRICE_ID_MONTHLY" in i for i in body["validation_issues"])
+
+    @pytest.mark.asyncio
+    async def test_non_admin_does_not_see_validation_issues_field(self):
+        settings = _settings(SHU_STRIPE_PRICE_ID_MONTHLY="")
+        response = await get_billing_config_endpoint(settings=settings, current_user=_user(admin=False))
+
+        body = _decode(response)
+        assert "validation_issues" not in body
+
+    @pytest.mark.asyncio
+    async def test_admin_sees_empty_list_when_not_configured(self):
+        """is_configured=False → empty validation_issues, not a missing-field flood."""
+        settings = _make_settings(SHU_STRIPE_MODE="test")
+        response = await get_billing_config_endpoint(settings=settings, current_user=_user(admin=True))
+
+        body = _decode(response)
+        assert body["validation_issues"] == []
+
+    @pytest.mark.asyncio
+    async def test_admin_validate_raises_returns_empty_list_not_500(self):
+        """If validate_configuration raises, the endpoint returns [] rather than 500."""
+
+        class RaisingSettings(BillingSettings):
+            def validate_configuration(self) -> list[str]:
+                raise RuntimeError("boom")
+
+        settings = RaisingSettings(
+            _env_file=None,
+            SHU_STRIPE_SECRET_KEY="sk_test_abc",
+            SHU_STRIPE_CUSTOMER_ID="cus_test_123",
+            SHU_STRIPE_SUBSCRIPTION_ID="sub_test_123",
+        )
+        response = await get_billing_config_endpoint(settings=settings, current_user=_user(admin=True))
+
+        body = _decode(response)
+        assert body["validation_issues"] == []

--- a/backend/src/tests/unit/billing/test_config.py
+++ b/backend/src/tests/unit/billing/test_config.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
-from shu.billing.config import BillingSettings
 from shu.billing.config import BillingSettings, log_billing_validation
 from shu.billing.router import get_billing_config_endpoint
 
@@ -44,6 +43,7 @@ def _settings(**overrides) -> BillingSettings:
         "SHU_STRIPE_CUSTOMER_ID": "cus_test_123",
         "SHU_STRIPE_SUBSCRIPTION_ID": "sub_test_123",
         "SHU_ROUTER_SHARED_SECRET": "a" * 64,
+        "SHU_CP_BASE_URL": "https://cp.example.com",
         "SHU_STRIPE_PRICE_ID_MONTHLY": "price_test_123",
         "SHU_STRIPE_MODE": "test",
     }
@@ -193,12 +193,6 @@ class TestBillingConfigEndpoint:
         body = _decode(response)
         assert body["validation_issues"] == []
 
-"""Tests for shu.billing.config — validators and validate_configuration logic.
-
-Coverage focus: the rules we actually wrote (TTL minimum, the CP-base-URL
-co-requirement). Pydantic's own type coercion and env-var loading are not
-re-tested here.
-"""
 
 def test_billing_state_cache_ttl_default(monkeypatch: pytest.MonkeyPatch) -> None:
     # Robust to whatever the developer happens to have in their .env / env.


### PR DESCRIPTION
Misconfigured billing was silent until the first request hit a billing endpoint, where the symptom was usually an opaque 4xx/5xx. This wires BillingSettings.validate_configuration() into the FastAPI lifespan and expose a live validation_issues list on /billing/config for admins so operators can re-inspect after env-var changes without scraping logs.

Self-hosted (no billing) deployments stay clean: when is_configured is False, the lifespan logs a single INFO ("self-hosted mode") and the endpoint returns an empty list rather than a flood of missing-field warnings.

Changes:
- Add log_billing_validation() helper in billing/config.py — branches on is_configured, emits INFO/WARNING/ERROR per the AC's three shapes, with structured extra={"field": "SHU_*", "issue": ...} for log parsers
- Call the helper from main.py lifespan after billing_state seeding
- Extend GET /billing/config with admin-only validation_issues field (gated by current_user.can_manage_users())
- Tests cover all five helper paths (configured/not/partial/mismatch/ raise) plus four endpoint cases including the validate-raises branch
- Test fixture isolates SHU_STRIPE_*/SHU_ROUTER_* env vars and disables .env loading so tests are deterministic regardless of dev/CI env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Administrators can now view billing configuration validation issues through the billing config endpoint.

* **Bug Fixes**
  * Application startup is more resilient; billing validation failures no longer prevent the server from launching.

* **Tests**
  * Added coverage for billing configuration validation logging and endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->