### PR TITLE
feat: [SHU-729] add slim API image variant and publish Makefile targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,24 @@ frontend/build
 backend/.venv
 backend/.mypy_cache
 
+# Tests — NEVER ship in production image. backend/src/tests/benchmark/
+# alone is ~1 GB of fixtures; tests as a whole have no runtime purpose.
+backend/src/tests
+
+# Python / test tool caches
+.coverage
+.coverage.*
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.hypothesis
+
+# Secrets / local-only configuration
+.env
+.env.*
+.private
+.secrets.baseline
+
 # Local data and logs
 logs
 data

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,24 @@ VERSION        := $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v
 BUILD_TIMESTAMP:= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 DB_RELEASE     := $(shell ls -1 backend/alembic/versions 2>/dev/null | grep -E '^[0-9]{3}_.+\.py$$' | cut -d _ -f1 | sort | tail -n1)
 
-.PHONY: build-api build-fe build-runner build-all
+.PHONY: build-api build-api-slim build-fe build-runner build-all \
+        publish-api publish-api-slim publish-fe publish-runner publish-all \
+        _require-registry
 
-# Build local Docker images
+# ----------------------------------------------------------------------------
+# Local image builds (no push).
+#
+# `build-api` is the standard image. It includes local text-embedding and
+# OCR inference engines (sentence-transformers, torch, transformers, easyocr,
+# pytesseract) so the app can run those workloads without external API
+# dependencies.
+#
+# `build-api-slim` excludes those packages. Use it for deployments that
+# route embedding and OCR through external APIs (e.g. SHU_LOCAL_EMBEDDING_ENABLED=false
+# plus an external OCR engine), where the local libraries are dead weight.
+# Tag suffix `-slim` keeps the two variants distinct in the local image cache.
+# ----------------------------------------------------------------------------
+
 build-api:
 	docker build \
 	  --build-arg SHU_APP_VERSION=$(VERSION) \
@@ -20,6 +35,17 @@ build-api:
 	  -f deployment/docker/api/Dockerfile \
 	  -t shu-api:latest \
 	  -t shu-api:$(VERSION) .
+
+build-api-slim:
+	docker build \
+	  --build-arg INCLUDE_LOCAL_INFERENCE=0 \
+	  --build-arg SHU_APP_VERSION=$(VERSION) \
+	  --build-arg SHU_GIT_SHA=$(GIT_SHA) \
+	  --build-arg SHU_BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+	  --build-arg SHU_DB_RELEASE=$(DB_RELEASE) \
+	  -f deployment/docker/api/Dockerfile \
+	  -t shu-api:$(VERSION)-slim \
+	  -t shu-api:latest-slim .
 
 build-fe:
 	docker build \
@@ -40,6 +66,65 @@ build-runner:
 	  -t shu-runner:$(VERSION) .
 
 build-all: build-api build-fe build-runner
+
+# ----------------------------------------------------------------------------
+# Manual build + tag + push to a container registry.
+#
+# Usage:
+#   make publish-api      REGISTRY=<your-registry-prefix>
+#   make publish-api-slim REGISTRY=<your-registry-prefix>
+#   make publish-fe       REGISTRY=<your-registry-prefix>
+#   make publish-runner   REGISTRY=<your-registry-prefix>
+#   make publish-all      REGISTRY=<your-registry-prefix>
+#
+# Each image gets three tags pushed:
+#   :$(VERSION)              — e.g. 1.2.3 (mutable; latest build for that version wins)
+#   :$(VERSION)-$(GIT_SHA)   — e.g. 1.2.3-abc1234 (immutable; bisect-friendly)
+#   :latest                  — convenience; do not pin downstream consumers to this
+#
+# Authenticate to the registry (`docker login <registry>`) out-of-band before
+# invoking these targets.
+# ----------------------------------------------------------------------------
+
+_require-registry:
+	@if [ -z "$(REGISTRY)" ]; then \
+	  echo "ERROR: REGISTRY is required, e.g. make publish-api REGISTRY=ghcr.io/my-org" ; \
+	  exit 1 ; \
+	fi
+
+publish-api: _require-registry build-api
+	docker tag shu-api:$(VERSION) $(REGISTRY)/shu-api:$(VERSION)
+	docker tag shu-api:$(VERSION) $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)
+	docker tag shu-api:$(VERSION) $(REGISTRY)/shu-api:latest
+	docker push $(REGISTRY)/shu-api:$(VERSION)
+	docker push $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)
+	docker push $(REGISTRY)/shu-api:latest
+
+publish-api-slim: _require-registry build-api-slim
+	docker tag shu-api:$(VERSION)-slim $(REGISTRY)/shu-api:$(VERSION)-slim
+	docker tag shu-api:$(VERSION)-slim $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)-slim
+	docker tag shu-api:$(VERSION)-slim $(REGISTRY)/shu-api:latest-slim
+	docker push $(REGISTRY)/shu-api:$(VERSION)-slim
+	docker push $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)-slim
+	docker push $(REGISTRY)/shu-api:latest-slim
+
+publish-fe: _require-registry build-fe
+	docker tag shu-frontend:$(VERSION) $(REGISTRY)/shu-frontend:$(VERSION)
+	docker tag shu-frontend:$(VERSION) $(REGISTRY)/shu-frontend:$(VERSION)-$(GIT_SHA)
+	docker tag shu-frontend:$(VERSION) $(REGISTRY)/shu-frontend:latest
+	docker push $(REGISTRY)/shu-frontend:$(VERSION)
+	docker push $(REGISTRY)/shu-frontend:$(VERSION)-$(GIT_SHA)
+	docker push $(REGISTRY)/shu-frontend:latest
+
+publish-runner: _require-registry build-runner
+	docker tag shu-runner:$(VERSION) $(REGISTRY)/shu-runner:$(VERSION)
+	docker tag shu-runner:$(VERSION) $(REGISTRY)/shu-runner:$(VERSION)-$(GIT_SHA)
+	docker tag shu-runner:$(VERSION) $(REGISTRY)/shu-runner:latest
+	docker push $(REGISTRY)/shu-runner:$(VERSION)
+	docker push $(REGISTRY)/shu-runner:$(VERSION)-$(GIT_SHA)
+	docker push $(REGISTRY)/shu-runner:latest
+
+publish-all: publish-api publish-fe publish-runner
 
 # Docker Compose build targets
 # Note: Docker Compose v2 uses buildx by default, no explicit builder management needed

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,24 @@ build-runner:
 build-all: build-api build-fe build-runner
 
 # ----------------------------------------------------------------------------
