### PR TITLE
fix: [SHU-763] parse alembic head from migration files directly

### DIFF
--- a/backend/src/shu/core/database.py
+++ b/backend/src/shu/core/database.py
@@ -4,8 +4,8 @@ This module provides database connection management, session handling,
 and utilities for database operations.
 """
 
+import ast
 import os
-import re
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -160,18 +160,51 @@ async def get_db_session() -> AsyncSession:
     return session_local()
 
 
-_REVISION_RE = re.compile(r'^revision\s*[:=]\s*[\'"]([^\'"]+)[\'"]', re.MULTILINE)
-_DOWN_REVISION_RE = re.compile(r'^down_revision\s*[:=]\s*[\'"]([^\'"]+)[\'"]', re.MULTILINE)
+def _read_revision_identifiers(source: str) -> tuple[str | None, tuple[str, ...]]:
+    """Return (revision, parents) parsed from module-level assignments.
+
+    `revision` is a single string. `down_revision` is normalised to a tuple of
+    parent ids — empty for the base, single-element for a normal migration,
+    multi-element for an alembic merge migration.
+    """
+    tree = ast.parse(source)
+    revision: str | None = None
+    parents: tuple[str, ...] = ()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets: list[ast.expr] = list(node.targets)
+            value_expr: ast.expr = node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+            value_expr = node.value
+        else:
+            continue
+        names = {t.id for t in targets if isinstance(t, ast.Name)}
+        try:
+            value = ast.literal_eval(value_expr)
+        except (ValueError, SyntaxError):
+            continue
+        if "revision" in names and isinstance(value, str):
+            revision = value
+        if "down_revision" in names:
+            if value is None:
+                parents = ()
+            elif isinstance(value, str):
+                parents = (value,)
+            elif isinstance(value, (tuple, list)) and all(isinstance(v, str) for v in value):
+                parents = tuple(value)
+    return revision, parents
 
 
 def _resolve_alembic_head() -> str:
     """Find the head revision in the bundled migrations/versions/ tree.
 
-    Regex-parses each file's `revision` and `down_revision` strings rather
-    than importing the modules. Migration modules can have side-effecting
-    imports (e.g. `from migrations.seed_data...`) that only resolve under
-    alembic's runtime sys.path setup; importing them at app startup would
-    couple shu-api to alembic's CLI conventions.
+    Reads each file with `ast.parse` + `ast.literal_eval` rather than importing
+    it. Migration modules can have side-effecting imports (e.g.
+    `from migrations.seed_data...`) that only resolve under alembic's runtime
+    sys.path setup; importing them at app startup would couple shu-api to
+    alembic's CLI conventions. AST parsing also correctly handles merge
+    migrations where `down_revision` is a tuple of parents.
     """
     from pathlib import Path
 
@@ -183,21 +216,19 @@ def _resolve_alembic_head() -> str:
     if versions_dir is None:
         raise DatabaseSessionError(f"migrations/versions/ not found; looked in {[str(p) for p in candidates]}")
 
-    revisions: dict[str, str | None] = {}
+    revisions: dict[str, tuple[str, ...]] = {}
     for path in versions_dir.glob("*.py"):
         if path.name == "__init__.py":
             continue
-        text_ = path.read_text()
-        rev = _REVISION_RE.search(text_)
-        if rev is None:
+        revision, parents = _read_revision_identifiers(path.read_text(encoding="utf-8"))
+        if revision is None:
             continue
-        down = _DOWN_REVISION_RE.search(text_)
-        revisions[rev.group(1)] = down.group(1) if down else None
+        revisions[revision] = parents
 
     if not revisions:
         raise DatabaseSessionError(f"no migration files found under {versions_dir}")
 
-    pointed_to = {d for d in revisions.values() if d is not None}
+    pointed_to = {parent for parents in revisions.values() for parent in parents}
     heads = [r for r in revisions if r not in pointed_to]
     if len(heads) != 1:
         raise DatabaseSessionError(

--- a/backend/src/shu/core/database.py
+++ b/backend/src/shu/core/database.py
@@ -5,6 +5,7 @@ and utilities for database operations.
 """
 
 import os
