### PR TITLE
refactor(tests): [SHU-778] route remaining integ-test loggers through…

### DIFF
--- a/backend/src/tests/integ/baseline/_setup.py
+++ b/backend/src/tests/integ/baseline/_setup.py
@@ -7,15 +7,15 @@ shared setup so the runners stay focused on their measurement logic.
 
 from __future__ import annotations
 
-import logging
 import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import text
 
 from integ.response_utils import extract_data
+from shu.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 async def ensure_local_provider_type(db) -> None:

--- a/backend/src/tests/integ/baseline/chat_latency_baseline.py
+++ b/backend/src/tests/integ/baseline/chat_latency_baseline.py
@@ -24,7 +24,6 @@ Defaults: N=10 sequential chats. Override via ``BASELINE_N=20`` env var.
 from __future__ import annotations
 
 import json
-import logging
 import math
 import os
 import sys
@@ -35,8 +34,9 @@ from integ.base_integration_test import BaseIntegrationTestSuite
 from integ.baseline._setup import create_local_chat_setup
 from integ.helpers.api_helpers import process_streaming_result
 from integ.helpers.auth import cleanup_framework_test_admin
+from shu.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Knob: number of sequential chats per run. Override via env var
 # (the integration framework's own argparse owns the CLI).

--- a/backend/src/tests/integ/baseline/pool_pressure_baseline.py
+++ b/backend/src/tests/integ/baseline/pool_pressure_baseline.py
@@ -48,7 +48,6 @@ Defaults: N=10 iterations. Override via ``BASELINE_N=20`` env var.
 from __future__ import annotations
 
 import json
-import logging
 import math
 import os
 import sys
@@ -61,8 +60,9 @@ from integ.baseline._setup import create_local_chat_setup
 from integ.helpers.auth import cleanup_framework_test_admin
 from integ.helpers.pool_observer import PoolObserver, WindowStats
 from shu.core.database import get_async_engine
+from shu.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DEFAULT_N = 10
 # Override iteration count via env var; the integration framework's own

--- a/backend/src/tests/integ/helpers/auth.py
+++ b/backend/src/tests/integ/helpers/auth.py
@@ -1,9 +1,10 @@
-import logging
 import uuid
 
 from integ.response_utils import extract_data
 
-logger = logging.getLogger(__name__)
+from shu.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 async def create_active_user_headers(client, admin_headers, role="regular_user"):

--- a/backend/src/tests/integ/helpers/pool_observer.py
+++ b/backend/src/tests/integ/helpers/pool_observer.py
@@ -38,17 +38,18 @@ For SSE-bracketed measurement, the caller opens the window when the first
 
 from __future__ import annotations
 
-import logging
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import event
 
+from shu.core.logging import get_logger
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/backend/src/tests/integ/integration_test_runner.py
+++ b/backend/src/tests/integ/integration_test_runner.py
@@ -101,7 +101,7 @@ class IntegrationTestRunner:
         # Add handler to root logger to capture all logs. Direct stdlib call:
         # we're operating on the root logger, not creating a module logger,
         # so shu.core.logging.get_logger does not apply.
-        root_logger = logging.getLogger()
+        root_logger = logging.getLogger()  # noqa: TID251
         root_logger.addHandler(self.log_file_handler)
 
         if wipe_file:
@@ -112,7 +112,7 @@ class IntegrationTestRunner:
     def cleanup_file_logging(self):
         """Clean up file logging handler."""
         if self.log_file_handler:
-            root_logger = logging.getLogger()
+            root_logger = logging.getLogger()  # noqa: TID251
             root_logger.removeHandler(self.log_file_handler)
             self.log_file_handler.close()
             self.log_file_handler = None
@@ -130,8 +130,8 @@ class IntegrationTestRunner:
         # we're setting levels on external/named loggers (not creating module
         # loggers), parallel to what shu.core.logging.setup_logging does for
         # the application.
-        logging.getLogger("httpx").setLevel(logging.WARNING)
-        logging.getLogger("shu.core.middleware").setLevel(logging.WARNING)
+        logging.getLogger("httpx").setLevel(logging.WARNING)  # noqa: TID251
+        logging.getLogger("shu.core.middleware").setLevel(logging.WARNING)  # noqa: TID251
 
         try:
             # Run FastAPI lifespan startup to wire DI, schema verification, etc.