-# Manual build + tag + push to a container registry.
+# Build + push to a container registry (multi-platform-aware).
+#
+# Architecture policy (SHU-779):
+#   * `build-*` targets above produce HOST-ARCH images for local `docker run`.
+#     On Apple Silicon Macs that's `linux/arm64`. Fast iteration, no QEMU.
+#   * `publish-*` targets below produce `linux/amd64` images via `docker buildx
+#     build --platform linux/amd64 --push`. This matches the production
+#     consumer (DOKS amd64 nodes). Builds on Apple Silicon use QEMU
+#     emulation for the amd64 step, which is slow but correct.
+#   * When an arm64-consuming cluster materializes (sovereignty-tier ARM
+#     DOKS, customer on-prem ARM), bump the specific publish target to
+#     `--platform linux/amd64,linux/arm64`. Don't pre-emptively multi-arch
+#     everything — the second arch doubles build time and registry storage
+#     for no benefit when the consumer base is amd64-only.
+#
+# Buildx uses --push to upload directly to the registry without loading
+# the image into the local docker daemon. No separate `docker tag` /
+# `docker push` steps; the -t flags become tags in the registry.
 #
 # Usage:
 #   make publish-api      REGISTRY=<your-registry-prefix>
@@ -82,9 +99,12 @@ build-all: build-api build-fe build-runner
 #   :$(VERSION)-$(GIT_SHA)   — e.g. 1.2.3-abc1234 (immutable; bisect-friendly)
 #   :latest                  — convenience; do not pin downstream consumers to this
 #
-# Authenticate to the registry (`docker login <registry>`) out-of-band before
-# invoking these targets.
+# Authenticate to the registry (`docker login <registry>` or `doctl registry
+# login` for DOCR) out-of-band before invoking these targets. buildx uses
+# the local docker config's registry credentials.
 # ----------------------------------------------------------------------------
+
+PUBLISH_PLATFORMS ?= linux/amd64
 
 _require-registry:
 	@if [ -z "$(REGISTRY)" ]; then \
@@ -92,37 +112,48 @@ _require-registry:
 	  exit 1 ; \
 	fi
 
-publish-api: _require-registry build-api
-	docker tag shu-api:$(VERSION) $(REGISTRY)/shu-api:$(VERSION)
-	docker tag shu-api:$(VERSION) $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)
-	docker tag shu-api:$(VERSION) $(REGISTRY)/shu-api:latest
-	docker push $(REGISTRY)/shu-api:$(VERSION)
-	docker push $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)
-	docker push $(REGISTRY)/shu-api:latest
+publish-api: _require-registry
+	docker buildx build --platform $(PUBLISH_PLATFORMS) --push \
+	  --build-arg SHU_APP_VERSION=$(VERSION) \
+	  --build-arg SHU_GIT_SHA=$(GIT_SHA) \
+	  --build-arg SHU_BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+	  --build-arg SHU_DB_RELEASE=$(DB_RELEASE) \
+	  -f deployment/docker/api/Dockerfile \
+	  -t $(REGISTRY)/shu-api:$(VERSION) \
+	  -t $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA) \
+	  -t $(REGISTRY)/shu-api:latest .
 