+import re
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -159,31 +160,55 @@ async def get_db_session() -> AsyncSession:
     return session_local()
 
 
-async def verify_schema_version() -> None:
-    """Raise DatabaseSessionError unless alembic_version matches the bundled head."""
+_REVISION_RE = re.compile(r'^revision\s*[:=]\s*[\'"]([^\'"]+)[\'"]', re.MULTILINE)
+_DOWN_REVISION_RE = re.compile(r'^down_revision\s*[:=]\s*[\'"]([^\'"]+)[\'"]', re.MULTILINE)
+
+
+def _resolve_alembic_head() -> str:
+    """Find the head revision in the bundled migrations/versions/ tree.
+
+    Regex-parses each file's `revision` and `down_revision` strings rather
+    than importing the modules. Migration modules can have side-effecting
+    imports (e.g. `from migrations.seed_data...`) that only resolve under
+    alembic's runtime sys.path setup; importing them at app startup would
+    couple shu-api to alembic's CLI conventions.
+    """
     from pathlib import Path
 
-    from alembic.config import Config
-    from alembic.script import ScriptDirectory
-
-    from ..models.registry import register_all_models
-
-    register_all_models()
-
     candidates = [
-        Path("/app/alembic.ini"),
-        Path(__file__).resolve().parents[3] / "alembic.ini",
+        Path("/app/migrations/versions"),
+        Path(__file__).resolve().parents[3] / "migrations" / "versions",
     ]
-    alembic_ini = next((p for p in candidates if p.exists()), None)
-    if alembic_ini is None:
-        raise DatabaseSessionError(
-            "alembic.ini not found in any expected location; cannot verify schema version. "
-            f"Looked in: {[str(p) for p in candidates]}"
-        )
+    versions_dir = next((p for p in candidates if p.is_dir()), None)
+    if versions_dir is None:
+        raise DatabaseSessionError(f"migrations/versions/ not found; looked in {[str(p) for p in candidates]}")
 
-    expected = ScriptDirectory.from_config(Config(str(alembic_ini))).get_current_head()
-    if expected is None:
-        raise DatabaseSessionError("alembic migrations directory has no head revision")
+    revisions: dict[str, str | None] = {}
+    for path in versions_dir.glob("*.py"):
+        if path.name == "__init__.py":
+            continue
+        text_ = path.read_text()
+        rev = _REVISION_RE.search(text_)
+        if rev is None:
+            continue
+        down = _DOWN_REVISION_RE.search(text_)
+        revisions[rev.group(1)] = down.group(1) if down else None
+
+    if not revisions:
+        raise DatabaseSessionError(f"no migration files found under {versions_dir}")
+
+    pointed_to = {d for d in revisions.values() if d is not None}
+    heads = [r for r in revisions if r not in pointed_to]
+    if len(heads) != 1:
+        raise DatabaseSessionError(
+            f"expected exactly one alembic head; found {heads}. " "Migrations have branched and need to be reconciled."
+        )
+    return heads[0]
+
+
+async def verify_schema_version() -> None:
+    """Raise DatabaseSessionError unless alembic_version matches the bundled head."""
+    expected = _resolve_alembic_head()
 
     engine = get_async_engine()
     async with engine.begin() as conn:

--- a/backend/src/tests/unit/core/test_database.py
+++ b/backend/src/tests/unit/core/test_database.py
@@ -77,38 +77,30 @@ def _patch_engine_with_query_result(monkeypatch, *, query_result):
     return conn
 
 
+class TestResolveAlembicHead:
+    """Smoke test against the real bundled migrations directory."""
+
+    def test_returns_single_head_from_real_migrations(self) -> None:
+        head = database._resolve_alembic_head()
+        assert head, "expected a non-empty head revision"
+
+
 class TestVerifySchemaVersion:
