### PR TITLE
refactor(db): [SHU-763] replace init_db create_all with fail-fast verify_schema_version

### DIFF
--- a/backend/src/shu/core/database.py
+++ b/backend/src/shu/core/database.py
@@ -159,42 +159,59 @@ async def get_db_session() -> AsyncSession:
     return session_local()
 
 
-async def init_db() -> None:
-    try:
-        # Ensure all models are imported so Base.metadata has all tables
-        from ..models.registry import register_all_models
+async def verify_schema_version() -> None:
+    """Raise DatabaseSessionError unless alembic_version matches the bundled head."""
+    from pathlib import Path
 
-        register_all_models()
-        engine = get_async_engine()
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
 
-        # Log database initialization
-        database_url = get_database_url()
-        parsed_url = database_url.replace("postgresql+asyncpg://", "postgresql://")
-        if "@" in parsed_url:
-            parts = parsed_url.split("@")
-            if len(parts) == 2:
-                host_part = parts[1]
-                if "/" in host_part:
-                    host_db = host_part.split("/")
-                    if len(host_db) == 2:
-                        host_port = host_db[0]
-                        database_name = host_db[1]
-                        logger.debug(f"Initializing database tables: Host={host_port}, Database={database_name}")
-                    else:
-                        logger.debug(f"Initializing database tables: Host={host_part}")
-                else:
-                    logger.debug(f"Initializing database tables: Host={host_part}")
-            else:
-                logger.debug("Initializing database tables")
-        else:
-            logger.debug("Initializing database tables")
+    from ..models.registry import register_all_models
 
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
-        logger.info("Database tables initialized successfully")
-    except Exception as e:
-        logger.error(f"Database initialization failed: {e!s}")
-        raise DatabaseSessionError(f"database initialization: {e!s}")
+    register_all_models()
+
+    candidates = [
+        Path("/app/alembic.ini"),
+        Path(__file__).resolve().parents[3] / "alembic.ini",
+    ]
+    alembic_ini = next((p for p in candidates if p.exists()), None)
+    if alembic_ini is None:
+        raise DatabaseSessionError(
+            "alembic.ini not found in any expected location; cannot verify schema version. "
+            f"Looked in: {[str(p) for p in candidates]}"
+        )
+
+    expected = ScriptDirectory.from_config(Config(str(alembic_ini))).get_current_head()
+    if expected is None:
+        raise DatabaseSessionError("alembic migrations directory has no head revision")
+
+    engine = get_async_engine()
+    async with engine.begin() as conn:
+        try:
+            result = await conn.execute(text("SELECT version_num FROM alembic_version"))
+            row = result.first()
+        except SQLAlchemyError as e:
+            raise DatabaseSessionError(
+                "alembic_version table missing — migrations have not run. "
+                "Run the shu-db-migrate Job (hosted) or `make migrate-local-lab` (dev) "
+                "before starting shu-api."
+            ) from e
+
+    if row is None or row[0] is None:
+        raise DatabaseSessionError(
+            "alembic_version row missing — migrations have not run. "
+            "Run the shu-db-migrate Job (hosted) or `make migrate-local-lab` (dev)."
+        )
+
+    current = row[0]
+    if current != expected:
+        raise DatabaseSessionError(
+            f"schema at revision {current!r}, code expects {expected!r}. "
+            "Run migrations (shu-db-migrate Job in hosted, `make migrate-local-lab` in dev) "
+            "before starting shu-api."
+        )
+
+    logger.info("Schema verified at alembic revision %s", current)
 
 
 async def close_db() -> None:

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -44,7 +44,7 @@ from .billing.billing_state_cache import initialize_billing_state_cache
 from .billing.router import router as billing_router
 from .core.cache_backend import initialize_cache_backend
 from .core.config import get_settings_instance
-from .core.database import init_db
+from .core.database import verify_schema_version
 from .core.exceptions import ShuException
 from .core.http_client import close_http_client
 from .core.logging import get_logger, setup_logging
@@ -183,10 +183,8 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
 
     configure_mupdf_store()
 