-publish-api-slim: _require-registry build-api-slim
-	docker tag shu-api:$(VERSION)-slim $(REGISTRY)/shu-api:$(VERSION)-slim
-	docker tag shu-api:$(VERSION)-slim $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)-slim
-	docker tag shu-api:$(VERSION)-slim $(REGISTRY)/shu-api:latest-slim
-	docker push $(REGISTRY)/shu-api:$(VERSION)-slim
-	docker push $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)-slim
-	docker push $(REGISTRY)/shu-api:latest-slim
+publish-api-slim: _require-registry
+	docker buildx build --platform $(PUBLISH_PLATFORMS) --push \
+	  --build-arg INCLUDE_LOCAL_INFERENCE=0 \
+	  --build-arg SHU_APP_VERSION=$(VERSION) \
+	  --build-arg SHU_GIT_SHA=$(GIT_SHA) \
+	  --build-arg SHU_BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+	  --build-arg SHU_DB_RELEASE=$(DB_RELEASE) \
+	  -f deployment/docker/api/Dockerfile \
+	  -t $(REGISTRY)/shu-api:$(VERSION)-slim \
+	  -t $(REGISTRY)/shu-api:$(VERSION)-$(GIT_SHA)-slim \
+	  -t $(REGISTRY)/shu-api:latest-slim .
 
-publish-fe: _require-registry build-fe
-	docker tag shu-frontend:$(VERSION) $(REGISTRY)/shu-frontend:$(VERSION)
-	docker tag shu-frontend:$(VERSION) $(REGISTRY)/shu-frontend:$(VERSION)-$(GIT_SHA)
-	docker tag shu-frontend:$(VERSION) $(REGISTRY)/shu-frontend:latest
-	docker push $(REGISTRY)/shu-frontend:$(VERSION)
-	docker push $(REGISTRY)/shu-frontend:$(VERSION)-$(GIT_SHA)
-	docker push $(REGISTRY)/shu-frontend:latest
+publish-fe: _require-registry
+	docker buildx build --platform $(PUBLISH_PLATFORMS) --push \
+	  --build-arg SHU_APP_VERSION=$(VERSION) \
+	  --build-arg SHU_GIT_SHA=$(GIT_SHA) \
+	  --build-arg SHU_BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+	  -f deployment/docker/frontend/Dockerfile \
+	  -t $(REGISTRY)/shu-frontend:$(VERSION) \
+	  -t $(REGISTRY)/shu-frontend:$(VERSION)-$(GIT_SHA) \
+	  -t $(REGISTRY)/shu-frontend:latest .
 
-publish-runner: _require-registry build-runner
-	docker tag shu-runner:$(VERSION) $(REGISTRY)/shu-runner:$(VERSION)
-	docker tag shu-runner:$(VERSION) $(REGISTRY)/shu-runner:$(VERSION)-$(GIT_SHA)
-	docker tag shu-runner:$(VERSION) $(REGISTRY)/shu-runner:latest
-	docker push $(REGISTRY)/shu-runner:$(VERSION)
-	docker push $(REGISTRY)/shu-runner:$(VERSION)-$(GIT_SHA)
-	docker push $(REGISTRY)/shu-runner:latest
+publish-runner: _require-registry
+	docker buildx build --platform $(PUBLISH_PLATFORMS) --push \
+	  --build-arg SHU_APP_VERSION=$(VERSION) \
+	  --build-arg SHU_GIT_SHA=$(GIT_SHA) \
+	  --build-arg SHU_BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
+	  -f deployment/docker/runner/Dockerfile \
+	  -t $(REGISTRY)/shu-runner:$(VERSION) \
+	  -t $(REGISTRY)/shu-runner:$(VERSION)-$(GIT_SHA) \
+	  -t $(REGISTRY)/shu-runner:latest .
 
 publish-all: publish-api publish-api-slim publish-fe publish-runner
 

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ publish-runner: _require-registry build-runner
 	docker push $(REGISTRY)/shu-runner:$(VERSION)-$(GIT_SHA)
 	docker push $(REGISTRY)/shu-runner:latest
 
-publish-all: publish-api publish-fe publish-runner
+publish-all: publish-api publish-api-slim publish-fe publish-runner
 
 # Docker Compose build targets
 # Note: Docker Compose v2 uses buildx by default, no explicit builder management needed

--- a/Makefile
+++ b/Makefile
@@ -137,13 +137,15 @@ compose-build-dev:
 
 # Docker Compose targets
 # - make up:           API + Postgres + Redis (backend only, inline workers)
-# - make up-full:      Full stack including frontend
-# - make up-dev:       Backend with hot-reload
-# - make up-full-dev:  Full stack with hot-reload backend
-# - make up-worker:    Dedicated worker (production)
-# - make up-worker-dev: Dedicated worker with hot-reload
+# - make up-full:           Full stack including frontend
+# - make up-dev:            Backend with hot-reload
+# - make up-full-dev:       Full stack with hot-reload backend
+# - make up-dev-slim:       Backend with hot-reload, slim image (external embedding only)
+# - make up-full-dev-slim:  Full stack with hot-reload backend, slim image
+# - make up-worker:         Dedicated worker (production)
+# - make up-worker-dev:     Dedicated worker with hot-reload
 