-    """SHU-763: shu-api refuses to start unless alembic_version matches expected head.
+    """shu-api refuses to start unless alembic_version matches the bundled head."""
 
-    All cases stub the alembic ScriptDirectory + the model registry so we exercise
-    the verification path itself rather than alembic resolution or import side
-    effects.
-    """
-
-    def _patch_alembic_head(self, monkeypatch, head: str | None = "abc123") -> None:
-        from pathlib import Path
-
-        monkeypatch.setattr(
-            Path,
-            "exists",
-            lambda self: True,
-        )
-        script_dir = MagicMock()
-        script_dir.get_current_head.return_value = head
-        monkeypatch.setattr("alembic.script.ScriptDirectory.from_config", lambda _cfg: script_dir)
-        monkeypatch.setattr("alembic.config.Config", lambda _path: MagicMock())
-        monkeypatch.setattr("shu.models.registry.register_all_models", lambda: None)
+    def _stub_head(self, monkeypatch, value: str = "abc123") -> None:
+        monkeypatch.setattr(database, "_resolve_alembic_head", lambda: value)
 
     @pytest.mark.asyncio
     async def test_returns_cleanly_when_versions_match(self, monkeypatch) -> None:
-        self._patch_alembic_head(monkeypatch, head="abc123")
+        self._stub_head(monkeypatch, "abc123")
         _patch_engine_with_query_result(monkeypatch, query_result=("abc123",))
 
         await database.verify_schema_version()  # no exception = pass
 
     @pytest.mark.asyncio
     async def test_raises_on_version_mismatch(self, monkeypatch) -> None:
-        self._patch_alembic_head(monkeypatch, head="abc123")
+        self._stub_head(monkeypatch, "abc123")
         _patch_engine_with_query_result(monkeypatch, query_result=("def456",))
 
         with pytest.raises(DatabaseSessionError, match="schema at revision 'def456'"):
@@ -116,7 +108,7 @@ class TestVerifySchemaVersion:
 
     @pytest.mark.asyncio
     async def test_raises_when_alembic_version_table_missing(self, monkeypatch) -> None:
-        self._patch_alembic_head(monkeypatch, head="abc123")
+        self._stub_head(monkeypatch, "abc123")
         _patch_engine_with_query_result(
             monkeypatch,
             query_result=ProgrammingError("SELECT", {}, Exception("relation does not exist")),
@@ -127,7 +119,7 @@ class TestVerifySchemaVersion:
 
     @pytest.mark.asyncio
     async def test_raises_when_version_row_absent(self, monkeypatch) -> None:
-        self._patch_alembic_head(monkeypatch, head="abc123")
+        self._stub_head(monkeypatch, "abc123")
         _patch_engine_with_query_result(monkeypatch, query_result=None)
 
         with pytest.raises(DatabaseSessionError, match="alembic_version row missing"):
@@ -135,7 +127,7 @@ class TestVerifySchemaVersion:
 
     @pytest.mark.asyncio
     async def test_raises_when_version_value_is_null(self, monkeypatch) -> None:
-        self._patch_alembic_head(monkeypatch, head="abc123")
+        self._stub_head(monkeypatch, "abc123")
         _patch_engine_with_query_result(monkeypatch, query_result=(None,))
 
         with pytest.raises(DatabaseSessionError, match="alembic_version row missing"):


### PR DESCRIPTION
Replace alembic ScriptDirectory with regex-based parsing of migration files to avoid import side effects at startup. Extract head resolution into `_resolve_alembic_head` and update tests accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Database schema verification now resolves the expected migration head directly from the bundled migrations, removing runtime dependencies on external migration tooling and discovery.

* **Tests**
  * Added a migration-head integrity test and refactored the schema verification test suite to use a simpler head-stubbing approach and to cover missing/invalid version cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/154)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->