--- a/backend/src/tests/integ/test_chat_concurrency_integration.py
+++ b/backend/src/tests/integ/test_chat_concurrency_integration.py
@@ -15,7 +15,6 @@ next request, defeating the test's whole point.
 """
 
 import asyncio
-import logging
 import uuid
 
 from integ.base_integration_test import BaseIntegrationTestSuite
@@ -24,8 +23,9 @@ from integ.helpers.auth import cleanup_framework_test_admin, cleanup_test_user, 
 from integ.response_utils import extract_data
 from shu.core.config import get_settings_instance
 from shu.core.database import get_async_engine
+from shu.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Drive enough concurrent requests to make pre-refactor code clearly fail
 # while staying achievable on the test env's actual capacity. The default

--- a/backend/src/tests/integ/test_chat_finalize_error_integration.py
+++ b/backend/src/tests/integ/test_chat_finalize_error_integration.py
@@ -15,7 +15,6 @@ Per TESTING.md, negative tests log the
 doesn't flag the expected LLM-call errors as real failures.
 """
 
-import logging
 import uuid
 from datetime import UTC, datetime
 
@@ -24,8 +23,9 @@ from sqlalchemy import text
 from integ.base_integration_test import BaseIntegrationTestSuite
 from integ.helpers.auth import cleanup_framework_test_admin, cleanup_test_user, create_active_user_with_id
 from integ.response_utils import extract_data
+from shu.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 # An OpenAI-compatible provider pointed at a port that's never listening.

--- a/backend/src/tests/integ/test_pool_observer_integration.py
+++ b/backend/src/tests/integ/test_pool_observer_integration.py
@@ -8,7 +8,6 @@ production refactor begins.
 """
 
 import asyncio
-import logging
 import sys
 from collections.abc import Callable
 
@@ -17,8 +16,9 @@ from sqlalchemy import text
 from integ.base_integration_test import BaseIntegrationTestSuite
 from integ.helpers.pool_observer import PoolObserver
 from shu.core.database import get_async_engine, get_async_session_local
+from shu.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 async def test_pool_observer_counts_query_checkout(client, db, auth_headers):


### PR DESCRIPTION
## Description
… shu.core.logging

The SHU-548 sweep ran before SHU-759 merged to main, so the new integration-test files SHU-759 introduced were pulled into the SHU-548 merge carrying the legacy `logging.getLogger(__name__)` pattern and never converted. `ruff check --select TID251` reported 12 violations across 8 files, directly contradicting SHU-548 ACs #1 and #2.

Eight SHU-759-origin files converted to the canonical pattern:
- baseline/_setup.py
- baseline/chat_latency_baseline.py
- baseline/pool_pressure_baseline.py
- helpers/auth.py
- helpers/pool_observer.py
- test_chat_concurrency_integration.py
- test_chat_finalize_error_integration.py
- test_pool_observer_integration.py

integration_test_runner.py: four call sites at lines 104, 115, 133, 134 operate on the root logger or set levels on external named loggers (httpx, shu.core.middleware) — these mirror the patterns that core/logging.py itself uses under per-file-ignores. Annotated with `# noqa: TID251` rather than converted; the existing in-file comments already document why `get_logger` does not apply.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #SHU-548

## Testing
Verified inside shu-api-dev that all 8 converted loggers now resolve under `shu.tests.integ.*`, matching the namespace SHU-548 standardized. `ruff --select TID251` now exits clean across backend/src/tests and backend/src/shu.

### Linting

- [x] Pre-commit hooks pass
- [x] CI linting checks pass
- [x] No linting warnings ignored without justification


## Reviewer Notes
These slipped by as they were merged while this branch was already checked out. Should be safe going forward now

---

**By submitting this PR, I confirm that:**

- [x] I have run `make lint-fix` and all linting checks pass
- [x] I have tested my changes locally
- [x] I have followed the coding standards in `docs/policies/DEVELOPMENT_STANDARDS.md`
- [x] I have read and followed the linting policy in `docs/policies/LINTING_POLICY.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test logging infrastructure to use the project's standardized logging utility across integration tests and helper modules, improving consistency in the testing framework.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->