-.PHONY: up up-full up-dev up-full-dev up-worker up-worker-dev up-workers up-split up-dev-split down logs logs-worker ps enable-bm25
+.PHONY: up up-full up-dev up-full-dev up-dev-slim up-full-dev-slim up-worker up-worker-dev up-workers up-split up-dev-split down logs logs-worker ps enable-bm25
 
 up:
 	docker compose -f $(COMPOSE_FILE) up -d
@@ -156,6 +158,16 @@ up-dev:
 
 up-full-dev:
 	docker compose -f $(COMPOSE_FILE) --profile dev up -d shu-api-dev shu-postgres shu-db-migrate redis shu-frontend-dev
+
+# Slim API image (no torch / sentence-transformers / pytesseract). Requires an
+# external embedding model registered in llm_models — slim bakes
+# SHU_LOCAL_EMBEDDING_ENABLED=false. Mutually exclusive with up-dev / up-full-dev
+# (port 8000 + shu-api-dev network alias). Run `make down` between switches.
+up-dev-slim:
+	docker compose -f $(COMPOSE_FILE) --profile dev-slim up -d shu-api-dev-slim shu-postgres shu-db-migrate redis
+
+up-full-dev-slim:
+	docker compose -f $(COMPOSE_FILE) --profile dev-slim --profile dev up -d shu-api-dev-slim shu-postgres shu-db-migrate redis shu-frontend-dev
 
 # Start dedicated worker (requires redis and db-migrate to be running)
 up-worker:
@@ -179,8 +191,8 @@ up-dev-split:
 	SHU_WORKERS_ENABLED=false docker compose -f $(COMPOSE_FILE) --profile dev --profile workers up -d shu-api-dev shu-postgres shu-db-migrate redis shu-worker-ingestion shu-worker-llm shu-worker-maintenance
 
 down:
-	docker compose -f $(COMPOSE_FILE) --profile dev --profile frontend --profile worker --profile worker-dev --profile workers down --remove-orphans || true
-	-docker rm -f shu-frontend shu-frontend-dev shu-api-dev shu-worker shu-worker-dev shu-worker-ingestion shu-worker-llm shu-worker-maintenance 2>/dev/null || true
+	docker compose -f $(COMPOSE_FILE) --profile dev --profile dev-slim --profile frontend --profile worker --profile worker-dev --profile workers down --remove-orphans || true
+	-docker rm -f shu-frontend shu-frontend-dev shu-api-dev shu-api-dev-slim shu-worker shu-worker-dev shu-worker-ingestion shu-worker-llm shu-worker-maintenance 2>/dev/null || true
 
 logs:
 	docker compose -f $(COMPOSE_FILE) logs -f

--- a/backend/src/shu/services/query/keyword.py
+++ b/backend/src/shu/services/query/keyword.py
@@ -389,13 +389,16 @@ class KeywordSearchMixin:
             scored_chunks = []
 
             # Get query embedding for similarity scoring (reuse precomputed if available)
-            from scipy.spatial.distance import cosine
+            import numpy as np
 
             if query_embedding is None:
                 from ...core.embedding_service import get_embedding_service
 
                 embedding_service = await get_embedding_service()
                 query_embedding = await embedding_service.embed_query(query, user_id=user_id)
+
+            query_vec = np.asarray(query_embedding, dtype=np.float32)
+            query_norm = float(np.linalg.norm(query_vec))
 
             # Preprocess query and get weights once (loop-invariant)
             processed = self.preprocess_query(query)
@@ -411,7 +414,10 @@ class KeywordSearchMixin:
 
                     chunk_embedding = json.loads(chunk_embedding)
 
-                similarity_score = float(1 - cosine(query_embedding, chunk_embedding))
+                chunk_vec = np.asarray(chunk_embedding, dtype=np.float32)
+                chunk_norm = float(np.linalg.norm(chunk_vec))
+                denom = query_norm * chunk_norm
+                similarity_score = float(np.dot(query_vec, chunk_vec) / denom) if denom > 0 else 0.0
                 similarity_score = max(0, similarity_score)  # Ensure non-negative
 
                 keyword_score = self._calculate_keyword_score(chunk.content, keyword_terms)

--- a/backend/src/tests/unit/core/test_embedding_service.py
+++ b/backend/src/tests/unit/core/test_embedding_service.py
@@ -211,9 +211,13 @@ class TestDIWiring:
         reset_embedding_service()
 
     @pytest.mark.asyncio
+    @patch("shu.core.embedding_service.resolve_embedding_dtype", return_value="float32")
+    @patch("shu.core.embedding_service.resolve_embedding_device", return_value="cpu")
     @patch("shu.core.embedding_service._service_manager")
     @patch("shu.core.embedding_service.get_settings_instance")
-    async def test_get_embedding_service_returns_singleton(self, mock_settings, mock_manager):
+    async def test_get_embedding_service_returns_singleton(
+        self, mock_settings, mock_manager, _mock_device, _mock_dtype
+    ):
         """Two calls to get_embedding_service should return the same instance."""
         settings = MagicMock()
         settings.default_embedding_model = "test-model"
@@ -290,9 +294,11 @@ class TestServiceResolution:
         reset_embedding_service()
 
     @pytest.mark.asyncio
