### PR TITLE
feat: [SHU-784] soft user-limit enforcement + Resend backend support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -829,6 +829,21 @@ SHU_STRIPE_USAGE_REPORT_INTERVAL=3600
 # Included tokens per user per month (informational; actual credits in Stripe)
 SHU_STRIPE_INCLUDED_TOKENS_PER_USER=0
 
+# Initial seat-enforcement mode written to `billing_state.user_limit_enforcement`
+# on the very first startup against a fresh DB. Sticky after that — operator
+# overrides via DB UPDATE survive restarts. Unset/empty → app falls back to a
+# heuristic (`hard` when Stripe is configured, `none` otherwise).
+#
+# Valid values:
+#   hard   Block over-limit registrations with 403. Safe default for billed
+#          deployments — prevents accidental seat-count overruns.
+#   soft   Allow over-limit registrations but force the new user inactive
+#          regardless of SHU_AUTO_ACTIVATE_USERS, so the admin must approve
+#          the over-limit signup. Use this for sandbox / friendly-customer
+#          deployments where blocking registration is too aggressive.
+#   none   No enforcement. Self-hosted / unbilled default.
+# SHU_USER_LIMIT_ENFORCEMENT_DEFAULT=
+
 
 # =============================================================================
 # DEVELOPMENT CONFIGURATION

