### PR TITLE
fix(llm): [SHU-768] capture streamed error bodies; wrap assistant input

### DIFF
--- a/backend/src/shu/llm/client.py
+++ b/backend/src/shu/llm/client.py
@@ -470,6 +470,12 @@ class UnifiedLLMClient:
 
         try:
             async with self.client.stream("POST", endpoint, json=payload, **stream_kwargs) as response:
+                # httpx streams the body lazily; on a 4xx/5xx the body hasn't been read yet,
+                # so downstream error extraction (ErrorSanitizer.extract_provider_error → response.text)
+                # would silently fail and we'd lose the provider's actual error message. Materialize
+                # the body before raising so the error path can see it.
+                if response.status_code >= 400:
+                    await response.aread()
                 response.raise_for_status()
 
                 # DEBUG: Log response headers for debugging
@@ -736,10 +742,12 @@ class UnifiedLLMClient:
             ) from e
         elif status_code == 400:
             logger.error(
-                "LLM configuration error (400) for provider %s: %s (request_id=%s)",
+                "LLM configuration error (400) for provider %s: %s (request_id=%s, endpoint=%s, body=%s)",
                 self.provider.name,
                 details.get("provider_message") or str(e),
                 details.get("request_id"),
+                details.get("endpoint"),
+                body_str,
             )
             # Use simple sanitized message - suggestions are in details for /test endpoint
             raise LLMConfigurationError(

--- a/backend/src/shu/services/providers/adapters/responses_adapter.py
+++ b/backend/src/shu/services/providers/adapters/responses_adapter.py
@@ -419,6 +419,19 @@ class ResponsesAdapter(BaseProviderAdapter):
 
             return {"role": role, "content": content_parts if content_parts else content}
 
+        # Assistant text replayed in a follow-up turn is sent as an explicit
+        # output_text content part with annotations=[]. OpenAI's documented schema
+        # (ResponseOutputTextParam) declares `annotations` as Required; the bare
+        # {"role":"assistant","content":"text"} shortcut works against the OpenAI
+        # API because their server normalizes for us, but the explicit form is the
+        # spec-correct wire payload and is accepted by every OpenAI-Responses-API
+        # provider that conforms to the documented schema.
+        if role == "assistant" and isinstance(content, str) and content:
+            return {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": content, "annotations": []}],
+            }
+
         # Standard role/content message
         return {"role": role, "content": content}
 

--- a/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
+++ b/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
@@ -249,3 +249,31 @@ async def test_inject_functions(responses_adapter):
             },
         ],
     }
+
+
+@pytest.mark.asyncio
+async def test_assistant_string_content_is_wrapped_with_annotations(responses_adapter):
+    """Prior-turn assistant text replays as an explicit output_text content part with
+    annotations=[]. OpenAI's documented ResponseOutputTextParam declares annotations
+    as required; the bare-string shortcut is accepted by OpenAI's server-side
+    normalization but is not the spec-correct wire form.
+    """
+    messages = ChatContext.from_dicts(
+        [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "follow up"},
+        ],
+        system_prompt=None,
+    )
+
+    payload = await responses_adapter.set_messages_in_payload(messages, {})
+
+    assert payload["input"] == [
+        {"role": "user", "content": "first question"},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "first answer", "annotations": []}],
+        },
+        {"role": "user", "content": "follow up"},
+    ]


### PR DESCRIPTION
Discovered during SHU-768 DigitalOcean compatibility evaluation.

httpx.AsyncClient.stream() does not read the response body before raise_for_status, so downstream error extraction silently caught ResponseNotRead and dropped the provider's error message on every streaming 4xx/5xx. Materialize the body via response.aread() when status >= 400 so the error path sees it. Also adds endpoint and body to the 400 server-log line for parity with the 5xx branch.

ResponseOutputTextParam declares annotations as Required per OpenAI's documented schema. Replaying assistant text as a bare-string content shortcut works against OpenAI because their server normalizes for us, but isn't the spec-correct wire form. Wrap as an explicit output_text part with annotations=[].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics by logging the request endpoint and complete provider error details for HTTP 400 errors.
  * Enhanced error handling in HTTP streaming responses to ensure error messages are fully accessible before raising exceptions.

* **New Features**
  * Updated assistant message formatting to use standardized content structure with explicit parts.

* **Tests**
  * Added tests validating proper serialization of assistant messages in conversation history.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->