+    @patch("shu.core.embedding_service.resolve_embedding_dtype", return_value="float32")
+    @patch("shu.core.embedding_service.resolve_embedding_device", return_value="cpu")
     @patch("shu.core.embedding_service._service_manager")
     @patch("shu.core.embedding_service.get_settings_instance")
-    async def test_local_enabled_uses_local(self, mock_settings, mock_manager):
+    async def test_local_enabled_uses_local(self, mock_settings, mock_manager, _mock_device, _mock_dtype):
         """When SHU_LOCAL_EMBEDDING_ENABLED=true, local service is used regardless of external models."""
         settings = MagicMock()
         settings.local_embedding_enabled = True

--- a/backend/src/tests/unit/workers/test_ocr_confidence_propagation.py
+++ b/backend/src/tests/unit/workers/test_ocr_confidence_propagation.py
@@ -212,6 +212,7 @@ class TestTesseractConfidenceIsQualityHeuristic:
 
     def test_tesseract_confidence_matches_calculate_text_quality(self):
         """The confidence returned equals _calculate_text_quality(text)."""
+        pytest.importorskip("pytesseract")
         extractor = _make_extractor()
 
         page = MagicMock()

--- a/deployment/compose/docker-compose.yml
+++ b/deployment/compose/docker-compose.yml
@@ -84,6 +84,59 @@ services:
       shu-db-migrate:
         condition: service_completed_successfully
 