--- a/backend/src/shu/api/auth.py
+++ b/backend/src/shu/api/auth.py
@@ -272,6 +272,7 @@ async def register_user(
         is_first_user = await user_service.is_first_user(db)
 
         # Enforce user limit (skip for the very first user bootstrapping the instance)
+        over_limit_soft = False
         if not is_first_user:
             limit_status = await check_user_limit(db)
             if limit_status.at_limit and limit_status.enforcement == "hard":
@@ -284,6 +285,11 @@ async def register_user(
                     "User registered above subscription limit",
                     extra={"current_users": limit_status.current_count, "limit": limit_status.user_limit},
                 )
+                # SHU-784: force admin approval on the over-limit user even if
+                # SHU_AUTO_ACTIVATE_USERS=true. Without this override, soft
+                # enforcement degenerates to `none` whenever auto-activate is
+                # on. Below the limit, operator policy still applies.
+                over_limit_soft = True
 
         user_role = user_service.determine_user_role(request.email, is_first_user)
         is_admin = user_role == UserRole.ADMIN
@@ -310,6 +316,7 @@ async def register_user(
                 admin_created=False,
                 requires_email_verification=True,
                 flush_only=True,
+                force_inactive=over_limit_soft,
             )
             verification_service = get_email_verification_service_dependency()
             await verification_service.issue_token(user, db)

--- a/backend/src/shu/api/auth.py
+++ b/backend/src/shu/api/auth.py
@@ -1173,6 +1173,14 @@ async def _seat_charge_preview(
       second check would see the just-flushed/updated user and falsely
       conclude an upgrade is needed even when the new user fits an open
       seat.
+
+    Fires under BOTH ``hard`` and ``soft`` enforcement (SHU-784): admin-
+    initiated writes (create user, activate pending user) are always a
+    deliberate "I want to consume a seat" action, so the Stripe upgrade
+    must be an informed admin confirmation regardless of self-registration
+    leniency. The only behavioral difference between hard and soft is
+    self-registration: hard blocks at 403; soft allows but lands inactive.
+    Skipped under ``none`` (no Stripe sub configured).
     """
     if seat_service is None:
         return None, False
@@ -1180,7 +1188,7 @@ async def _seat_charge_preview(
         limit_status = await check_user_limit(db)
     except StripeClientError as e:
         _raise_seat_error_http(e)
-    if not (limit_status.at_limit and limit_status.enforcement == "hard"):
+    if not (limit_status.at_limit and limit_status.enforcement in ("hard", "soft")):
         return None, False
 
     if confirm_header != "true":

--- a/backend/src/shu/auth/password_auth.py
+++ b/backend/src/shu/auth/password_auth.py
@@ -137,6 +137,7 @@ class PasswordAuthService:
         admin_created: bool = False,
         flush_only: bool = False,
         requires_email_verification: bool = False,
+        force_inactive: bool = False,
     ) -> User:
         """Create a new user with password authentication.
 
@@ -151,6 +152,14 @@ class PasswordAuthService:
         user clicks the verification link. Only meaningful for self-
         registration; admin-created accounts are vouched-for and skip
         verification entirely.
+
+        ``force_inactive=True`` (SHU-784) overrides the auto-activate
+        branch in the verification path to land `is_active=False`. Used
+        by the soft user-limit enforcement at_limit branch — over-limit
+        registrations must require admin approval even when the operator
+        has set ``SHU_AUTO_ACTIVATE_USERS=true``, otherwise soft
+        enforcement is indistinguishable from `none`. No effect on the
+        admin-created or legacy (no-email-backend) paths.
         """
         # Check if user already exists
         stmt = select(User).where(User.email == email)
@@ -179,7 +188,12 @@ class PasswordAuthService:
             # When True, the operator has explicitly trusted email
             # verification as sufficient activation signal, and verifying
             # flips the only remaining gate.
-            is_active = bool(self.settings.auto_activate_users)
+            #
+            # SHU-784: `force_inactive` overrides the auto-activate
+            # decision when the caller knows this signup violates a
+            # billing constraint (soft enforcement + at_limit). Below
+            # the limit, operator policy still wins.
+            is_active = False if force_inactive else bool(self.settings.auto_activate_users)
             email_verified = False
         else:
             role = "regular_user"  # Force regular_user role for self-registration

--- a/backend/src/shu/billing/config.py
+++ b/backend/src/shu/billing/config.py
@@ -86,6 +86,14 @@ class BillingSettings(BaseSettings):
     # This is for informational purposes; actual credits are in Stripe product config
     included_tokens_per_user: int = Field(0, alias="SHU_STRIPE_INCLUDED_TOKENS_PER_USER")
 
+    # Initial seat-enforcement mode written to `billing_state.user_limit_enforcement`
+    # on the very first startup against a fresh DB (see main.py startup seed).
+    # Operator overrides via DB UPDATE survive restarts. `None` → fall back to
+    # the built-in default (`hard` when `is_configured`, else `none`).
+    user_limit_enforcement_default: Literal["soft", "hard", "none"] | None = Field(
+        None, alias="SHU_USER_LIMIT_ENFORCEMENT_DEFAULT"
+    )
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/backend/src/shu/billing/enforcement.py
+++ b/backend/src/shu/billing/enforcement.py
@@ -149,11 +149,12 @@ async def check_user_limit(
     if user_limit == 0:
         return _NO_LIMIT
 
-    # `soft` is a legal legacy column value with no behavior distinct from
-    # `hard` today; collapse to `none` so callers don't need to special-case.
+    # `soft` is preserved as a distinct mode (SHU-784): registration is
+    # allowed past the seat limit, but the warn-and-proceed path in
+    # `api/auth.py` logs the over-limit event and the new user lands
+    # inactive via the normal `SHU_AUTO_ACTIVATE_USERS=false` path. Admins
+    # decide whether to bring the user on. `hard` still blocks at 403.
     enforcement = billing_config.get("user_limit_enforcement", "soft")
-    if enforcement == "soft":
-        enforcement = "none"
 
     if enforcement == "hard":
         # Serialise concurrent user-creation requests at the DB level.

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -295,17 +295,20 @@ async def lifespan(app: FastAPI):  # noqa: PLR0912, PLR0915
         async with session_maker() as session:
             async with session.begin():
                 _, inserted = await BillingStateService.ensure_singleton(session)
-            # SHU-730: seed enforcement mode exactly once per deployment. Only
-            # writes when the singleton was freshly inserted so operator edits
-            # survive restarts. `is_configured` is our proxy for "hosted +
-            # billed", where hard enforcement is the safe default; self-hosted
-            # stays `none`.
+            # SHU-730 / SHU-784: seed enforcement mode exactly once per
+            # deployment. Only writes when the singleton was freshly inserted
+            # so operator edits survive restarts. Explicit operator override
+            # via SHU_USER_LIMIT_ENFORCEMENT_DEFAULT wins; otherwise
+            # `is_configured` is our proxy for "hosted + billed", where hard
+            # enforcement is the safe default; self-hosted stays `none`.
             if inserted:
+                if billing_settings.user_limit_enforcement_default is not None:
+                    enforcement_seed = billing_settings.user_limit_enforcement_default
+                else:
+                    enforcement_seed = "hard" if billing_settings.is_configured else "none"
                 await BillingStateService.update(
                     session,
-                    updates={
-                        "user_limit_enforcement": "hard" if billing_settings.is_configured else "none",
-                    },
+                    updates={"user_limit_enforcement": enforcement_seed},
                     source="startup:seed_enforcement",
                 )
             await BillingStateService.seed_from_config(session, billing_settings)

--- a/backend/src/shu/services/providers/adapters/responses_adapter.py
+++ b/backend/src/shu/services/providers/adapters/responses_adapter.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import jmespath
 
+from shu.core.logging import get_logger
 from shu.core.safe_decimal import safe_decimal
 from shu.models.plugin_execution import CallableTool
 
@@ -22,6 +23,8 @@ from ..adapter_base import (
     ProviderToolCallEventResult,
     ToolCallInstructions,
 )
+
+logger = get_logger(__name__)
 
 
 class ResponsesAdapter(BaseProviderAdapter):
@@ -140,6 +143,40 @@ class ResponsesAdapter(BaseProviderAdapter):
                 content=f"Got incomplete response from provider because '{incomplete_response}'"
             )
 
+        # Mid-stream terminal failure events — OpenAI Responses can emit
+        # `response.failed` (server-side failure with structured error) or a
+        # top-level `error` SSE event (rate limit, transient backend, content
+        # filter, etc.). Without explicit handlers these chunks fall through
+        # to `return None`, the SSE iteration ends with no terminal event,
+        # and the chat-streaming loop surfaces a generic "NoFinalMessage"
+        # error that hides the actual cause.
+        failed_message = jmespath.search(
+            "type=='response.failed' && (response.error.message || response.error.code || response.incomplete_details.reason)",
+            chunk,
+        )
+        if failed_message:
+            response_id = jmespath.search("response.id", chunk)
+            error_code = jmespath.search("response.error.code", chunk)
+            logger.error(
+                "Responses stream returned response.failed | response_id=%s code=%s message=%s",
+                response_id,
+                error_code,
+                failed_message,
+            )
+            return ProviderErrorEventResult(content=f"Provider reported response.failed: {failed_message}")
+
+        top_level_error = jmespath.search("type=='error' && (error.message || message)", chunk)
+        if top_level_error:
+            error_code = jmespath.search("error.code || code", chunk)
+            error_type = jmespath.search("error.type || type", chunk)
+            logger.error(
+                "Responses stream returned top-level error event | type=%s code=%s message=%s",
+                error_type,
+                error_code,
+                top_level_error,
+            )
+            return ProviderErrorEventResult(content=f"Provider stream error: {top_level_error}")
+
         function_call_reasoning_result = jmespath.search(
             "type=='response.output_item.done' && item.type=='reasoning' && item", chunk
         )
@@ -186,6 +223,33 @@ class ResponsesAdapter(BaseProviderAdapter):
 
             if final_text:
                 return ProviderFinalEventResult(content=final_text, metadata={"usage": self.usage})
+
+            # response.completed arrived but we found neither an extractable
+            # text item nor any streamed deltas. Without a final event the
+            # chat-streaming loop falls through to a generic NoFinalMessage;
+            # log the relevant fields and surface a real error instead.
+            # Skip when the stream has function_call follow-up work either
+            # already captured on this adapter or embedded in this chunk's
+            # response.output — those continue through finalize_provider_events.
+            # Reasoning items alone do not count: a response.completed whose
+            # only output is a reasoning item has no path to a final answer
+            # (no text to surface, no function_call to bounce off of), and
+            # silently swallowing it would surface as a generic NoFinalMessage.
+            chunk_output = (chunk.get("response") or {}).get("output") or []
+            has_chunk_function_call = any(
+                isinstance(it, dict) and it.get("type") == "function_call" for it in chunk_output
+            )
+            if not self.function_call_messages and not has_chunk_function_call:
+                response_id = jmespath.search("response.id", chunk)
+                output_item_types = [it.get("type") for it in chunk_output if isinstance(it, dict)]
+                logger.error(
+                    "Responses stream completed with no extractable content | response_id=%s output_item_types=%s",
+                    response_id,
+                    output_item_types,
+                )
+                return ProviderErrorEventResult(
+                    content="Provider returned response.completed with no text content and no tool calls."
+                )
 
         return None
 
@@ -419,20 +483,10 @@ class ResponsesAdapter(BaseProviderAdapter):
 
             return {"role": role, "content": content_parts if content_parts else content}
 
-        # Assistant text replayed in a follow-up turn is sent as an explicit
-        # output_text content part with annotations=[]. OpenAI's documented schema
-        # (ResponseOutputTextParam) declares `annotations` as Required; the bare
-        # {"role":"assistant","content":"text"} shortcut works against the OpenAI
-        # API because their server normalizes for us, but the explicit form is the
-        # spec-correct wire payload and is accepted by every OpenAI-Responses-API
-        # provider that conforms to the documented schema.
-        if role == "assistant" and isinstance(content, str) and content:
-            return {
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": content, "annotations": []}],
-            }
-
-        # Standard role/content message
+        # Standard role/content message — bare string content. Verified
+        # against OpenAI, OpenRouter, and (for non-Gemma models) DigitalOcean
+        # on /v1/responses, single- and multi-turn, with prior-turn context
+        # preserved across the assistant replay.
         return {"role": role, "content": content}
 
     async def set_messages_in_payload(self, messages: ChatContext, payload: dict[str, Any]) -> dict[str, Any]:

--- a/backend/src/shu/services/user_service.py
+++ b/backend/src/shu/services/user_service.py
@@ -305,6 +305,7 @@ class UserService:
 
         # Enforce user limit (skip for the very first user bootstrapping the instance)
         soft_limit_info: dict[str, int] | None = None
+        over_limit_soft = False
         if not is_first_user:
             from shu.billing.enforcement import check_user_limit
 
@@ -316,9 +317,19 @@ class UserService:
                 )
             if limit_status.at_limit and limit_status.enforcement == "soft":
                 soft_limit_info = {"current_users": limit_status.current_count, "limit": limit_status.user_limit}
+                over_limit_soft = True
 
         user_role = self.determine_user_role(email, is_first_user)
-        is_active = self.is_active(user_role, is_first_user)
+        # SHU-784: when soft enforcement reports at_limit, force the
+        # non-admin signup inactive even if `SHU_AUTO_ACTIVATE_USERS=true`,
+        # else soft enforcement degenerates to `none`. Admins still land
+        # active (the email is operator-vouched via `admin_emails`).
+        # `over_limit_soft` is only True when the limit check ran — which
+        # only happens for `not is_first_user` — so no first-user guard.
+        if over_limit_soft and user_role != UserRole.ADMIN:
+            is_active = False
+        else:
+            is_active = self.is_active(user_role, is_first_user)
 
         user = User(
             email=email,

--- a/backend/src/tests/unit/api/test_auth_seat_preflight.py
+++ b/backend/src/tests/unit/api/test_auth_seat_preflight.py
@@ -404,6 +404,86 @@ class TestCreateUserPreflight:
         seat_service.confirm_upgrade.assert_not_awaited()
         db.rollback.assert_awaited()
 
+    @pytest.mark.asyncio
+    async def test_soft_at_limit_triggers_preflight_same_as_hard(self):
+        """SHU-784: admin-create under soft + at_limit must still 402.
+
+        Soft only changes self-registration leniency. Admin-initiated writes
+        are deliberate seat purchases and must remain informed actions —
+        the Stripe upgrade preview fires identically under hard and soft.
+        Without this, admin-creates under soft silently bypass Stripe and
+        the seat count desyncs from the active user count.
+        """
+        request = CreateUserRequest(
+            email="new@example.com", password="pw12345678", name="New", auth_method="password"
+        )
+        db = AsyncMock()
+        current_user = MagicMock()
+        seat_service = _make_seat_service(preview=_make_preview())
+
+        with patch(
+            "shu.api.auth.check_user_limit",
+            return_value=UserLimitStatus(
+                enforcement="soft", at_limit=True, current_count=3, user_limit=3
+            ),
+        ):
+            response = await create_user(
+                request,
+                current_user=current_user,
+                db=db,
+                user_service=_make_user_service(),
+                seat_service=seat_service,
+                x_seat_charge_confirmed=None,
+            )
+
+        assert response.status_code == 402
+        body = _parse_envelope(response)
+        assert body["error"]["code"] == "seat_limit_reached"
+        seat_service.confirm_upgrade.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_none_at_limit_skips_preflight(self):
+        """Enforcement `none` (self-hosted / unbilled) bypasses the preflight.
+
+        Counterpart to the soft+hard coverage above — `none` is the only
+        enforcement value that should NOT trigger the Stripe upgrade prompt.
+        """
+        request = CreateUserRequest(
+            email="self-hosted@example.com",
+            password="pw12345678",
+            name="SH",
+            auth_method="password",
+        )
+        db = AsyncMock()
+        current_user = MagicMock()
+        seat_service = _make_seat_service()
+
+        mock_user = MagicMock()
+        mock_user.to_dict.return_value = {"email": "self-hosted@example.com"}
+
+        with (
+            patch(
+                "shu.api.auth.check_user_limit",
+                return_value=UserLimitStatus(
+                    enforcement="none", at_limit=True, current_count=99, user_limit=0
+                ),
+            ),
+            patch("shu.api.auth.password_auth_service") as mock_pw,
+        ):
+            mock_pw.create_user = AsyncMock(return_value=mock_user)
+            response = await create_user(
+                request,
+                current_user=current_user,
+                db=db,
+                user_service=_make_user_service(),
+                seat_service=seat_service,
+                x_seat_charge_confirmed=None,
+            )
+
+        assert response.data["email"] == "self-hosted@example.com"
+        seat_service.confirm_upgrade.assert_not_awaited()
+        seat_service.preview_upgrade.assert_not_awaited()
+
 
 class TestActivateUserPreflight:
     @pytest.mark.asyncio
@@ -463,6 +543,44 @@ class TestActivateUserPreflight:
 
         seat_service.preview_upgrade.assert_not_awaited()
         seat_service.confirm_upgrade.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_activate_at_limit_under_soft_still_returns_402(self):
+        """SHU-784: admin-activate of a pending user under soft + at_limit
+        runs the same preflight as hard.
+
+        Self-registration over the limit lands inactive under soft (no
+        Stripe write). When the admin then activates that user, the user
+        is moving into a billable seat — Stripe must be consulted so the
+        admin sees the charge before confirming.
+        """
+        db = AsyncMock()
+        current_user = MagicMock()
+        seat_service = _make_seat_service(preview=_make_preview())
+
+        mock_user = MagicMock()
+        mock_user.is_active = False
+        user_service = MagicMock()
+        user_service.get_user_by_id = AsyncMock(return_value=mock_user)
+
+        with patch(
+            "shu.api.auth.check_user_limit",
+            return_value=UserLimitStatus(
+                enforcement="soft", at_limit=True, current_count=3, user_limit=3
+            ),
+        ):
+            response = await activate_user(
+                "42",
+                current_user=current_user,
+                db=db,
+                user_service=user_service,
+                seat_service=seat_service,
+                x_seat_charge_confirmed=None,
+            )
+
+        assert response.status_code == 402
+        body = _parse_envelope(response)
+        assert body["error"]["code"] == "seat_limit_reached"
 
 
 class TestUpdateUserPreflight:

--- a/backend/src/tests/unit/auth/test_password_auth.py
+++ b/backend/src/tests/unit/auth/test_password_auth.py
@@ -578,3 +578,30 @@ class TestCreateUserVerificationActivationComposition:
         # gate remains.
         assert user.is_active is True
         assert user.email_verified is False
+
+    @pytest.mark.asyncio
+    async def test_force_inactive_overrides_auto_activate_true(
+        self, mock_settings_moderate, mock_db: AsyncMock
+    ) -> None:
+        """SHU-784: soft enforcement at_limit must override auto_activate=true.
+
+        Without the override, an over-limit signup with auto-activate on would
+        land active after email verification, making soft enforcement
+        indistinguishable from `none`. The caller (api/auth.py register_user)
+        passes ``force_inactive=True`` when ``check_user_limit`` returns
+        ``soft + at_limit``.
+        """
+        service = self._service(mock_settings_moderate, auto_activate=True)
+        user = await service.create_user(
+            email="new@example.com",
+            password="ValidPass1!",
+            name="New User",
+            db=mock_db,
+            requires_email_verification=True,
+            flush_only=True,
+            force_inactive=True,
+        )
+        # Admin must approve the over-limit user even though operator
+        # set SHU_AUTO_ACTIVATE_USERS=true.
+        assert user.is_active is False
+        assert user.email_verified is False

--- a/backend/src/tests/unit/billing/test_enforcement.py
+++ b/backend/src/tests/unit/billing/test_enforcement.py
@@ -11,7 +11,6 @@ from shu.billing.enforcement import (
     UserLimitStatus,
     assert_subscription_active,
     check_user_limit,
-    get_current_billing_state,
 )
 
 _P_BILLING_CONFIG = "shu.billing.enforcement.get_billing_config"
@@ -70,11 +69,13 @@ class TestCheckUserLimit:
     @pytest.mark.asyncio
     @patch(_P_ACTIVE_USER_COUNT)
     @patch(_P_BILLING_CONFIG)
-    async def test_soft_enforcement_is_treated_as_none(self, mock_config, mock_count):
-        """`soft` is a legal legacy value but always normalises to `none`.
+    async def test_soft_enforcement_preserved_with_accurate_at_limit(self, mock_config, mock_count):
+        """`soft` is returned as-is (SHU-784) with `at_limit` reflecting reality.
 
-        B1 disables `soft` until it has a real behavior separate from `hard`
-        — legacy rows with soft-set values must not block or warn.
+        Caller in `api/auth.py` reads `enforcement=soft + at_limit` and logs
+        a warning while letting registration proceed — the new user lands
+        inactive via the SHU_AUTO_ACTIVATE_USERS=false default. Unlike `hard`,
+        no row-level lock is acquired (no enforcement → no serialization need).
         """
         mock_config.return_value = {
             "stripe_subscription_id": "sub_123",
@@ -85,15 +86,20 @@ class TestCheckUserLimit:
 
         result = await check_user_limit(db, _stripe_client_with_seats(5))
 
-        assert result.enforcement == "none"
+        assert result.enforcement == "soft"
         assert result.at_limit is True
         assert result.current_count == 5
+        assert result.user_limit == 5
 
     @pytest.mark.asyncio
     @patch(_P_ACTIVE_USER_COUNT)
     @patch(_P_BILLING_CONFIG)
-    async def test_default_enforcement_is_normalised_to_none(self, mock_config, mock_count):
-        """Missing `user_limit_enforcement` defaults to `soft` → normalised to `none`."""
+    async def test_default_enforcement_is_soft(self, mock_config, mock_count):
+        """Missing `user_limit_enforcement` in billing_config defaults to `soft`.
+
+        Matches the `billing_state.user_limit_enforcement` column default;
+        adapters surface it as-is rather than substituting another value.
+        """
         mock_config.return_value = {
             "stripe_subscription_id": "sub_123",
         }
@@ -102,7 +108,8 @@ class TestCheckUserLimit:
 
         result = await check_user_limit(db, _stripe_client_with_seats(5))
 
-        assert result.enforcement == "none"
+        assert result.enforcement == "soft"
+        assert result.at_limit is False
 
     @pytest.mark.asyncio
     @patch(_P_STATE_SERVICE, new_callable=AsyncMock)

--- a/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
+++ b/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
@@ -21,6 +21,7 @@ from shu.services.providers import adapter_base
 from shu.services.providers.adapter_base import (
     ProviderAdapterContext,
     ProviderContentDeltaEventResult,
+    ProviderErrorEventResult,
     ProviderFinalEventResult,
     ProviderReasoningDeltaEventResult,
     ProviderToolCallEventResult,
@@ -265,11 +266,18 @@ async def test_inject_functions(responses_adapter):
 
 
 @pytest.mark.asyncio
-async def test_assistant_string_content_is_wrapped_with_annotations(responses_adapter):
-    """Prior-turn assistant text replays as an explicit output_text content part with
-    annotations=[]. OpenAI's documented ResponseOutputTextParam declares annotations
-    as required; the bare-string shortcut is accepted by OpenAI's server-side
-    normalization but is not the spec-correct wire form.
+async def test_assistant_string_content_is_sent_as_bare_string(responses_adapter):
+    """Prior-turn assistant text replays as a bare-string ``content`` value.
+
+    Verified empirically (scripts/responses_replay_probe.sh) against OpenAI,
+    OpenRouter, and DigitalOcean (non-Gemma) on /v1/responses, single- and
+    multi-turn, with prior-turn context preserved.
+
+    Wrapping the assistant text as an ``output_text`` content part with
+    ``annotations: []`` (the c4eeb0f shape) breaks OpenRouter on turn 2+ with
+    ``invalid_prompt``; wrapping as ``input_text`` breaks OpenAI on turn 2+
+    with "Supported values are: 'output_text' and 'refusal'." Bare string is
+    the only shape accepted across every conformant Responses provider.
     """
     messages = ChatContext.from_dicts(
         [
@@ -284,9 +292,79 @@ async def test_assistant_string_content_is_wrapped_with_annotations(responses_ad
 
     assert payload["input"] == [
         {"role": "user", "content": "first question"},
-        {
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": "first answer", "annotations": []}],
-        },
+        {"role": "assistant", "content": "first answer"},
         {"role": "user", "content": "follow up"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_response_failed_event_emits_error(responses_adapter):
+    """A `response.failed` SSE chunk surfaces as a ProviderErrorEventResult with the cause.
+
+    Without this branch the chunk falls through to `return None`, the SSE
+    iteration ends with no terminal event, and the chat-streaming loop
+    raises a generic "NoFinalMessage" error that hides the real failure.
+    """
+    chunk = {
+        "type": "response.failed",
+        "response": {
+            "error": {"code": "server_error", "message": "Backend is having a bad day"},
+        },
+    }
+    result = await responses_adapter.handle_provider_event(chunk)
+    assert isinstance(result, ProviderErrorEventResult)
+    assert "Backend is having a bad day" in result.content
+
+
+@pytest.mark.asyncio
+async def test_top_level_error_event_emits_error(responses_adapter):
+    """A top-level `error` SSE chunk surfaces as a ProviderErrorEventResult."""
+    chunk = {
+        "type": "error",
+        "error": {"message": "rate limited", "type": "rate_limit"},
+    }
+    result = await responses_adapter.handle_provider_event(chunk)
+    assert isinstance(result, ProviderErrorEventResult)
+    assert "rate limited" in result.content
+
+
+@pytest.mark.asyncio
+async def test_response_completed_with_no_content_emits_error(responses_adapter):
+    """`response.completed` with no text item and no streamed deltas emits an error.
+
+    Previously this silently returned None and bubbled up as a generic
+    NoFinalMessage. If tool calls were captured in this stream the
+    follow-up path handles them, so this only fires when there's truly
+    nothing actionable.
+    """
+    chunk = {
+        "type": "response.completed",
+        "response": {"output": [], "usage": {"input_tokens": 1, "output_tokens": 0}},
+    }
+    result = await responses_adapter.handle_provider_event(chunk)
+    assert isinstance(result, ProviderErrorEventResult)
+    assert "no text content" in result.content
+
+
+@pytest.mark.asyncio
+async def test_response_completed_with_only_reasoning_emits_error(responses_adapter):
+    """`response.completed` with reasoning items but no function_call or text emits an error.
+
+    Reasoning-only completions have no path to a final answer — no text to
+    surface, and no function_call output for the follow-up cycle to bounce
+    off of. Without this, the chat-streaming loop sees zero events and
+    raises a generic NoFinalMessage that hides the real condition.
+    """
+    chunk = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_reasoning_only",
+            "output": [
+                {"id": "rs_only", "type": "reasoning", "summary": []},
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        },
+    }
+    result = await responses_adapter.handle_provider_event(chunk)
+    assert isinstance(result, ProviderErrorEventResult)
+    assert "no text content" in result.content

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#2E5A87" />
     <meta
       name="description"
-      content="Shu - AI Chat Interface with RAG"
+      content="SShu - Alpha - Your private AI"
     />
     <meta name="author" content="Open Shu" />
     <meta name="keywords" content="AI, Chat, Shu, RAG, Knowledge Base" />
@@ -18,13 +18,13 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Shu - AI Chat Interface" />
-    <meta property="og:description" content="Shu - AI Chat Interface with RAG" />
+    <meta property="og:description" content="Shu - Your private AI" />
     <meta property="og:image" content="/favicon-dark.png" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:title" content="Shu - AI Chat Interface" />
-    <meta property="twitter:description" content="Shu - AI Chat Interface with RAG" />
+    <meta property="twitter:description" content="Shu - Your private AI" />
     <meta property="twitter:image" content="/favicon-dark.png" />
 
     <title>Shu</title>

--- a/frontend/src/components/UserManagement.js
+++ b/frontend/src/components/UserManagement.js
@@ -85,7 +85,12 @@ const UserManagement = () => {
     enabled: canManageUsers(),
   });
   const subscription = extractDataFromResponse(subscriptionResponse) || {};
-  const isSeatGateActive = subscription.user_limit_enforcement === 'hard';
+  // SHU-784: seat-management UI is on whenever billing is enforcing seats —
+  // both `hard` and `soft`. The only behavioral difference between the two
+  // modes is self-registration leniency; seat economics (open seats,
+  // release, scheduled deactivation, Stripe upgrade preview on admin
+  // create/activate) apply identically. Only `none` hides the UI.
+  const isSeatGateActive = subscription.user_limit_enforcement !== 'none';
 
   // Treat a 402 seat_limit_reached response as a phase-1 preview instead
   // of an error: pop the consent modal, and remember the retry closure so

--- a/frontend/src/components/__tests__/UserManagement.seat.test.js
+++ b/frontend/src/components/__tests__/UserManagement.seat.test.js
@@ -90,7 +90,7 @@ describe('UserManagement — inline seat affordances (SHU-730)', () => {
     vi.clearAllMocks();
   });
 
-  it('renders no seat UI when user_limit_enforcement is not "hard"', async () => {
+  it('renders no seat UI when user_limit_enforcement is "none"', async () => {
     setupMocks({
       users: [makeUser()],
       subscription: makeSubscription({ user_limit_enforcement: 'none' }),
@@ -102,6 +102,24 @@ describe('UserManagement — inline seat affordances (SHU-730)', () => {
     expect(screen.queryByRole('button', { name: /Schedule deactivation/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Release one open seat/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/open seat/i)).not.toBeInTheDocument();
+  });
+
+  it('renders seat UI when user_limit_enforcement is "soft" (SHU-784)', async () => {
+    // Seat management visible under soft — enforcement mode only controls
+    // self-registration leniency, not whether seat economics apply. The
+    // open-seats counter, release button, and per-row deactivation flag
+    // are the same regardless of hard vs soft.
+    setupMocks({
+      users: [makeUser()],
+      subscription: makeSubscription({ user_limit_enforcement: 'soft' }),
+    });
+    renderComponent();
+
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+
+    expect(screen.getByText(/open seat/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Schedule deactivation on period end/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Release one open seat/i })).toBeInTheDocument();
   });
 
   it('renders flag button on each active row when enforcement is hard', async () => {

--- a/scripts/responses_replay_probe.sh
+++ b/scripts/responses_replay_probe.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Probe four assistant-replay payload shapes against two Responses-compatible
+# providers (OpenAI, OpenRouter). Goal: find a single spec-correct shape that
+# works on both, with the prior turn's text actually visible to the model on
+# turn 2 (not just an HTTP 200).
+#
+# Each variant sends the same two-turn conversation:
+#   turn 1 user:      "My favorite color is purple. Please remember this."
+#   turn 1 assistant: "Got it — your favorite color is purple."   (hardcoded, replayed)
+#   turn 2 user:      "What is my favorite color? Reply with just one word."
+#
+# Pass criteria: HTTP 200 AND the model's turn-2 answer contains "purple".
+# A 200 without "purple" means the assistant turn was structurally accepted
+# but the model didn't see the content — that's a silent context loss and
+# disqualifies the shape.
+#
+# Usage:
+#   export OPENAI_API_KEY=...
+#   export OPENROUTER_API_KEY=...
+#   export DO_API_KEY=...                            # optional; if unset, DO probe is skipped
+#   export XAI_API_KEY=...                           # optional; if unset, xAI probe is skipped
+#   bash scripts/responses_replay_probe.sh
+#
+# Optional overrides:
+#   OPENAI_MODEL=gpt-4.1-nano (default)
+#   OPENROUTER_MODEL=meta-llama/llama-3.3-70b-instruct (default)
+#   DO_MODEL_OS=gemma-4-31B-it (default; the known-quirky cell)
+#   XAI_MODEL (required if XAI_API_KEY set; check https://docs.x.ai for current model ids)
+
+set -uo pipefail
+
+: "${OPENAI_API_KEY:?OPENAI_API_KEY must be set}"
+: "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY must be set}"
+OPENAI_MODEL="${OPENAI_MODEL:-gpt-4.1-nano}"
+OPENROUTER_MODEL="${OPENROUTER_MODEL:-meta-llama/llama-3.3-70b-instruct}"
+DO_MODEL_OS="${DO_MODEL_OS:-qwen3.5-397b-a17b}"
+
+ASSIST="Got it — your favorite color is purple."
+USER1="My favorite color is purple. Please remember this."
+USER2="What is my favorite color? Reply with just one word."
+
+# ANSI helpers
+hr() { printf '\n──── %s ────\n' "$1"; }
+
+# Run one variant against one endpoint.
+# Args: label, endpoint_url, auth_header_value, payload_json
+run_test() {
+  local label="$1"
+  local url="$2"
+  local auth="$3"
+  local payload="$4"
+  local response
+  response=$(curl -sS -X POST "$url" \
+    -H "Authorization: Bearer $auth" \
+    -H "Content-Type: application/json" \
+    -d "$payload")
+
+  # Compact summary: did it 200, did the model say "purple", and the raw answer.
+  echo "$response" | jq -c --arg label "$label" '
+    if .error then
+      {label: $label, http: "FAIL", error: (.error.message // .error)}
+    else
+      ((.output // []) | map(select(.type=="message")) | .[0].content // []) as $c
+      | ($c | map(select(.type=="output_text")) | .[0].text // null) as $answer
+      | {
+          label: $label,
+          http: "OK",
+          context_ok: (($answer // "") | ascii_downcase | contains("purple")),
+          answer: $answer
+        }
+    end'
+}
+
+probe_provider() {
+  local pname="$1" url="$2" auth="$3" model="$4"
+
+  hr "Provider: $pname  Model: $model"
+
+  # A. EasyInputMessage + output_text + annotations:[]  (OpenAI-protocol-correct per its error message)
+  A=$(jq -nc --arg m "$model" --arg t "$ASSIST" --arg u1 "$USER1" --arg u2 "$USER2" '{
+    model: $m,
+    input: [
+      {role:"user", content:$u1},
+      {role:"assistant", content:[{type:"output_text", text:$t, annotations:[]}]},
+      {role:"user", content:$u2}
+    ]
+  }')
+  run_test "A. output_text + annotations:[]" "$url" "$auth" "$A"
+
+  # B. EasyInputMessage + input_text  (vLLM-friendly, rejected by OpenAI)
+  B=$(jq -nc --arg m "$model" --arg t "$ASSIST" --arg u1 "$USER1" --arg u2 "$USER2" '{
+    model: $m,
+    input: [
+      {role:"user", content:$u1},
+      {role:"assistant", content:[{type:"input_text", text:$t}]},
+      {role:"user", content:$u2}
+    ]
+  }')
+  run_test "B. input_text" "$url" "$auth" "$B"
+
+  # C. Full OutputItem (type:"message" + id + status + output_text + annotations:[])
+  C=$(jq -nc --arg m "$model" --arg t "$ASSIST" --arg u1 "$USER1" --arg u2 "$USER2" '{
+    model: $m,
+    input: [
+      {role:"user", content:$u1},
+      {
+        type:"message",
+        id:"msg_probe_001",
+        role:"assistant",
+        status:"completed",
+        content:[{type:"output_text", text:$t, annotations:[]}]
+      },
+      {role:"user", content:$u2}
+    ]
+  }')
+  run_test "C. full OutputItem" "$url" "$auth" "$C"
+
+  # D. Bare-string content shortcut
+  D=$(jq -nc --arg m "$model" --arg t "$ASSIST" --arg u1 "$USER1" --arg u2 "$USER2" '{
+    model: $m,
+    input: [
+      {role:"user", content:$u1},
+      {role:"assistant", content:$t},
+      {role:"user", content:$u2}
+    ]
+  }')
+  run_test "D. bare string" "$url" "$auth" "$D"
+}
+
+probe_provider "OpenAI"     "https://api.openai.com/v1/responses"     "$OPENAI_API_KEY"     "$OPENAI_MODEL"
+probe_provider "OpenRouter" "https://openrouter.ai/api/v1/responses"  "$OPENROUTER_API_KEY" "$OPENROUTER_MODEL"
+
+if [[ -n "${DO_API_KEY:-}" ]]; then
+  probe_provider "DigitalOcean (OS)" "https://inference.do-ai.run/v1/responses" "$DO_API_KEY" "$DO_MODEL_OS"
+else
+  echo
+  echo "(skipping DigitalOcean — set DO_API_KEY to include)"
+fi
+
+if [[ -n "${XAI_API_KEY:-}" ]]; then
+  if [[ -z "${XAI_MODEL:-}" ]]; then
+    echo
+    echo "ERROR: XAI_API_KEY is set but XAI_MODEL is not. Set XAI_MODEL=<grok-id> and re-run."
+  else
+    probe_provider "xAI" "https://api.x.ai/v1/responses" "$XAI_API_KEY" "$XAI_MODEL"
+  fi
+else
+  echo
+  echo "(skipping xAI — set XAI_API_KEY and XAI_MODEL to include)"
+fi
+
+echo
+echo 'Pick the variant whose row reads {http:"OK", context_ok:true} for ALL probed providers.'


### PR DESCRIPTION
Make `user_limit_enforcement=soft` a real mode distinct from `none`: drop the soft→none collapse in check_user_limit so the warn-and-proceed branch in register_user is reachable. Add SHU_USER_LIMIT_ENFORCEMENT_DEFAULT env (Literal-typed) read by the startup seed so the chart can pick the initial billing_state value without a DB write.

Close the SHU_AUTO_ACTIVATE_USERS coherence gap: soft + at_limit must force is_active=False even when auto-activate is on, else soft degenerates to `none`. Wired via a new force_inactive kwarg on PasswordAuthService.create_user (password path) and an explicit over-limit-soft branch in UserService SSO registration. Below-limit signups still honor operator policy on both paths.

Tests: existing test_soft_enforcement_is_treated_as_none flipped to preserve soft semantics; new test_force_inactive_overrides_auto_activate_true locks down the override behavior. Removed a pre-existing unused import flagged by ruff. .env.example documents the new var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable initial user-limit enforcement mode (soft, hard, none) on startup.
  * Seat-management UI now appears for soft enforcement as well as hard.
  * Added provider probe script to validate responses payload variants.

* **Improvements**
  * Soft enforcement preserved and treated distinctly from none across flows.
  * Soft and hard enforcement both trigger seat-charge preflight where applicable.
  * Soft enforcement can keep new non-admin accounts inactive when limits are exceeded.

* **Documentation**
  * Added env setting docs for the new default enforcement option and updated page metadata.

* **Tests**
  * Extended coverage for enforcement, seat preflight, and response-serialization behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->