### PR TITLE
fix: close auth middleware DB session via async with, not async-for/b…

### DIFF
--- a/backend/src/shu/core/middleware.py
+++ b/backend/src/shu/core/middleware.py
@@ -265,10 +265,13 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             from sqlalchemy import select
 
             from ..auth.models import User
-            from ..core.database import get_db
+            from ..core.database import get_async_session_local
 
-            # Get database session
-            async for db in get_db():
+            # Get database session — use async with to guarantee cleanup on every exit
+            # path (return, exception, anyio cancellation). The async-for/break idiom
+            # suspends the generator and defers cleanup to the asyncgen GC finalizer,
+            # which can orphan connections under load or cancellation pressure.
+            async with get_async_session_local()() as db:
                 # Determine lookup based on auth mode
                 if getattr(request.state, "api_key_authenticated", False):
                     settings = get_settings_instance()
@@ -366,7 +369,6 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                             "must_change_password": current_user.must_change_password,
                         }
                     )
-                break
 
         except Exception as e:
             logger.error(f"Database error during user validation: {e}")

--- a/backend/src/tests/unit/core/test_auth_middleware_session_lifecycle.py
+++ b/backend/src/tests/unit/core/test_auth_middleware_session_lifecycle.py
@@ -1,0 +1,241 @@
+"""Session-lifecycle tests for AuthenticationMiddleware.
+
+These tests assert that the middleware closes its database session by the time
+``dispatch()`` returns. They were written to verify the fix for a pool-leak
+class of bug:
+
+    async for db in get_db():       # WRONG — suspends the generator
+        ...
+        break                       #         session.close() deferred to GC
+
+vs.
+
+    async with get_async_session_local()() as db:   # CORRECT — close on exit
+        ...
+
+When the generator is left suspended by ``break``, ``session.close()`` does
+not run synchronously — it is deferred to asyncio's asyncgen finalizer hook
+and, under load or cancellation pressure, the ``_ConnectionFairy`` may be
+GC'd before the finalizer runs, producing the
+``non-checked-in connection found in GC`` warnings observed in production.
+This test asserts the close happens synchronously, which is true if and only
+if the middleware uses the ``async with`` pattern.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from shu.auth.jwt_manager import JWTManager
+from shu.core.middleware import AuthenticationMiddleware
+
+
+def _make_request(path: str, method: str, auth_header: str | None) -> Request:
+    """Build a minimal Starlette Request, optionally with an Authorization header."""
+    headers: list[tuple[bytes, bytes]] = []
+    if auth_header is not None:
+        headers.append((b"authorization", auth_header.encode()))
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": b"",
+        "headers": headers,
+        "root_path": "",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+    }
+    return Request(scope)
+
+
+async def _ok_handler(request: Request) -> Response:
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+@pytest.fixture
+def session_tracker(monkeypatch):
+    """Patch ``get_async_session_local`` to return a factory that tracks every
+    session's create/close events.
+
+    Both code paths route through this factory:
+
+    - Old code: ``get_db()`` calls ``get_async_session_local()`` then
+      ``async with session_local() as session:``.
+    - New code: ``async with get_async_session_local()() as db:``.
+
+    Either path will produce a TrackingSession; the difference is *when*
+    close() is invoked relative to the middleware's dispatch returning.
+    """
+    stats = {"created": 0, "closed": 0, "open": []}
+
+    stub_user = SimpleNamespace(
+        id="test-user-id",
+        email="test@example.com",
+        name="Test User",
+        role="admin",
+        is_active=True,
+        must_change_password=False,
+        password_changed_at=None,
+        # last_login set to today so _update_daily_login is a no-op (no commit needed)
+        last_login=datetime.now(UTC),
+    )
+
+    class TrackingSession:
+        def __init__(self) -> None:
+            stats["created"] += 1
+            stats["open"].append(self)
+            self._closed = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            await self.close()
+            return False
+
+        async def execute(self, stmt, *args, **kwargs):
+            result = MagicMock()
+            result.scalar_one_or_none = lambda: stub_user
+            return result
+
+        async def commit(self) -> None:
+            pass
+
+        async def rollback(self) -> None:
+            pass
+
+        async def close(self) -> None:
+            if not self._closed:
+                stats["closed"] += 1
+                stats["open"].remove(self)
+                self._closed = True
+
+    def factory():
+        return TrackingSession()
+
+    # Patch where the middleware (and get_db) looks it up. Both the old and
+    # the fixed middleware import `get_async_session_local` lazily inside
+    # dispatch(), so a single patch covers both code paths.
+    monkeypatch.setattr("shu.core.database.get_async_session_local", lambda: factory)
+
+    return stats
+
+
+@pytest.fixture
+def valid_bearer_token() -> str:
+    """A real, valid JWT signed with the test JWT_SECRET_KEY from conftest."""
+    jwt_mgr = JWTManager()
+    return jwt_mgr.create_access_token(
+        {
+            "user_id": "test-user-id",
+            "email": "test@example.com",
+            "role": "admin",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_closes_session_synchronously(session_tracker, valid_bearer_token):
+    """The DB session must be closed by the time dispatch() returns.
+
+    This is the regression guard for the ``async for db in get_db(): break``
+    anti-pattern. With that pattern, the generator is suspended at break time
+    and ``session.close()`` is deferred to GC. With the ``async with`` fix,
+    close is synchronous.
+    """
+    middleware = AuthenticationMiddleware(app=AsyncMock())
+    request = _make_request("/api/v1/some-protected", "GET", f"Bearer {valid_bearer_token}")
+
+    response = await middleware.dispatch(request, _ok_handler)
+
+    assert response.status_code == 200
+    assert session_tracker["created"] >= 1, "middleware should have opened at least one session"
+    assert session_tracker["closed"] == session_tracker["created"], (
+        f"orphan session(s) detected after dispatch returned: "
+        f"created={session_tracker['created']}, closed={session_tracker['closed']}, "
+        f"open={len(session_tracker['open'])}. The middleware did not close its DB "
+        f"session synchronously — this is the pre-fix async-for/break pattern."
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_closes_session_on_early_return(session_tracker, monkeypatch):
+    """Early returns (e.g. inactive user → 400) must also close the session.
+
+    Equally important as the happy path: with ``async for db in get_db(): return ...``,
+    the early return suspends the generator just like ``break`` does. The
+    ``async with`` pattern handles early returns correctly via ``__aexit__``.
+    """
+    # Make the stub user inactive — middleware returns 400 mid-block.
+    inactive_user = SimpleNamespace(
+        id="test-user-id",
+        email="test@example.com",
+        name="Test User",
+        role="admin",
+        is_active=False,  # <-- forces early return
+        must_change_password=False,
+        password_changed_at=None,
+        last_login=datetime.now(UTC),
+    )
+
+    def factory():
+        # Reuse the TrackingSession class via a fresh factory that returns
+        # the inactive user from execute().
+        stats = session_tracker
+
+        class InactiveTrackingSession:
+            def __init__(self) -> None:
+                stats["created"] += 1
+                stats["open"].append(self)
+                self._closed = False
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                await self.close()
+                return False
+
+            async def execute(self, stmt, *args, **kwargs):
+                result = MagicMock()
+                result.scalar_one_or_none = lambda: inactive_user
+                return result
+
+            async def commit(self) -> None:
+                pass
+
+            async def rollback(self) -> None:
+                pass
+
+            async def close(self) -> None:
+                if not self._closed:
+                    stats["closed"] += 1
+                    stats["open"].remove(self)
+                    self._closed = True
+
+        return InactiveTrackingSession()
+
+    monkeypatch.setattr("shu.core.database.get_async_session_local", lambda: factory)
+
+    jwt_mgr = JWTManager()
+    token = jwt_mgr.create_access_token(
+        {"user_id": "test-user-id", "email": "test@example.com", "role": "admin"}
+    )
+
+    middleware = AuthenticationMiddleware(app=AsyncMock())
+    request = _make_request("/api/v1/some-protected", "GET", f"Bearer {token}")
+
+    response = await middleware.dispatch(request, _ok_handler)
+
+    assert response.status_code == 400, "inactive user should produce 400"
+    assert session_tracker["closed"] == session_tracker["created"], (
+        f"orphan session on early-return path: created={session_tracker['created']}, "
+        f"closed={session_tracker['closed']}"
+    )


### PR DESCRIPTION
## Background

There was a report that `shu-api` was spamming its logs with SQLAlchemy `non-checked-in connection found in GC` warnings after merging SHU-759 onto their branch. The hand-off pointed at SHU-759 (the chat-streaming DB session refactor) and SHU-731 (memory hardening with aggressive `gc.collect()`) as the likely regressions, because the symptom appeared after those merges.

## Investigation

Walked the SHU-759 and SHU-731 diffs and audited every DB-session-acquiring call site on the branch:

- **Chat streaming** (`services/chat_streaming.py`): clean — sessions are acquired via `async with session_factory() as session:` for the finalize phase only, exactly as SHU-759 intended.
- **All 7 `get_db_session()` background-task callers**: clean — every one wraps in `try: ... finally: try: await db.close() except: pass`.
- **Worker (`worker.py` + all `WorkloadType` handlers)**: clean — all use `async with session_local()`.
- **Scheduler service** (`scheduler_service.py:598`): clean.

Wired up a diagnostic switch (`SHU_DB_POOL_DEBUG=1`, separate commit) that lifts `sqlalchemy.pool` to DEBUG without echoing duplicate handlers, then reproduced normal usage locally. Pool checkout/checkin balanced 551/551, no warnings.

## Root cause

`AuthenticationMiddleware.dispatch()` acquired its session with the FastAPI DI idiom misused outside DI:

```python
async for db in get_db():
    ...
    break
```

The `break` exits the loop without driving the generator to completion, leaving `get_db()` **suspended at the `yield`**. The generator's `finally: await session.close()` never runs synchronously — it's queued onto asyncio's asyncgen-finalizer hook, which under GC pressure can be destroyed before it runs, orphaning the `_ConnectionFairy`. That's the source of the GC warnings.

`git log -S "async for db in get_db"` shows the pattern has been in `middleware.py` **since the initial commit**. It's not a SHU-759 or SHU-731 regression; it's a latent bug both branches surfaced — SHU-731's periodic `gc.collect()` in particular accelerates the race between asyncgen finalization and GC. This middleware runs on every authenticated request, which matches the "spamming" description; on pre-SHU-731 builds the same leak was happening silently.

## Fix

Replace `async for db in get_db(): ... break` with `async with get_async_session_local()() as db:` and drop the `break`. The context manager's `__aexit__` runs synchronously on every exit path (normal return, early `JSONResponse` return, exception, anyio cancellation) and calls `session.close()` before `dispatch()` returns.

## Verification

A/B-tested the fix by stashing it and running a new regression test against the old code:

| State | Result |
|---|---|
| Buggy middleware (`async for ... break`) | ❌ Test fails: `created=1, closed=0`; pytest teardown reports `<async_generator_athrow>: Task was destroyed but it is pending` |
| Fixed middleware (`async with`) | ✅ Test passes |

The teardown error is the same failure mode as the production warning, reproduced deterministically in the test runner — strong evidence this code path is the culprit, not just a plausible suspect.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Referenced tickets #SHU-759 & SHU-731

## Testing
- [x] Unit tests added/updated
- [x] `pytest backend/src/tests/unit/core/test_auth_middleware_session_lifecycle.py` — both tests pass on the fix, both fail when the fix is reverted
- [x] Existing middleware tests still pass

### Linting

- [x] Pre-commit hooks pass
- [x] CI linting checks pass
- [x] No linting warnings ignored without justification

### Documentation

- [x] Code comments added where needed
- [N/A] README updated (if applicable)
- [N/A] API docs updated (if applicable)
- [N/A] Migration guide provided (if breaking change)

### Security

- [ ] No hardcoded secrets or credentials
- [ ] No sensitive data in logs
- [ ] Input validation added
- [ ] Authentication/authorization checked

## Reviewer Notes
<!-- Anything specific you want reviewers to focus on? -->

---

**By submitting this PR, I confirm that:**

- [x] I have run `make lint-fix` and all linting checks pass
- [x] I have tested my changes locally
- [x] I have followed the coding standards in `docs/policies/DEVELOPMENT_STANDARDS.md`
- [x] I have read and followed the linting policy in `docs/policies/LINTING_POLICY.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection cleanup in the authentication process to prevent orphaned connections during cancellation or high-load scenarios.

* **Tests**
  * Added tests verifying proper session lifecycle management in authentication middleware.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/161)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->