### PR TITLE
feat(logging): [SHU-797] skip file handler when SHU_LOG_DIR is empty

### DIFF
--- a/backend/src/shu/core/config.py
+++ b/backend/src/shu/core/config.py
@@ -393,6 +393,10 @@ class Settings(BaseSettings):
     @field_validator("log_dir", mode="before")
     @classmethod
     def _resolve_log_dir(cls, v: str) -> str:
+        # Empty string is a valid value meaning "no file handler — stdout only".
+        # Used by the hosted profile where kubelet + log aggregation handle capture.
+        if v == "" or v is None:
+            return ""
         try:
             p = Path(v)
             if p.is_absolute():

--- a/backend/src/shu/core/logging.py
+++ b/backend/src/shu/core/logging.py
@@ -4,11 +4,15 @@ This module sets up structured logging with better readability, color coding,
 proper alignment, and appropriate log levels for different environments.
 
 Log file management:
-- Each process startup archives the previous log file with a timestamp suffix.
-- A plain FileHandler writes to a fresh file (no TimedRotatingFileHandler).
-- The unified scheduler's LogMaintenanceSource handles midnight rotation and
-  retention cleanup on every tick, so old archives are pruned continuously
-  rather than only at startup.
+- When ``SHU_LOG_DIR`` is set to a non-empty path, a ``ManagedFileHandler``
+  writes to ``${SHU_LOG_DIR}/shu_${hostname}.log``. Each process startup
+  archives the previous log file with a timestamp suffix. The unified
+  scheduler's ``LogMaintenanceSource`` handles midnight rotation and
+  retention cleanup on every tick.
+- When ``SHU_LOG_DIR`` is empty, only the stdout ``StreamHandler`` is
+  installed. This is the hosted profile: kubelet captures stdout and a
+  log-aggregation agent ships it onward, so a disk-backed handler would
+  duplicate writes and pin logs to a single-writer volume.
 """
 
 import json
@@ -347,35 +351,41 @@ def setup_logging() -> None:  # noqa: PLR0915
     # Create file handler using configurable log directory and our ManagedFileHandler.
     # Startup archiving gives each app cycle a clean file. Midnight rotation and
     # retention cleanup are handled by the scheduler's LogMaintenanceSource.
+    # When SHU_LOG_DIR is empty (hosted profile with log aggregation), skip the
+    # file handler entirely — kubelet captures stdout and Fluent Bit ships it.
     global _managed_file_handler  # noqa: PLW0603
-    log_dir = Path(settings.log_dir)
-    os.makedirs(log_dir, exist_ok=True)
+    file_handler: ManagedFileHandler | None = None
+    if settings.log_dir:
+        log_dir = Path(settings.log_dir)
+        os.makedirs(log_dir, exist_ok=True)
 
-    # Include hostname in filename so horizontally scaled replicas don't clobber each other
-    hostname = socket.gethostname()
-    log_file_path = os.path.join(log_dir, f"shu_{hostname}.log")
+        # Include hostname in filename so horizontally scaled replicas don't clobber each other
+        hostname = socket.gethostname()
+        log_file_path = os.path.join(log_dir, f"shu_{hostname}.log")
 
-    # Archive the previous run's log file before the handler opens it.
-    # Each restart gets a unique timestamp suffix so same-day restarts
-    # never collide.
-    log_path = Path(log_file_path)
-    if log_path.exists() and log_path.stat().st_size > 0:
-        ts = datetime.now(UTC).strftime("%Y-%m-%d_%H-%M-%S")
-        archive_path = f"{log_file_path}.{ts}"
-        try:
-            log_path.rename(archive_path)
-        except OSError:
-            pass  # worst case we append; not worth crashing over
+        # Archive the previous run's log file before the handler opens it.
+        # Each restart gets a unique timestamp suffix so same-day restarts
+        # never collide.
+        log_path = Path(log_file_path)
+        if log_path.exists() and log_path.stat().st_size > 0:
+            ts = datetime.now(UTC).strftime("%Y-%m-%d_%H-%M-%S")
+            archive_path = f"{log_file_path}.{ts}"
+            try:
+                log_path.rename(archive_path)
+            except OSError:
+                pass  # worst case we append; not worth crashing over
 
-    file_handler = ManagedFileHandler(
-        log_file_path,
-        retention_days=settings.log_retention_days,
-    )
-    file_handler.setFormatter(formatter)
-    _managed_file_handler = file_handler
+        file_handler = ManagedFileHandler(
+            log_file_path,
+            retention_days=settings.log_retention_days,
+        )
+        file_handler.setFormatter(formatter)
+        _managed_file_handler = file_handler
 
-    # Run an initial cleanup of old archives at startup
-    _cleanup_old_log_archives(log_dir, settings.log_retention_days)
+        # Run an initial cleanup of old archives at startup
+        _cleanup_old_log_archives(log_dir, settings.log_retention_days)
+    else:
+        _managed_file_handler = None
 
     # Immediately configure SQLAlchemy loggers to use our formatter
     # This prevents SQLAlchemy from setting up its own logging
@@ -399,7 +409,8 @@ def setup_logging() -> None:  # noqa: PLR0915
     # Clear existing handlers and add our handlers
     root_logger.handlers.clear()
     root_logger.addHandler(console_handler)
-    root_logger.addHandler(file_handler)
+    if file_handler is not None:
+        root_logger.addHandler(file_handler)
 
     # Set specific logger levels based on config
     # Uvicorn logs - use config level but cap at WARNING to reduce noise
@@ -424,7 +435,8 @@ def setup_logging() -> None:  # noqa: PLR0915
         log.handlers.clear()
         # Add our handlers with our formatter for consistent styling
         log.addHandler(console_handler)
-        log.addHandler(file_handler)
+        if file_handler is not None:
+            log.addHandler(file_handler)
         # Disable propagation to prevent double logging
         log.propagate = False
 
@@ -479,7 +491,8 @@ def setup_logging() -> None:  # noqa: PLR0915
     for uvicorn_log in [uvicorn_logger, uvicorn_access_logger, uvicorn_error_logger]:
         uvicorn_log.handlers.clear()
         uvicorn_log.addHandler(console_handler)
-        uvicorn_log.addHandler(file_handler)
+        if file_handler is not None:
+            uvicorn_log.addHandler(file_handler)
         uvicorn_log.propagate = False
 
     logger.info(

--- a/backend/src/tests/unit/core/test_logging.py
+++ b/backend/src/tests/unit/core/test_logging.py
@@ -1,0 +1,88 @@
+"""Unit tests for setup_logging() handler installation under hosted vs OSS profiles."""
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from shu.core import logging as shu_logging
+from shu.core.logging import ManagedFileHandler, setup_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state() -> None:
+    """Reset module-level globals and root logger handlers around each test.
+
+    setup_logging() mutates module globals and the root logger; tests would
+    otherwise leak handler state into each other.
+    """
+    shu_logging._LOGGING_CONFIGURED = False
+    shu_logging._managed_file_handler = None
+    saved_handlers = logging.root.handlers.copy()
+    saved_level = logging.root.level
+    try:
+        logging.root.handlers.clear()
+        yield
+    finally:
+        shu_logging._LOGGING_CONFIGURED = False
+        shu_logging._managed_file_handler = None
+        logging.root.handlers.clear()
+        for h in saved_handlers:
+            logging.root.addHandler(h)
+        logging.root.setLevel(saved_level)
+
+
+def _stub_settings(log_dir: str) -> object:
+    class _S:
+        pass
+
+    s = _S()
+    s.environment = "test"
+    s.log_level = "INFO"
+    s.log_format = "json"
+    s.log_dir = log_dir
+    s.log_retention_days = 14
+    return s
+
+
+class TestSetupLoggingHostedProfile:
+    """log_dir='' must skip the ManagedFileHandler and install only StreamHandler."""
+
+    def test_empty_log_dir_installs_only_stream_handler(self) -> None:
+        with patch("shu.core.logging.get_settings_instance", return_value=_stub_settings("")):
+            setup_logging()
+
+        root = logging.root
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0], logging.StreamHandler)
+        assert not isinstance(root.handlers[0], ManagedFileHandler)
+        assert shu_logging.get_managed_file_handler() is None
+
+    def test_empty_log_dir_log_maintenance_consumers_noop(self) -> None:
+        with patch("shu.core.logging.get_settings_instance", return_value=_stub_settings("")):
+            setup_logging()
+
+        # run_log_cleanup() and rotate-checks should silently no-op when no
+        # ManagedFileHandler is installed — the explicit None-guard contract
+        # used by scheduler_service.LogMaintenanceSource and worker._run_log_maintenance.
+        assert shu_logging.get_managed_file_handler() is None
+        shu_logging.run_log_cleanup()
+
+
+class TestSetupLoggingOssProfile:
+    """log_dir pointing at a real path must install both handlers (regression test)."""
+
+    def test_populated_log_dir_installs_file_and_stream_handlers(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "logs"
+        with patch("shu.core.logging.get_settings_instance", return_value=_stub_settings(str(log_dir))):
+            setup_logging()
+
+        root = logging.root
+        handler_types = {type(h) for h in root.handlers}
+        assert ManagedFileHandler in handler_types
+        assert any(
+            isinstance(h, logging.StreamHandler) and not isinstance(h, ManagedFileHandler) for h in root.handlers
+        )
+        assert shu_logging.get_managed_file_handler() is not None
+        assert log_dir.is_dir()


### PR DESCRIPTION
Hosted deployments use kubelet + Fluent Bit for log capture; a disk-backed ManagedFileHandler would duplicate writes and pin logs to a single-writer PVC (blocking multi-replica). Setting SHU_LOG_DIR="" now installs only the stdout StreamHandler, while a non-empty value preserves the existing file-rotation path for OSS standalone.

Changes:
- core/logging.py: gate ManagedFileHandler install + handler-attach sites (root, sqlalchemy, uvicorn) on truthy settings.log_dir
- core/config.py: log_dir validator passes "" through unchanged instead of resolving to the repo root
- tests/unit/core/test_logging.py: cover both profiles plus the LogMaintenanceSource no-op contract when no handler is installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced logging configuration to dynamically adapt based on settings: supports both file-based and stdout-only modes without duplicate writes in hosted deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->