-    # Initialize database connection
     try:
-        await init_db()
-        logger.info("Database initialized successfully")
+        await verify_schema_version()
 
         # Log database configuration
         from .core.database import get_database_url
@@ -233,10 +231,9 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
         except Exception as e:
             logger.warning(f"Startup DB release check error: {e}")
 
-    except Exception as e:
-        # Do not crash the app if DB is unavailable; log and continue. Health/readiness will reflect DB status.
-        logger.error(f"Failed to initialize database: {e}", exc_info=True)
-        # continue without raising to allow the app to start
+    except Exception:
+        logger.error("Schema verification failed — refusing to start", exc_info=True)
+        raise
 
     # Initialize eagerly so backend connection errors surface at startup, not on first request.
     await initialize_cache_backend()

--- a/backend/src/shu/worker.py
+++ b/backend/src/shu/worker.py
@@ -41,7 +41,7 @@ from sqlalchemy import select
 
 from .auth.models import User
 from .core.config import get_settings_instance
-from .core.database import get_async_session_local, init_db
+from .core.database import get_async_session_local, verify_schema_version
 from .core.exceptions import ShuException
 from .core.logging import get_logger, setup_logging
 from .core.queue_backend import get_queue_backend
@@ -1364,12 +1364,10 @@ async def run_worker(  # noqa: PLR0915 — linear startup/shutdown sequence; spl
         concurrency: Number of concurrent worker tasks to run.
 
     """
-    # Initialize database connection
     try:
-        await init_db()
-        logger.info("Database initialized successfully")
+        await verify_schema_version()
     except Exception as e:
-        logger.error("Failed to initialize database: %s", e, exc_info=True)
+        logger.error("Schema verification failed: %s", e, exc_info=True)
         sys.exit(1)
 
     # Get queue backend (shared by all workers)

--- a/backend/src/tests/integ/integration_test_runner.py
+++ b/backend/src/tests/integ/integration_test_runner.py
@@ -129,7 +129,7 @@ class IntegrationTestRunner:
         logging.getLogger("src.shu.core.middleware").setLevel(logging.WARNING)
 
         try:
-            # Run FastAPI lifespan startup to ensure init_db() is executed
+            # Run FastAPI lifespan startup to wire DI, schema verification, etc.
             try:
                 self._lifespan_cm = self.app.router.lifespan_context(self.app)
                 await self._lifespan_cm.__aenter__()

--- a/backend/src/tests/unit/core/test_database.py
+++ b/backend/src/tests/unit/core/test_database.py
@@ -1,9 +1,13 @@
 """Unit tests for database engine construction."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import ProgrammingError
 
 from shu.core import database
+from shu.core.exceptions import DatabaseSessionError
 
 
 def _stub_settings(*, use_pgbouncer: bool) -> SimpleNamespace:
@@ -46,3 +50,93 @@ class TestGetAsyncEnginePgBouncer:
             database.get_async_engine()
 
         assert mock_engine.call_args.kwargs["connect_args"] == {}
+
+
+def _patch_engine_with_query_result(monkeypatch, *, query_result):
+    """Wire get_async_engine() to return a mock whose conn.execute resolves to query_result.
+
+    query_result may be:
+      - a tuple/list/None to be returned as the .first() row
+      - an Exception instance to be raised by conn.execute
+    """
+    conn = AsyncMock()
+    if isinstance(query_result, Exception):
+        conn.execute.side_effect = query_result
+    else:
+        result = MagicMock()
+        result.first.return_value = query_result
+        conn.execute.return_value = result
+
+    begin_ctx = AsyncMock()
+    begin_ctx.__aenter__.return_value = conn
+    begin_ctx.__aexit__.return_value = None
+
+    engine = MagicMock()
+    engine.begin.return_value = begin_ctx
+    monkeypatch.setattr(database, "get_async_engine", lambda: engine)
+    return conn
+
+
+class TestVerifySchemaVersion:
+    """SHU-763: shu-api refuses to start unless alembic_version matches expected head.
+
+    All cases stub the alembic ScriptDirectory + the model registry so we exercise
+    the verification path itself rather than alembic resolution or import side
+    effects.
+    """
+
+    def _patch_alembic_head(self, monkeypatch, head: str | None = "abc123") -> None:
+        from pathlib import Path
+
+        monkeypatch.setattr(
+            Path,
+            "exists",
+            lambda self: True,
+        )
+        script_dir = MagicMock()
+        script_dir.get_current_head.return_value = head
+        monkeypatch.setattr("alembic.script.ScriptDirectory.from_config", lambda _cfg: script_dir)
+        monkeypatch.setattr("alembic.config.Config", lambda _path: MagicMock())
+        monkeypatch.setattr("shu.models.registry.register_all_models", lambda: None)
+
+    @pytest.mark.asyncio
+    async def test_returns_cleanly_when_versions_match(self, monkeypatch) -> None:
+        self._patch_alembic_head(monkeypatch, head="abc123")
+        _patch_engine_with_query_result(monkeypatch, query_result=("abc123",))
+
+        await database.verify_schema_version()  # no exception = pass
+
+    @pytest.mark.asyncio
+    async def test_raises_on_version_mismatch(self, monkeypatch) -> None:
+        self._patch_alembic_head(monkeypatch, head="abc123")
+        _patch_engine_with_query_result(monkeypatch, query_result=("def456",))
+
+        with pytest.raises(DatabaseSessionError, match="schema at revision 'def456'"):
+            await database.verify_schema_version()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_alembic_version_table_missing(self, monkeypatch) -> None:
+        self._patch_alembic_head(monkeypatch, head="abc123")
+        _patch_engine_with_query_result(
+            monkeypatch,
+            query_result=ProgrammingError("SELECT", {}, Exception("relation does not exist")),
+        )
+
+        with pytest.raises(DatabaseSessionError, match="alembic_version table missing"):
+            await database.verify_schema_version()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_version_row_absent(self, monkeypatch) -> None:
+        self._patch_alembic_head(monkeypatch, head="abc123")
+        _patch_engine_with_query_result(monkeypatch, query_result=None)
+
+        with pytest.raises(DatabaseSessionError, match="alembic_version row missing"):
+            await database.verify_schema_version()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_version_value_is_null(self, monkeypatch) -> None:
+        self._patch_alembic_head(monkeypatch, head="abc123")
+        _patch_engine_with_query_result(monkeypatch, query_result=(None,))
+
+        with pytest.raises(DatabaseSessionError, match="alembic_version row missing"):
+            await database.verify_schema_version()

--- a/backend/src/tests/unit/core/test_worker_mode.py
+++ b/backend/src/tests/unit/core/test_worker_mode.py
@@ -297,14 +297,14 @@ async def test_workers_enabled_starts_with_api():
         # Mock the worker components and expensive lifespan operations
         with patch('shu.core.queue_backend.get_queue_backend') as mock_get_backend, \
              patch('shu.core.worker.Worker') as mock_worker_class, \
-             patch('shu.main.init_db') as mock_init_db, \
+             patch('shu.main.verify_schema_version') as mock_verify_schema, \
              patch('shu.services.scheduler_service.start_scheduler', new_callable=AsyncMock) as mock_scheduler, \
              patch('shu.main._initialize_policy_cache', new_callable=AsyncMock):
 
             # Setup mocks
             mock_backend = AsyncMock()
             mock_get_backend.return_value = mock_backend
-            mock_init_db.return_value = None
+            mock_verify_schema.return_value = None
             mock_scheduler_task = MagicMock()
             mock_scheduler_task.done.return_value = True
             mock_scheduler.return_value = mock_scheduler_task
@@ -359,14 +359,14 @@ async def test_workers_enabled_with_concurrency():
     with patch('shu.main.settings', mock_settings), \
          patch('shu.core.queue_backend.get_queue_backend') as mock_get_backend, \
          patch('shu.core.worker.Worker') as mock_worker_class, \
-         patch('shu.main.init_db') as mock_init_db, \
+         patch('shu.main.verify_schema_version') as mock_verify_schema, \
          patch('shu.services.scheduler_service.start_scheduler', new_callable=AsyncMock) as mock_scheduler, \
          patch('shu.main._initialize_policy_cache', new_callable=AsyncMock):
 
         # Setup mocks
         mock_backend = AsyncMock()
         mock_get_backend.return_value = mock_backend
-        mock_init_db.return_value = None
+        mock_verify_schema.return_value = None
         mock_scheduler_task = MagicMock()
         mock_scheduler_task.done.return_value = True
         mock_scheduler.return_value = mock_scheduler_task
@@ -428,10 +428,10 @@ async def test_worker_entrypoint_starts_without_api():
 
     # Mock database and backend initialization
     with (
-        patch("shu.worker.init_db") as mock_init_db,
+        patch("shu.worker.verify_schema_version") as mock_verify_schema,
         patch("shu.worker.get_queue_backend") as mock_get_backend,
     ):
-        mock_init_db.return_value = None
+        mock_verify_schema.return_value = None
         mock_backend = InMemoryQueueBackend()
         mock_get_backend.return_value = mock_backend
 
@@ -452,7 +452,7 @@ async def test_worker_entrypoint_starts_without_api():
             pass
 
         # Verify database was initialized
-        mock_init_db.assert_called_once()
+        mock_verify_schema.assert_called_once()
 
         # Verify backend was retrieved
         mock_get_backend.assert_called_once()
@@ -480,11 +480,11 @@ async def test_api_starts_cleanly_with_workers_enabled():
         # Mock worker components to avoid actual startup
         with patch('shu.core.queue_backend.get_queue_backend') as mock_get_backend, \
              patch('shu.core.worker.Worker') as mock_worker_class, \
-             patch('shu.main.init_db') as mock_init_db:
+             patch('shu.main.verify_schema_version') as mock_verify_schema:
 
             mock_backend = AsyncMock()
             mock_get_backend.return_value = mock_backend
-            mock_init_db.return_value = None
+            mock_verify_schema.return_value = None
 
 
             mock_worker = MagicMock()
@@ -515,9 +515,9 @@ async def test_api_starts_cleanly_with_workers_disabled():
     from shu.main import create_app
 
     with patch.dict(os.environ, {'SHU_WORKERS_ENABLED': 'false'}, clear=False):
-        # Mock init_db to avoid database connection
-        with patch("shu.main.init_db") as mock_init_db:
-            mock_init_db.return_value = None
+        # Mock schema verification to avoid database connection
+        with patch("shu.main.verify_schema_version") as mock_verify_schema:
+            mock_verify_schema.return_value = None
 
 
             # Create app


### PR DESCRIPTION
shu-api startup no longer creates schema. Migrations are the sole schema-mutating path; the app verifies and refuses to start on mismatch. This eliminates a sleeper bug where shu-api winning the cold-apply race against the migrate Job produced a partial schema (missing alembic-only DDL like CREATE EXTENSION and the BM25 search_vector column) with no alembic_version row, causing later alembic upgrade head runs to fail with DuplicateTable.

verify_schema_version() reads the bundled migrations/versions/ directory via alembic ScriptDirectory, queries SELECT version_num FROM alembic_version, and raises DatabaseSessionError on:
  - alembic_version table missing  (migrations have not run)
  - alembic_version row missing or NULL
  - revision mismatch              (named operator action in message)

Each error message names the operator action (run shu-db-migrate Job in hosted, make migrate-local-lab in dev). The lifespan/worker outer catch re-raises so the pod exits non-zero and CrashLoopBackOffs.

Five unit tests cover match, mismatch, table-missing, row-missing, and null-value cases. Existing test_worker_mode mocks renamed from init_db to verify_schema_version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented database schema version verification during application startup.

* **Bug Fixes**
  * Enhanced startup robustness by requiring explicit schema version validation. The application now fails fast with clear error messages if the database schema doesn't match expected migrations, preventing potential data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->