+  # Shu RAG Backend API (Development, slim image — no local torch / OCR engines)
+  # Mutually exclusive with shu-api-dev: both bind port 8000 and the network alias
+  # shu-api-dev so shu-frontend-dev's proxy target resolves to whichever one is up.
+  shu-api-dev-slim:
+    build:
+      context: ../..
+      dockerfile: deployment/docker/api/Dockerfile
+      args:
+        INCLUDE_LOCAL_INFERENCE: "0"
+    container_name: shu-api-dev-slim
+    env_file: ../../.env
+    environment:
+      - SHU_DATABASE_URL=postgresql+asyncpg://shu:password@shu-postgres:5432/shu
+      - SHU_REDIS_URL=redis://redis:6379
+      - SHU_LOG_LEVEL=DEBUG
+      - SHU_LOG_FORMAT=text
+      - SHU_API_HOST=0.0.0.0
+      - SHU_API_PORT=8000
+      - SHU_ENVIRONMENT=development
+      - SHU_APP_VERSION=0.0.6-dev-slim
+      - SHU_PLUGINS_ROOT=/app/plugins
+      - SHU_WORKERS_ENABLED=${SHU_WORKERS_ENABLED:-true}
+      # Slim image has no torch / sentence-transformers / pytesseract.
+      # Embedding must route to an external model registered in llm_models.
+      - SHU_LOCAL_EMBEDDING_ENABLED=false
+      - PYTHONPATH=/app/src
+      - OAUTH_REDIRECT_URI=http://localhost:3000/auth/callback
+      - MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-2}
+      - SHU_MEMORY_TRIM_INTERVAL_SECONDS=${SHU_MEMORY_TRIM_INTERVAL_SECONDS:-60}
+      - SHU_DISABLE_JEMALLOC=${SHU_DISABLE_JEMALLOC:-}
+    ports:
+      - "8000:8000"
+    volumes:
+      - ../../backend/src:/app/src
+      - ../../backend/alembic:/app/alembic
+      - ../../backend/alembic.ini:/app/alembic.ini
+      - ../../backend/scripts:/app/scripts
+      - ../../data:/app/data
+      - ../../plugins:/app/plugins
+    networks:
+      shu-network:
+        aliases:
+          - shu-api-dev
+    restart: unless-stopped
+    profiles:
+      - dev-slim
+    command: ["python", "-m", "uvicorn", "shu.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+    depends_on:
+      shu-postgres:
+        condition: service_healthy
+      shu-db-migrate:
+        condition: service_completed_successfully
+
   # Shu Postgres
   shu-postgres:
     image: paradedb/paradedb:latest-pg18

--- a/deployment/docker/api/Dockerfile
+++ b/deployment/docker/api/Dockerfile
@@ -1,78 +1,115 @@
 # syntax=docker/dockerfile:1.6
 
-# Use an official Python runtime as a parent image
-FROM python:3.11-slim
+# Multi-stage build. The standard image includes local text-embedding and OCR
+# inference engines (sentence-transformers, torch, transformers, easyocr,
+# pytesseract). Pass `--build-arg INCLUDE_LOCAL_INFERENCE=0` to produce the
+# slim variant, which excludes those packages — for deployments that route
+# embedding and OCR through external APIs and don't need local inference.
+#
+# Build from the repository root:
+#   docker build -f deployment/docker/api/Dockerfile .                                       # standard (with local inference)
+#   docker build -f deployment/docker/api/Dockerfile --build-arg INCLUDE_LOCAL_INFERENCE=0 . # slim
+#
+# Corresponding Makefile targets: `make build-api` (standard) and
+# `make build-api-slim`.
 
-# Build-time metadata (optionally provided)
+# =============================================================================
+# Builder stage — install build tools + Python deps, then discard the build
+# tooling. Only the resulting site-packages tree carries into the runtime
+# image.
+# =============================================================================
+
+FROM python:3.11-slim AS builder
+
+ARG INCLUDE_LOCAL_INFERENCE=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+COPY requirements.txt requirements-local-inference.txt ./
+
+# pip install --prefix=/install stages the install tree separately from
+# system /usr/local. The runtime stage COPYs /install over to its own
+# /usr/local. The BuildKit pip cache mount (`--mount=type=cache`)
+# accelerates rebuilds — pip reads cached wheels on a re-run instead of
+# re-downloading. The mount is not committed to any layer, so it has
+# zero effect on final image size.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --prefix=/install -r requirements.txt && \
+    if [ "$INCLUDE_LOCAL_INFERENCE" = "1" ]; then \
+        echo "INCLUDE_LOCAL_INFERENCE=1 — installing local embedding + OCR engines" && \
+        pip install --prefix=/install -r requirements-local-inference.txt ; \
+    else \
+        echo "INCLUDE_LOCAL_INFERENCE=0 — slim variant, skipping local inference engines" ; \
+    fi
+
+# =============================================================================
+# Runtime stage — slim base, only the deps + source needed to run the app.
+# No build-essential, no git, no pip caches.
+# =============================================================================
+
+FROM python:3.11-slim AS runtime
+
+# Build-time metadata baked into the image as default env values.
 ARG SHU_APP_VERSION
 ARG SHU_GIT_SHA
 ARG SHU_BUILD_TIMESTAMP
 ARG SHU_DB_RELEASE
 
-
-# Set the working directory in the container
-WORKDIR /app
-
-# Install system dependencies. libjemalloc2 is LD_PRELOADed below to reduce
-# long-running-process RSS retention vs. glibc's default 8×nproc arenas
-# (SHU-731). SHU_DISABLE_JEMALLOC=1 at runtime clears LD_PRELOAD if an
-# operator needs to fall back to glibc for comparison.
+# Runtime system deps:
+#   curl       — used by HEALTHCHECK
+#   libjemalloc2 — LD_PRELOADed by entrypoint to reduce long-running-process
+#                  RSS retention vs. glibc's default 8×nproc arenas (SHU-731).
+#                  SHU_DISABLE_JEMALLOC=1 clears LD_PRELOAD at runtime.
+# build-essential and git are intentionally NOT installed here — they only
+# matter during the builder stage's pip install.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
-    git \
-    libjemalloc2 \
+      curl \
+      libjemalloc2 \
     && rm -rf /var/lib/apt/lists/* \
-    # Record the concrete jemalloc path once so runtime doesn't have to
-    # guess multi-arch paths (amd64 vs arm64 live in different dirs).
     && JEMALLOC_PATH="$(find /usr/lib -name 'libjemalloc.so.2' | head -n1)" \
     && [ -n "$JEMALLOC_PATH" ] && printf '%s\n' "$JEMALLOC_PATH" > /etc/shu-jemalloc-path
 
-# Copy the requirements file into the container at /app
-COPY requirements.txt .
+# Bring over Python deps from the builder stage. /install becomes /usr/local.
+COPY --from=builder /install /usr/local
 
-# Install any needed packages specified in requirements.txt (cache wheels for faster rebuilds)
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir -r requirements.txt
+WORKDIR /app
 
-# Copy the rest of the application's code into the container at /app
-# NOTE: These COPY commands assume the build context is the repository root.
-# Build from repo root using: docker build -f deployment/docker/api/Dockerfile .
-# When using docker-compose, the context is set in the compose file (see deployment/compose/docker-compose.yml).
-COPY backend/src/ ./src/
-COPY backend/migrations/ ./migrations/
-COPY backend/alembic.ini ./alembic.ini
-COPY backend/scripts/ ./scripts/
-
-# Create plugin and data directories, and non-root user to run the application
-RUN mkdir -p /app/data/plugins /app/data/branding /app/data/attachments /app/data/logs /app/data/ingestion \
-    && adduser --disabled-password --gecos "" appuser \
+# Create non-root user + data directories. Done in one layer BEFORE the
+# COPY --chown calls so subsequent COPYs can target the user directly.
+RUN adduser --disabled-password --gecos "" appuser \
+    && mkdir -p /app/data/plugins /app/data/branding /app/data/attachments /app/data/logs /app/data/ingestion \
     && chown -R appuser:appuser /app
+
+# Application source. COPY --chown avoids the chown-layer duplication that
+# would otherwise double the size of every file in /app on the image.
+# Tests are excluded via .dockerignore (backend/src/tests).
+COPY --chown=appuser:appuser backend/src/ ./src/
+COPY --chown=appuser:appuser backend/migrations/ ./migrations/
+COPY --chown=appuser:appuser backend/alembic.ini ./alembic.ini
+COPY --chown=appuser:appuser backend/scripts/ ./scripts/
+# Entrypoint script copied last so edits to it don't invalidate the larger
+# source-copy layers above. `--chmod=755` sets the executable bit at COPY
+# time, avoiding a separate `RUN chmod` layer and the USER root/appuser
+# swap that would otherwise be needed.
+COPY --chmod=755 --chown=appuser:appuser deployment/docker/api/entrypoint.sh /usr/local/bin/shu-entrypoint.sh
+
 USER appuser
 
-# Define runtime environment via Kubernetes/Compose; only set PYTHONPATH here
 ENV PYTHONPATH=/app/src \
     SHU_APP_VERSION=${SHU_APP_VERSION:-0.0.0-dev} \
     SHU_GIT_SHA=${SHU_GIT_SHA:-unknown} \
     SHU_BUILD_TIMESTAMP=${SHU_BUILD_TIMESTAMP:-unknown} \
     SHU_DB_RELEASE=${SHU_DB_RELEASE:-}
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/v1/health/liveness || exit 1
 
-# Expose port
 EXPOSE 8000
 
-# Entrypoint wires jemalloc via LD_PRELOAD at startup (SHU-731). Done as an
-# entrypoint rather than a hard-coded ENV so operators can disable it via
-# SHU_DISABLE_JEMALLOC=1 without needing to build a new image, and so we
-# don't bake an arch-specific path into the image metadata.
-COPY deployment/docker/api/entrypoint.sh /usr/local/bin/shu-entrypoint.sh
-USER root
-RUN chmod +x /usr/local/bin/shu-entrypoint.sh
-USER appuser
 ENTRYPOINT ["/usr/local/bin/shu-entrypoint.sh"]
-
-# Specify the command to run on container startup (run ASGI server)
 CMD ["uvicorn", "shu.main:app", "--host", "0.0.0.0", "--port", "8000", "--lifespan", "on"]

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -6,11 +6,12 @@ This guide covers deployment patterns, worker modes, scaling strategies, and pro
 
 1. [Deployment Modes Overview](#deployment-modes-overview)
 2. [Worker Architecture](#worker-architecture)
-3. [Docker Compose Deployment](#docker-compose-deployment)
-4. [Kubernetes Deployment](#kubernetes-deployment)
-5. [Environment Variables Reference](#environment-variables-reference)
-6. [Scaling Patterns](#scaling-patterns)
-7. [Troubleshooting](#troubleshooting)
+3. [Container Images](#container-images)
+4. [Docker Compose Deployment](#docker-compose-deployment)
+5. [Kubernetes Deployment](#kubernetes-deployment)
+6. [Environment Variables Reference](#environment-variables-reference)
+7. [Scaling Patterns](#scaling-patterns)
+8. [Troubleshooting](#troubleshooting)
 
 ---
 

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -101,6 +101,57 @@ Workers can consume all workload types or specific types for targeted scaling.
 
 ---
 
+## Container Images
+
+`shu-api` ships in two variants:
+
+| Variant | Image tag | What's inside | Approx size |
+| --- | --- | --- | --- |
+| **Standard** | `shu-api:<version>` | Everything, including local text-embedding (`sentence-transformers`, `torch`, `transformers`) and local OCR engines (`easyocr`, `pytesseract`) | ~5 GB |
+| **Slim** | `shu-api:<version>-slim` | The standard image minus the local inference engines above. For deployments that route embedding and OCR through external APIs | ~1.5–2 GB |
+
+Both variants are functionally identical at the code level — the slim variant simply omits the Python packages that are only needed when running embedding or OCR inference locally. The runtime defers imports of those packages behind feature flags (`SHU_LOCAL_EMBEDDING_ENABLED`, OCR engine selection), so the slim image works as long as those flags route to external providers.
+
+### Building locally
+
+```bash
+# Standard image (default — includes local inference)
+make build-api
+
+# Slim image (skips sentence-transformers, torch, transformers, easyocr, pytesseract)
+make build-api-slim
+```
+
+`build-api` produces `shu-api:latest` and `shu-api:<version>`. `build-api-slim` adds the `-slim` suffix to both.
+
+### Publishing to a registry
+
+```bash
+# Standard variant — three tags pushed: :version, :version-gitsha, :latest
+make publish-api REGISTRY=<your-registry-prefix>
+
+# Slim variant — three tags with -slim suffix
+make publish-api-slim REGISTRY=<your-registry-prefix>
+
+# Frontend + runner (single variant each)
+make publish-fe     REGISTRY=<your-registry-prefix>
+make publish-runner REGISTRY=<your-registry-prefix>
+
+# Convenience: all three (api + fe + runner, standard variant)
+make publish-all    REGISTRY=<your-registry-prefix>
+```
+
+Authenticate to the registry (`docker login <registry>`) out-of-band before invoking these targets.
+
+### Dependency split
+
+- `requirements.txt` — core dependencies; installed in both variants.
+- `requirements-local-inference.txt` — `sentence-transformers`, `torch`, `transformers`, `easyocr`, `pytesseract`. Installed by default; skipped when the Dockerfile build arg `INCLUDE_LOCAL_INFERENCE=0` (set automatically by `build-api-slim`).
+
+`scipy` is pulled in transitively by `torch` / `transformers` and falls out of the slim image naturally.
+
+---
+
 ## Docker Compose Deployment
 
 ### Basic Stack (Inline Workers)

--- a/requirements-local-inference.txt
+++ b/requirements-local-inference.txt
@@ -1,0 +1,24 @@
+# Dependencies for running text-embedding and OCR inference LOCALLY inside
+# the app (no external API calls). Installed by the standard build.
+#
+# Skipped when the Dockerfile is built with `--build-arg INCLUDE_LOCAL_INFERENCE=0`
+# (the `make build-api-slim` target). The slim variant is for deployments
+# that route embedding and OCR through external APIs and don't need these
+# libraries at runtime — skipping them shrinks the image significantly.
+#
+# The runtime code defers imports of these packages behind feature flags
+# (`SHU_LOCAL_EMBEDDING_ENABLED`, OCR engine selection) so a slim image
+# won't reach the import sites as long as those flags select external
+# providers.
+#
+# scipy is intentionally NOT listed — it's pulled in transitively by
+# torch / transformers and falls out naturally when they aren't installed.
+
+# Local text-embedding inference
+sentence-transformers==5.0.0
+torch==2.7.1
+transformers==4.53.2
+
+# Local OCR engines
+pytesseract==0.3.13  # tesseract wrapper
+easyocr==1.7.2       # deep-learning OCR

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,7 @@ PyYAML==6.0.3  # YAML processing for experience import/export
 # to skip them. Pillow and OpenCV stay here because they preprocess images
 # before sending to the recognition engine regardless of where that engine
 # runs.
-Pillow==12.1.1  # Image preprocessing
+Pillow==12.2.0  # Image preprocessing (12.2.0 includes security fixes vs 12.1.1)
 opencv-python-headless==4.12.0.88  # Advanced image preprocessing (headless for server/Docker)
 
 # Primary OCR engine - PaddleOCR (best for legal documents and tables)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,10 +26,11 @@ google-auth-httplib2==0.2.0
 google-api-python-client==2.176.0
 
 
-# Text processing and embeddings
-sentence-transformers==5.0.0
-torch==2.7.1
-transformers==4.53.2
+# Text processing and embeddings.
+# Local embedding inference deps (sentence-transformers, torch, transformers)
+# live in requirements-local-inference.txt — installed by the standard build,
+# skipped only when `--build-arg INCLUDE_LOCAL_INFERENCE=0` (the slim variant
+# for deployments that use external embedding APIs).
 numpy==2.2.6
 tiktoken==0.9.0  # Token counting for LLM context estimation
 
@@ -91,15 +92,17 @@ jmespath==1.0.1
 croniter>=6.0.0  # Cron expression parsing for schedulers
 PyYAML==6.0.3  # YAML processing for experience import/export
 
-# OCR dependencies for image-based PDF text extraction
-pytesseract==0.3.13  # OCR engine wrapper (fallback)
-Pillow==12.1.1  # Image processing for OCR
-opencv-python-headless==4.12.0.88  # Advanced image preprocessing for OCR (headless for server/Docker)
+# OCR support — image preprocessing only. Local OCR engines (pytesseract,
+# easyocr) live in requirements-local-inference.txt and are installed by
+# default; deployments using an external OCR API can build the slim variant
+# to skip them. Pillow and OpenCV stay here because they preprocess images
+# before sending to the recognition engine regardless of where that engine
+# runs.
+Pillow==12.1.1  # Image preprocessing
+opencv-python-headless==4.12.0.88  # Advanced image preprocessing (headless for server/Docker)
 
 # Primary OCR engine - PaddleOCR (best for legal documents and tables)
 #paddlepaddle==3.1.0  # PaddleOCR backend
 #paddleocr==3.1.0  # Advanced OCR with layout analysis
 
-# Optional advanced OCR engines (install as needed)
-easyocr==1.7.2  # Deep learning OCR with better accuracy
 # textract>=1.6.5  # Temporarily disabled due to metadata issues


### PR DESCRIPTION
Introduce `INCLUDE_LOCAL_INFERENCE` build arg to produce a slim image that omits sentence-transformers, torch, transformers, easyocr, and pytesseract (~1.5–2 GB vs ~5 GB standard). Extract local inference deps into requirements-local-inference.txt. Add `build-api-slim` and `publish-*` Makefile targets with versioned/SHA/latest tagging. Exclude tests, caches, and secrets from Docker builds via .dockerignore. Refactor Dockerfile to multi-stage builder/runtime split to drop build-essential and git from the final image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a slim API image variant and dev-slim compose service to run a smaller backend without local inference engines
  * New build & publish targets to build, tag, and publish standard and slim images across platforms

* **Documentation**
  * Documented container image variants, build flags, publish/tag workflows, and size/contents guidance

* **Chores**
  * Excluded large test fixtures, caches, and local secret files from images; split heavy inference deps into an optional requirements file
  * Converted Docker build to multi-stage, non-root runtime for smaller, safer images

* **Bug Fixes / Tests**
  * Tests updated to skip or mock optional inference deps and improved embedding numeric computation for stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/159)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->