### PR TITLE
[SHUI-785] CP endpoints for multi tenant provisioning

### DIFF
--- a/backend/migrations/versions/r009_0002_drop_stray_unique_indexes.py
+++ b/backend/migrations/versions/r009_0002_drop_stray_unique_indexes.py
@@ -1,0 +1,83 @@
+"""Drop stray pre-RLS unique indexes on tenant-scoped columns.
+
+Revision ID: r009_0002
+Revises: r009_0001
+Create Date: 2026-05-21
+
+Before SHU-761, several tenant-scoped tables were created with
+``Column(name, unique=True)`` (and matching ``slug`` columns), which
+Postgres backed with a UNIQUE constraint named ``<table>_<column>_key``
+plus an automatically-named unique INDEX. Migration 009 dropped the
+named constraints and added composite ``(tenant_id, <column>)`` UNIQUEs
+in their place — but on at least some Postgres versions / migration
+histories the unique enforcement also persists as a separately-named
+index (e.g. ``ix_access_policies_name``) that 009 never targets.
+
+Symptom: a second tenant trying to use a policy name that another
+tenant already uses fails with ``duplicate key value violates unique
+constraint "ix_access_policies_name"``, defeating the per-tenant
+uniqueness the model documents.
+
+Fix: for every table 009's ``_tenant_scoped_unique_swaps`` touched,
+unconditionally drop the legacy ``<table>_<column>_key`` constraint
+(no-op when 009's drop already succeeded) AND drop any ``ix_<table>_<col>``
+index that may exist, then recreate the latter as non-unique so the
+query-time index lookup the model declares via ``index=True`` is still
+there. Per-tenant uniqueness is preserved by the composite
+``uq_<table>_tenant_<col>`` constraint that 009 added.
+
+Idempotent: every statement uses ``IF EXISTS`` / ``IF NOT EXISTS``, so
+re-running on a clean schema is a no-op.
+
+Policy: idempotent per docs/policies/DB_MIGRATION_POLICY.md §Policy.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "r009_0002"
+down_revision = "r009_0001"
+branch_labels = None
+depends_on = None
+
+
+# (table, column) — mirror of 009's `_tenant_scoped_unique_swaps`. If 009
+# ever adds another table to that list, this list grows in lockstep.
+_AFFECTED_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("mcp_server_connections", "name"),
+    ("access_policies", "name"),
+    ("knowledge_bases", "slug"),
+    ("experiences", "slug"),
+    ("user_groups", "name"),
+)
+
+
+def upgrade() -> None:
+    """Drop the legacy global-unique enforcement; keep a plain index."""
+    for table, col in _AFFECTED_COLUMNS:
+        # SQLAlchemy's default name for column-level UNIQUE — 009 already
+        # tries to drop these, but the IF EXISTS guard makes this a no-op
+        # rather than an error if 009 succeeded.
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_{col}_key")
+        # The stray unique index this migration is here to fix. CASCADE so
+        # any constraint that happens to be backed by this index goes too
+        # — without CASCADE, dropping a constraint-backing index raises.
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_{col} CASCADE")
+        # Recreate as a plain (non-unique) index to keep query lookups on
+        # the column cheap. The model declares `index=True` so this is the
+        # shape the ORM expects on the live table.
+        op.execute(f"CREATE INDEX IF NOT EXISTS ix_{table}_{col} ON {table} ({col})")
+
+
+def downgrade() -> None:
+    """Recreating the legacy global-unique indexes is intentionally not done.
+
+    The original `unique=True` was a pre-RLS bug — it prevented two tenants
+    from picking the same name, which contradicts the per-tenant uniqueness
+    that ``uq_<table>_tenant_<col>`` enforces. Downgrade only drops the plain
+    index this migration created; it does not restore the broken constraint.
+    """
+    for table, col in _AFFECTED_COLUMNS:
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_{col}")

--- a/backend/migrations/versions/r009_0002_drop_stray_unique_indexes.py
+++ b/backend/migrations/versions/r009_0002_drop_stray_unique_indexes.py
@@ -57,18 +57,44 @@ _AFFECTED_COLUMNS: tuple[tuple[str, str], ...] = (
 def upgrade() -> None:
     """Drop the legacy global-unique enforcement; keep a plain index."""
     for table, col in _AFFECTED_COLUMNS:
-        # SQLAlchemy's default name for column-level UNIQUE — 009 already
-        # tries to drop these, but the IF EXISTS guard makes this a no-op
-        # rather than an error if 009 succeeded.
-        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_{col}_key")
-        # The stray unique index this migration is here to fix. CASCADE so
-        # any constraint that happens to be backed by this index goes too
-        # — without CASCADE, dropping a constraint-backing index raises.
-        op.execute(f"DROP INDEX IF EXISTS ix_{table}_{col} CASCADE")
+        index_name = f"ix_{table}_{col}"
+        legacy_constraint = f"{table}_{col}_key"
+        # Drop the known Postgres-default constraint name first. 009 already
+        # attempts this; IF EXISTS makes the second attempt a no-op.
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {legacy_constraint}")
+
+        # Drop contraints
+        op.execute(
+            f"""
+            DO $$
+            DECLARE
+                con_name text;
+                con_table text;
+            BEGIN
+                SELECT c.conname, t.relname
+                  INTO con_name, con_table
+                  FROM pg_constraint c
+                  JOIN pg_class i ON c.conindid = i.oid
+                  JOIN pg_class t ON c.conrelid = t.oid
+                 WHERE i.relname = '{index_name}'
+                 LIMIT 1;
+                IF con_name IS NOT NULL THEN
+                    RAISE NOTICE 'r009_0002: dropping constraint % on % (backed by %)',
+                        con_name, con_table, '{index_name}';
+                    EXECUTE format('ALTER TABLE %I DROP CONSTRAINT IF EXISTS %I',
+                                   con_table, con_name);
+                END IF;
+            END
+            $$;
+            """
+        )
+        # Now the index can be dropped without CASCADE — any constraint
+        # owning it was removed by the block above.
+        op.execute(f"DROP INDEX IF EXISTS {index_name}")
         # Recreate as a plain (non-unique) index to keep query lookups on
         # the column cheap. The model declares `index=True` so this is the
         # shape the ORM expects on the live table.
-        op.execute(f"CREATE INDEX IF NOT EXISTS ix_{table}_{col} ON {table} ({col})")
+        op.execute(f"CREATE INDEX IF NOT EXISTS {index_name} ON {table} ({col})")
 
 
 def downgrade() -> None:

--- a/backend/src/shu/api/admin/tenant_admin.py
+++ b/backend/src/shu/api/admin/tenant_admin.py
@@ -46,13 +46,45 @@ accidentally claim the path.
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from shu.auth.password_auth import PasswordAuthService
+from shu.billing.router_envelope import verify_router_envelope_dep
 from shu.core.database import get_admin_session_local, get_async_session_local
-from shu.services.audit_logger import DefaultAuditLogger
+from shu.schemas.cp_provisioning import (
+    CreateTenantRequest,
+    CreateTenantResponse,
+    SetModelConfigsRequest,
+    SetModelConfigsResponse,
+    SetPoliciesRequest,
+    SetPoliciesResponse,
+    SetPromptRequest,
+    SetPromptResponse,
+    SetUserActiveRequest,
+    SetUserActiveResponse,
+)
+from shu.services.audit_logger import AuditLogger, DefaultAuditLogger
+from shu.services.model_configuration_service import ModelConfigurationService
+from shu.services.password_reset_service import get_password_reset_service_dependency
+from shu.services.policy_service import PolicyService
+from shu.services.prompt_service import PromptService
 from shu.services.tenant_admin_service import TenantAdminService
+from shu.services.user_service import UserService
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+# `cp_router` carries the CP-driven provisioning surface (SHU-785). It lives
+# alongside `router` in this module so the entire `/admin/*` namespace stays
+# grep-able in one place, but uses a different auth dependency — HMAC
+# envelope verification — because the caller is the Control Plane process,
+# not a human admin. The `verify_router_envelope_dep` declared at the router
+# level inherits onto every handler attached to `cp_router`, so individual
+# handlers do not need to repeat it.
+cp_router = APIRouter(
+    prefix="/admin/cp",
+    tags=["admin", "cp"],
+    dependencies=[Depends(verify_router_envelope_dep)],
+)
 
 
 def get_tenant_admin_service() -> TenantAdminService:
@@ -62,9 +94,134 @@ def get_tenant_admin_service() -> TenantAdminService:
     rather than importing the class directly — the indirection is what
     lets tests override the dep with a stub via FastAPI's
     ``dependency_overrides``.
+
+    The CP-only collaborators (``PasswordAuthService``,
+    ``PasswordResetService``) are wired here too so the same
+    ``TenantAdminService`` instance can serve both human-admin endpoints
+    and CP provisioning endpoints — there's no per-call switch over the
+    operating mode, just whether the new method gets called.
     """
     return TenantAdminService(
         app_session_local=get_async_session_local(),
         admin_session_local=get_admin_session_local(),
         audit_logger=DefaultAuditLogger(),
+        password_auth=PasswordAuthService(),
+        password_reset=get_password_reset_service_dependency(),
+    )
+
+
+# Each CP service dep gets its own factory rather than inlining the
+# construction at every handler so route handlers stay one line of
+# `Depends(...)` per collaborator. The `db=None` placeholder is acceptable
+# because cp_* methods open their own session via the injected
+# `tenant_admin_svc` and never touch `self.db`.
+
+
+def get_cp_audit_logger() -> AuditLogger:
+    return DefaultAuditLogger()
+
+
+def get_cp_model_configuration_service(
+    admin_svc: TenantAdminService = Depends(get_tenant_admin_service),
+    audit: AuditLogger = Depends(get_cp_audit_logger),
+) -> ModelConfigurationService:
+    return ModelConfigurationService(
+        db=None,
+        tenant_admin_svc=admin_svc,
+        audit_logger=audit,
+    )
+
+
+def get_cp_policy_service(
+    admin_svc: TenantAdminService = Depends(get_tenant_admin_service),
+    audit: AuditLogger = Depends(get_cp_audit_logger),
+) -> PolicyService:
+    return PolicyService(
+        db=None,
+        tenant_admin_svc=admin_svc,
+        audit_logger=audit,
+    )
+
+
+def get_cp_prompt_service(
+    admin_svc: TenantAdminService = Depends(get_tenant_admin_service),
+    audit: AuditLogger = Depends(get_cp_audit_logger),
+) -> PromptService:
+    return PromptService(
+        db=None,
+        tenant_admin_svc=admin_svc,
+        audit_logger=audit,
+    )
+
+
+def get_cp_user_service() -> UserService:
+    return UserService()
+
+
+# ---------------------------------------------------------------------------
+# CP-driven tenant provisioning endpoints (SHU-785)
+# ---------------------------------------------------------------------------
+
+
+@cp_router.post("/tenants", response_model=CreateTenantResponse)
+async def cp_create_tenant(
+    payload: CreateTenantRequest,
+    admin_svc: TenantAdminService = Depends(get_tenant_admin_service),
+) -> CreateTenantResponse:
+    return await admin_svc.create_tenant(payload, payload.reason)
+
+
+@cp_router.put(
+    "/tenants/{tenant_id}/model-configs",
+    response_model=SetModelConfigsResponse,
+)
+async def cp_set_model_configs(
+    tenant_id: str,
+    payload: SetModelConfigsRequest,
+    mc_svc: ModelConfigurationService = Depends(get_cp_model_configuration_service),
+) -> SetModelConfigsResponse:
+    return await mc_svc.cp_upsert_by_name(tenant_id, payload, payload.reason)
+
+
+@cp_router.put(
+    "/tenants/{tenant_id}/policies",
+    response_model=SetPoliciesResponse,
+)
+async def cp_set_policies(
+    tenant_id: str,
+    payload: SetPoliciesRequest,
+    policy_svc: PolicyService = Depends(get_cp_policy_service),
+) -> SetPoliciesResponse:
+    return await policy_svc.cp_replace_and_bind(tenant_id, payload, payload.reason)
+
+
+@cp_router.put(
+    "/tenants/{tenant_id}/prompt",
+    response_model=SetPromptResponse,
+)
+async def cp_set_prompt(
+    tenant_id: str,
+    payload: SetPromptRequest,
+    prompt_svc: PromptService = Depends(get_cp_prompt_service),
+) -> SetPromptResponse:
+    return await prompt_svc.cp_upsert_by_name(tenant_id, payload, payload.reason)
+
+
+@cp_router.patch(
+    "/tenants/{tenant_id}/user/active",
+    response_model=SetUserActiveResponse,
+)
+async def cp_set_user_active(
+    tenant_id: str,
+    payload: SetUserActiveRequest,
+    user_svc: UserService = Depends(get_cp_user_service),
+    admin_svc: TenantAdminService = Depends(get_tenant_admin_service),
+    audit: AuditLogger = Depends(get_cp_audit_logger),
+) -> SetUserActiveResponse:
+    return await user_svc.cp_set_user_active(
+        tenant_id,
+        payload.is_active,
+        payload.reason,
+        tenant_admin_svc=admin_svc,
+        audit_logger=audit,
     )

--- a/backend/src/shu/core/middleware.py
+++ b/backend/src/shu/core/middleware.py
@@ -188,6 +188,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             "/openapi.json",
             "/static/",  # Self-hosted static assets (e.g., ReDoc JS)
             "/api/v1/settings/branding/assets/",
+            "/api/v1/admin/cp/",
         ]
         return any(path.startswith(prefix) for prefix in public_prefixes)
 

--- a/backend/src/shu/main.py
+++ b/backend/src/shu/main.py
@@ -18,6 +18,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from .api.admin.tenant_admin import cp_router as cp_tenant_admin_router
 from .api.admin.tenant_admin import router as tenant_admin_router
 from .api.auth import router as auth_router
 from .api.branding import router as branding_router
@@ -930,6 +931,9 @@ def setup_routes(app: FastAPI) -> None:
     # Cross-tenant admin (SHU-761). Empty surface today — registered so
     # operator endpoints can be added under /admin/* without touching main.py.
     app.include_router(tenant_admin_router, prefix=settings.api_v1_prefix)
+    # CP-driven tenant provisioning surface (SHU-785). HMAC envelope auth
+    # inherits from the router-level dependency declared in tenant_admin.py.
+    app.include_router(cp_tenant_admin_router, prefix=settings.api_v1_prefix)
 
     # User preferences routes
     # Host auth routes (generic provider connection status)

--- a/backend/src/shu/schemas/cp_provisioning.py
+++ b/backend/src/shu/schemas/cp_provisioning.py
@@ -1,0 +1,178 @@
+"""Pydantic schemas for the `/admin/cp/*` Control-Plane provisioning endpoints.
+
+Strict types throughout: CP is an external system and silently coercing the
+wrong shape is the opposite of what we want at this boundary. `extra="forbid"`
+on every inbound model so a contract drift surfaces here rather than as a
+silently-dropped field downstream.
+
+Response models are plain BaseModel — we control what we emit, so the same
+strictness isn't needed on the outbound side.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictStr,
+    field_validator,
+)
+
+# CP must seed with a non-blocking status so the just-created tenant can serve
+# chat on the very next request. Rejecting terminal/blocked states at the API
+# boundary surfaces a CP-side bug here, not at first chat in
+# `enforcement.assert_subscription_active`.
+_ALLOWED_SEED_SUBSCRIPTION_STATUSES: frozenset[str] = frozenset({"active", "trialing", "pending"})
+
+
+class _CpInboundBase(BaseModel):
+    """Shared config for all CP→Shu request models."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/cp/tenants
+# ---------------------------------------------------------------------------
+
+
+class BillingInput(_CpInboundBase):
+    stripe_customer_id: StrictStr | None = None
+    stripe_subscription_id: StrictStr | None = None
+    billing_email: StrictStr | None = None
+    subscription_status: StrictStr
+    current_period_start: AwareDatetime | None = None
+    current_period_end: AwareDatetime | None = None
+    user_limit_enforcement: Literal["soft", "hard", "none"] = "hard"
+
+    @field_validator("subscription_status")
+    @classmethod
+    def _validate_seed_status(cls, v: str) -> str:
+        if v not in _ALLOWED_SEED_SUBSCRIPTION_STATUSES:
+            raise ValueError(
+                f"subscription_status {v!r} not allowed at seed time; "
+                f"must be one of {sorted(_ALLOWED_SEED_SUBSCRIPTION_STATUSES)}"
+            )
+        return v
+
+
+class UserInput(_CpInboundBase):
+    email: StrictStr
+    name: StrictStr
+
+
+class CreateTenantRequest(_CpInboundBase):
+    tenant_id: StrictStr
+    billing: BillingInput
+    user: UserInput
+    reason: StrictStr = Field(min_length=1)
+
+
+class CreateTenantResponse(BaseModel):
+    tenant_id: str
+    user_id: str
+    welcome_email_sent: bool
+    billing_state_created: bool
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/cp/tenants/{tenant_id}/model-configs
+# ---------------------------------------------------------------------------
+
+
+class ModelConfigInput(_CpInboundBase):
+    name: StrictStr
+    provider_name: StrictStr
+    model_name: StrictStr
+    parameter_overrides: dict[str, Any] | None = None
+    prompt_name: StrictStr | None = None
+    functionalities: dict[str, Any] | None = None
+
+
+class SetModelConfigsRequest(_CpInboundBase):
+    configs: list[ModelConfigInput]
+    side_call_model_config_name: StrictStr | None = None
+    profiling_model_config_name: StrictStr | None = None
+    reason: StrictStr = Field(min_length=1)
+
+
+class SetModelConfigsResponse(BaseModel):
+    config_ids_by_name: dict[str, str]
+    side_call_model_config_id: str | None
+    profiling_model_config_id: str | None
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/cp/tenants/{tenant_id}/policies
+# ---------------------------------------------------------------------------
+
+
+class PolicyStatementInput(_CpInboundBase):
+    # Mirrors `AccessPolicyStatement` columns: each row is a list of actions
+    # and a list of resources stored as JSON. `effect` lives at the policy
+    # level (one column on `access_policies`), not here.
+    actions: list[StrictStr] = Field(min_length=1)
+    resources: list[StrictStr] = Field(min_length=1)
+
+
+class PolicyInput(_CpInboundBase):
+    name: StrictStr
+    effect: Literal["allow", "deny"]
+    description: StrictStr | None = None
+    statements: list[PolicyStatementInput]
+
+
+class SetPoliciesRequest(_CpInboundBase):
+    # Wipe-and-replace semantics: the tenant's existing policy set is
+    # deleted (cascading through bindings and statements) and replaced with
+    # `policies`. CP is the source of truth for the policy set; partial
+    # diffs aren't supported.
+    policies: list[PolicyInput]
+    bind_to_all_users: StrictBool = True
+    reason: StrictStr = Field(min_length=1)
+
+
+class SetPoliciesResponse(BaseModel):
+    policy_ids_by_name: dict[str, str]
+    bindings_created: int
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/cp/tenants/{tenant_id}/prompt
+# ---------------------------------------------------------------------------
+
+
+class PromptInput(_CpInboundBase):
+    name: StrictStr
+    content: StrictStr
+    entity_type: StrictStr | None = None
+
+
+class SetPromptRequest(_CpInboundBase):
+    prompt: PromptInput
+    reason: StrictStr = Field(min_length=1)
+
+
+class SetPromptResponse(BaseModel):
+    prompt_id: str
+
+
+# ---------------------------------------------------------------------------
+# PATCH /admin/cp/tenants/{tenant_id}/user/active
+# ---------------------------------------------------------------------------
+
+
+class SetUserActiveRequest(_CpInboundBase):
+    is_active: StrictBool
+    reason: StrictStr = Field(min_length=1)
+
+
+class SetUserActiveResponse(BaseModel):
+    user_id: str
+    email: str
+    is_active: bool

--- a/backend/src/shu/schemas/cp_provisioning.py
+++ b/backend/src/shu/schemas/cp_provisioning.py
@@ -14,20 +14,12 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from pydantic import (
-    AwareDatetime,
     BaseModel,
     ConfigDict,
     Field,
     StrictBool,
     StrictStr,
-    field_validator,
 )
-
-# CP must seed with a non-blocking status so the just-created tenant can serve
-# chat on the very next request. Rejecting terminal/blocked states at the API
-# boundary surfaces a CP-side bug here, not at first chat in
-# `enforcement.assert_subscription_active`.
-_ALLOWED_SEED_SUBSCRIPTION_STATUSES: frozenset[str] = frozenset({"active", "trialing", "pending"})
 
 
 class _CpInboundBase(BaseModel):
@@ -41,24 +33,16 @@ class _CpInboundBase(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# `subscription_status` and the period bounds are intentionally NOT on this
+# payload. Per SHU-774 the tenant DB no longer reads those columns — CP is
+# the source of truth via the polling adapter (see billing/router.py:359 and
+# billing/cp_client.py). Sending them here would be silently dropped, so the
+# contract refuses them rather than pretending to accept them.
 class BillingInput(_CpInboundBase):
     stripe_customer_id: StrictStr | None = None
     stripe_subscription_id: StrictStr | None = None
     billing_email: StrictStr | None = None
-    subscription_status: StrictStr
-    current_period_start: AwareDatetime | None = None
-    current_period_end: AwareDatetime | None = None
     user_limit_enforcement: Literal["soft", "hard", "none"] = "hard"
-
-    @field_validator("subscription_status")
-    @classmethod
-    def _validate_seed_status(cls, v: str) -> str:
-        if v not in _ALLOWED_SEED_SUBSCRIPTION_STATUSES:
-            raise ValueError(
-                f"subscription_status {v!r} not allowed at seed time; "
-                f"must be one of {sorted(_ALLOWED_SEED_SUBSCRIPTION_STATUSES)}"
-            )
-        return v
 
 
 class UserInput(_CpInboundBase):
@@ -128,10 +112,12 @@ class PolicyInput(_CpInboundBase):
 
 
 class SetPoliciesRequest(_CpInboundBase):
-    # Wipe-and-replace semantics: the tenant's existing policy set is
-    # deleted (cascading through bindings and statements) and replaced with
-    # `policies`. CP is the source of truth for the policy set; partial
-    # diffs aren't supported.
+    # Per-name surgical replace: each policy in `policies` deletes any
+    # existing row with the same `(tenant_id, name)` (cascading through
+    # bindings and statements) and inserts the new version. Policies NOT
+    # in the payload are left untouched. An empty list is a no-op — the
+    # explicit safety guard against a malformed empty payload wiping the
+    # entire tenant's policy set in silo deployments.
     policies: list[PolicyInput]
     bind_to_all_users: StrictBool = True
     reason: StrictStr = Field(min_length=1)
@@ -147,10 +133,14 @@ class SetPoliciesResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# CP-managed prompts are always `entity_type='llm_model'` for now. The
+# multi-entity-type concept exists in the model layer for in-tenant admin
+# tooling, but the CP surface intentionally pins one type so the natural
+# key stays `(tenant_id, name)` and the model-config prompt_name resolver
+# can't pick the wrong row.
 class PromptInput(_CpInboundBase):
     name: StrictStr
     content: StrictStr
-    entity_type: StrictStr | None = None
 
 
 class SetPromptRequest(_CpInboundBase):

--- a/backend/src/shu/services/model_configuration_service.py
+++ b/backend/src/shu/services/model_configuration_service.py
@@ -5,6 +5,7 @@ that combines base models + prompts + optional knowledge bases into user-facing
 configurations that users select for chat and other interactions.
 """
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import and_, func, or_, select
@@ -13,12 +14,14 @@ from sqlalchemy.orm import selectinload
 
 if TYPE_CHECKING:
     from ..auth.models import User
+    from ..services.audit_logger import AuditLogger
+    from ..services.tenant_admin_service import TenantAdminService
 
 from shu.services.providers.adapter_base import get_adapter_from_provider
 from shu.services.providers.parameter_definitions import serialize_parameter_mapping
 
 from ..auth.models import User
-from ..core.exceptions import ShuException, ValidationError
+from ..core.exceptions import NotFoundError, ShuException, ValidationError
 from ..core.logging import get_logger
 from ..llm.param_mapping import build_provider_params
 from ..models.knowledge_base import KnowledgeBase
@@ -26,6 +29,11 @@ from ..models.llm_provider import LLMModel, LLMProvider, ModelType
 from ..models.model_configuration import ModelConfiguration
 from ..models.model_configuration_kb_prompt import ModelConfigurationKBPrompt
 from ..models.prompt import Prompt
+from ..models.system_setting import SystemSetting
+from ..schemas.cp_provisioning import (
+    SetModelConfigsRequest,
+    SetModelConfigsResponse,
+)
 from ..schemas.model_configuration import (
     ModelConfigurationCreate,
     ModelConfigurationList,
@@ -33,6 +41,11 @@ from ..schemas.model_configuration import (
     ModelConfigurationUpdate,
 )
 from .knowledge_base_service import KnowledgeBaseService
+from .side_call_settings import (
+    PROFILING_MODEL_SETTING_KEY,
+    SIDE_CALL_MODEL_SETTING_KEY,
+)
+from .tenant_admin_service import CP_ACTOR
 
 logger = get_logger(__name__)
 
@@ -40,8 +53,19 @@ logger = get_logger(__name__)
 class ModelConfigurationService:
     """Service for managing model configurations."""
 
-    def __init__(self, db: AsyncSession) -> None:
+    def __init__(
+        self,
+        db: AsyncSession,
+        *,
+        tenant_admin_svc: "TenantAdminService | None" = None,
+        audit_logger: "AuditLogger | None" = None,
+    ) -> None:
         self.db = db
+        # `tenant_admin_svc` and `audit_logger` are only required by the
+        # CP provisioning path (cp_upsert_by_name). Existing in-tenant
+        # callers pass `db` only; the optional kwargs keep them working.
+        self._tenant_admin_svc = tenant_admin_svc
+        self._audit = audit_logger
 
     async def create_model_configuration(
         self, config_data: ModelConfigurationCreate, created_by: str
@@ -893,3 +917,195 @@ class ModelConfigurationService:
                 except ValidationError as ve:
                     raise ShuException(str(ve), "PARAM_VALIDATION_ERROR")
         return None
+
+    async def cp_upsert_by_name(
+        self,
+        tenant_id: str,
+        payload: SetModelConfigsRequest,
+        reason: str,
+    ) -> SetModelConfigsResponse:
+        """Upsert model configurations from a CP-driven set + write side-call /
+        profiling pointers in one call.
+
+        Runs inside `TenantAdminService.impersonate_tenant(...)` so the
+        tenant_id is set on `app.tenant_id` and RLS WITH CHECK / auto-stamp
+        cooperate. The whole batch shares one transaction — any resolution
+        failure (provider/prompt) rolls everything back so we never leave a
+        half-applied set.
+
+        Upsert key: (tenant_id, name). Existing MC rows keep their UUIDs on
+        re-call so downstream FKs in `conversations.model_configuration_id`
+        stay valid. Configs not in the payload are left alone.
+        """
+        if self._tenant_admin_svc is None or self._audit is None:
+            raise RuntimeError(
+                "ModelConfigurationService.cp_upsert_by_name requires "
+                "tenant_admin_svc and audit_logger to be injected"
+            )
+
+        config_ids_by_name: dict[str, str] = {}
+
+        async with self._tenant_admin_svc.impersonate_tenant(tenant_id, CP_ACTOR, reason) as session:
+            # CP isn't a tenant user; created_by is NOT NULL, so attribute
+            # the row to the lex-first user. Cosmetic; revisit when a real
+            # system-user concept lands.
+            first_user_row = (await session.execute(select(User.id).order_by(User.id).limit(1))).scalar_one_or_none()
+            if first_user_row is None and payload.configs:
+                raise NotFoundError("tenant has no users; create the tenant before pushing " "model_configurations")
+
+            for cfg in payload.configs:
+                provider = (
+                    await session.execute(
+                        select(LLMProvider)
+                        .where(
+                            and_(
+                                LLMProvider.name == cfg.provider_name,
+                                LLMProvider.is_active.is_(True),
+                            )
+                        )
+                        .limit(1)
+                    )
+                ).scalar_one_or_none()
+                if provider is None:
+                    raise NotFoundError(f"no active llm_provider matches name {cfg.provider_name!r}")
+
+                # Validate the model exists for the resolved provider —
+                # otherwise we'd insert a model_config that fails on first use.
+                model_row = (
+                    await session.execute(
+                        select(LLMModel.id).where(
+                            and_(
+                                LLMModel.provider_id == provider.id,
+                                LLMModel.model_name == cfg.model_name,
+                                LLMModel.is_active.is_(True),
+                            )
+                        )
+                    )
+                ).scalar_one_or_none()
+                if model_row is None:
+                    raise NotFoundError(f"model {cfg.model_name!r} not found for provider " f"{cfg.provider_name!r}")
+
+                prompt_id: str | None = None
+                if cfg.prompt_name is not None:
+                    prompt_id = (
+                        await session.execute(select(Prompt.id).where(Prompt.name == cfg.prompt_name).limit(1))
+                    ).scalar_one_or_none()
+                    if prompt_id is None:
+                        raise NotFoundError(f"prompt {cfg.prompt_name!r} not found in tenant")
+
+                existing_mc = (
+                    await session.execute(
+                        select(ModelConfiguration).where(ModelConfiguration.name == cfg.name).limit(1)
+                    )
+                ).scalar_one_or_none()
+
+                if existing_mc is None:
+                    mc = ModelConfiguration(
+                        name=cfg.name,
+                        llm_provider_id=provider.id,
+                        model_name=cfg.model_name,
+                        prompt_id=prompt_id,
+                        parameter_overrides=cfg.parameter_overrides,
+                        functionalities=cfg.functionalities,
+                        created_by=first_user_row,
+                    )
+                    session.add(mc)
+                    await session.flush()
+                    event = "cp_model_config_inserted"
+                else:
+                    existing_mc.llm_provider_id = provider.id
+                    existing_mc.model_name = cfg.model_name
+                    existing_mc.prompt_id = prompt_id
+                    existing_mc.parameter_overrides = cfg.parameter_overrides
+                    existing_mc.functionalities = cfg.functionalities
+                    mc = existing_mc
+                    event = "cp_model_config_updated"
+
+                config_ids_by_name[cfg.name] = mc.id
+                await self._audit.log(
+                    event=event,
+                    actor=CP_ACTOR,
+                    target=cfg.name,
+                    reason=reason,
+                )
+
+            # Side-call / profiling pointers come AFTER the MC batch so the
+            # IDs we want to point at exist. They can also reference an MC
+            # not in this payload (e.g., one created on a previous call).
+            side_call_id = await self._resolve_or_lookup_mc_id(
+                session, payload.side_call_model_config_name, config_ids_by_name
+            )
+            profiling_id = await self._resolve_or_lookup_mc_id(
+                session, payload.profiling_model_config_name, config_ids_by_name
+            )
+
+            if side_call_id is not None:
+                await self._upsert_pointer_setting(session, SIDE_CALL_MODEL_SETTING_KEY, side_call_id, reason)
+            if profiling_id is not None:
+                await self._upsert_pointer_setting(
+                    session,
+                    PROFILING_MODEL_SETTING_KEY,
+                    profiling_id,
+                    reason,
+                )
+
+            await session.commit()
+
+        return SetModelConfigsResponse(
+            config_ids_by_name=config_ids_by_name,
+            side_call_model_config_id=side_call_id,
+            profiling_model_config_id=profiling_id,
+        )
+
+    async def _resolve_or_lookup_mc_id(
+        self,
+        session: AsyncSession,
+        name: str | None,
+        just_upserted: dict[str, str],
+    ) -> str | None:
+        """Resolve an MC name to an id — first via the just-upserted set, then
+        by querying the tenant scope (so CP can re-point to an MC seeded on a
+        previous call without re-listing it).
+        """
+        if name is None:
+            return None
+        if name in just_upserted:
+            return just_upserted[name]
+        mc_id = (
+            await session.execute(select(ModelConfiguration.id).where(ModelConfiguration.name == name).limit(1))
+        ).scalar_one_or_none()
+        if mc_id is None:
+            raise NotFoundError(
+                f"model_configuration {name!r} not found in tenant; cannot "
+                f"point side-call/profiling at a non-existent config"
+            )
+        return mc_id
+
+    async def _upsert_pointer_setting(
+        self,
+        session: AsyncSession,
+        key: str,
+        model_config_id: str,
+        reason: str,
+    ) -> None:
+        """Write the side_call_model_config_id / profiling_model_config_id
+        pointer into system_settings. Shape matches what SideCallService reads
+        — `setting.value["model_config_id"]` is what `get_side_call_model`
+        looks at.
+        """
+        existing = (await session.execute(select(SystemSetting).where(SystemSetting.key == key))).scalar_one_or_none()
+        value = {
+            "model_config_id": model_config_id,
+            "updated_by": CP_ACTOR,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        if existing is None:
+            session.add(SystemSetting(key=key, value=value))
+        else:
+            existing.value = value
+        await self._audit.log(
+            event="cp_system_setting_upserted",
+            actor=CP_ACTOR,
+            target=key,
+            reason=reason,
+        )

--- a/backend/src/shu/services/model_configuration_service.py
+++ b/backend/src/shu/services/model_configuration_service.py
@@ -818,11 +818,22 @@ class ModelConfigurationService:
         self, config_data: ModelConfigurationCreate, provider: LLMProvider | None
     ) -> dict[str, Any]:
         raw_overrides = getattr(config_data, "parameter_overrides", None) or {}
+        return self._normalize_parameter_overrides(raw_overrides, provider, self.db)
+
+    def _normalize_parameter_overrides(
+        self,
+        raw_overrides: dict[str, Any] | None,
+        provider: LLMProvider | None,
+        db_session: AsyncSession | None,
+    ) -> dict[str, Any]:
+        # Strip unknown keys and coerce types so a payload that the adapter
+        # would later reject at first use can't be persisted in the first
+        # place. Shared by the tenant-admin CRUD paths and CP provisioning.
         try:
-            adapter = get_adapter_from_provider(self.db, provider)
+            adapter = get_adapter_from_provider(db_session, provider)
             return build_provider_params(
                 serialize_parameter_mapping(adapter.get_parameter_mapping()) or {},
-                raw_overrides,
+                raw_overrides or {},
                 None,
             )
         except ValidationError as ve:
@@ -907,15 +918,7 @@ class ModelConfigurationService:
         if "parameter_overrides" in update_dict:
             overrides_candidate = update_dict.pop("parameter_overrides")
             if overrides_candidate is not None:
-                try:
-                    adapter = get_adapter_from_provider(self.db, provider)
-                    return build_provider_params(
-                        serialize_parameter_mapping(adapter.get_parameter_mapping()) or {},
-                        overrides_candidate or {},
-                        None,
-                    )
-                except ValidationError as ve:
-                    raise ShuException(str(ve), "PARAM_VALIDATION_ERROR")
+                return self._normalize_parameter_overrides(overrides_candidate, provider, self.db)
         return None
 
     async def cp_upsert_by_name(
@@ -963,12 +966,18 @@ class ModelConfigurationService:
                                 LLMProvider.is_active.is_(True),
                             )
                         )
+                        .options(selectinload(LLMProvider.provider_definition))
                         .order_by(LLMProvider.id)
                         .limit(1)
                     )
                 ).scalar_one_or_none()
                 if provider is None:
                     raise NotFoundError(f"no active llm_provider matches name {cfg.provider_name!r}")
+
+                # CP-supplied overrides go through the same adapter-aware
+                # normalization as the tenant-admin CRUD paths so unknown
+                # keys can't be persisted and rejected at first use.
+                normalized_overrides = self._normalize_parameter_overrides(cfg.parameter_overrides, provider, session)
 
                 # Validate the model exists for the resolved provider —
                 # otherwise we'd insert a model_config that fails on first use.
@@ -1015,7 +1024,7 @@ class ModelConfigurationService:
                         llm_provider_id=provider.id,
                         model_name=cfg.model_name,
                         prompt_id=prompt_id,
-                        parameter_overrides=cfg.parameter_overrides,
+                        parameter_overrides=normalized_overrides,
                         functionalities=cfg.functionalities,
                         created_by=first_user_row,
                     )
@@ -1026,7 +1035,7 @@ class ModelConfigurationService:
                     existing_mc.llm_provider_id = provider.id
                     existing_mc.model_name = cfg.model_name
                     existing_mc.prompt_id = prompt_id
-                    existing_mc.parameter_overrides = cfg.parameter_overrides
+                    existing_mc.parameter_overrides = normalized_overrides
                     existing_mc.functionalities = cfg.functionalities
                     mc = existing_mc
                     event = "cp_model_config_updated"

--- a/backend/src/shu/services/model_configuration_service.py
+++ b/backend/src/shu/services/model_configuration_service.py
@@ -28,7 +28,7 @@ from ..models.knowledge_base import KnowledgeBase
 from ..models.llm_provider import LLMModel, LLMProvider, ModelType
 from ..models.model_configuration import ModelConfiguration
 from ..models.model_configuration_kb_prompt import ModelConfigurationKBPrompt
-from ..models.prompt import Prompt
+from ..models.prompt import EntityType, Prompt
 from ..models.system_setting import SystemSetting
 from ..schemas.cp_provisioning import (
     SetModelConfigsRequest,
@@ -963,6 +963,7 @@ class ModelConfigurationService:
                                 LLMProvider.is_active.is_(True),
                             )
                         )
+                        .order_by(LLMProvider.id)
                         .limit(1)
                     )
                 ).scalar_one_or_none()
@@ -988,7 +989,16 @@ class ModelConfigurationService:
                 prompt_id: str | None = None
                 if cfg.prompt_name is not None:
                     prompt_id = (
-                        await session.execute(select(Prompt.id).where(Prompt.name == cfg.prompt_name).limit(1))
+                        await session.execute(
+                            select(Prompt.id)
+                            .where(
+                                and_(
+                                    Prompt.name == cfg.prompt_name,
+                                    Prompt.entity_type == EntityType.LLM_MODEL,
+                                )
+                            )
+                            .limit(1)
+                        )
                     ).scalar_one_or_none()
                     if prompt_id is None:
                         raise NotFoundError(f"prompt {cfg.prompt_name!r} not found in tenant")

--- a/backend/src/shu/services/policy_service.py
+++ b/backend/src/shu/services/policy_service.py
@@ -10,7 +10,9 @@ access checks reflect the latest state.
 
 from __future__ import annotations
 
-from sqlalchemy import func, or_, select
+from typing import TYPE_CHECKING
+
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -30,7 +32,13 @@ from shu.schemas.access_policy import (
     PolicyListResponse,
     PolicyResponse,
 )
+from shu.schemas.cp_provisioning import SetPoliciesRequest, SetPoliciesResponse
 from shu.services.policy_engine import POLICY_CACHE
+from shu.services.tenant_admin_service import CP_ACTOR
+
+if TYPE_CHECKING:
+    from shu.services.audit_logger import AuditLogger
+    from shu.services.tenant_admin_service import TenantAdminService
 
 logger = get_logger(__name__)
 
@@ -42,8 +50,17 @@ class PolicyService:
     and statements are always included inline, not as sub-resources.
     """
 
-    def __init__(self, db: AsyncSession) -> None:
+    def __init__(
+        self,
+        db: AsyncSession,
+        *,
+        tenant_admin_svc: TenantAdminService | None = None,
+        audit_logger: AuditLogger | None = None,
+    ) -> None:
         self.db = db
+        # The two CP-only deps. Existing in-tenant callers don't pass them.
+        self._tenant_admin_svc = tenant_admin_svc
+        self._audit = audit_logger
 
     async def create_policy(self, data: PolicyInput, created_by: str) -> AccessPolicy:
         """Create a complete policy document with bindings and statements.
@@ -312,3 +329,131 @@ class PolicyService:
                     resources=s.resources,
                 )
             )
+
+    async def cp_replace_and_bind(
+        self,
+        tenant_id: str,
+        payload: SetPoliciesRequest,
+        reason: str,
+    ) -> SetPoliciesResponse:
+        """Replace named policies and (optionally) bind them to all users.
+
+        Per-name surgical replace: each policy in the payload deletes any
+        existing row with the same `(tenant_id, name)` and inserts the new
+        version. Policies NOT in the payload are LEFT ALONE — they keep
+        their rows, statements, and bindings. An empty payload is a no-op.
+
+        Two reasons for this scope rather than a tenant-wide wipe:
+        * In silo deployments the tenant IS the entire database; a
+          tenant-wide wipe is a customer-wide destructive event if CP
+          ever ships a malformed empty payload.
+        * Even in multi-tenant mode, CP only knows what it's pushing,
+          not what's already there. Implicit "everything else is retired"
+          is too much policy authority to grant a single API call.
+
+        Bindings on a replaced policy cascade away with the old row
+        (`ondelete="CASCADE"` on `access_policy_bindings.policy_id`).
+        `bind_to_all_users=True` recreates bindings for the new policy
+        IDs. Policies not in the payload keep their bindings untouched.
+
+        `AccessPolicy.created_by` is non-nullable FK; CP isn't a user, so
+        inserted rows are attributed to the lexicographically-first user
+        id in the tenant. Cosmetic until a real system-user concept lands.
+        """
+        if self._tenant_admin_svc is None or self._audit is None:
+            raise RuntimeError(
+                "PolicyService.cp_replace_and_bind requires tenant_admin_svc and audit_logger to be injected"
+            )
+
+        policy_ids_by_name: dict[str, str] = {}
+        bindings_created = 0
+        policy_names = [p.name for p in payload.policies]
+
+        async with self._tenant_admin_svc.impersonate_tenant(tenant_id, CP_ACTOR, reason) as session:
+            first_user_id = (await session.execute(select(User.id).order_by(User.id).limit(1))).scalar_one_or_none()
+            if first_user_id is None:
+                raise NotFoundError("tenant has no users; create the tenant before pushing policies")
+
+            replaced_count = 0
+            if policy_names:
+                # Only delete policies that are to be changed. This allows us to call silo customers
+                # and not break their entire setup.
+                replaced_count = (
+                    await session.execute(
+                        select(func.count())
+                        .select_from(AccessPolicy)
+                        .where(AccessPolicy.tenant_id == tenant_id)
+                        .where(AccessPolicy.name.in_(policy_names))
+                    )
+                ).scalar() or 0
+                await session.execute(
+                    delete(AccessPolicy)
+                    .where(AccessPolicy.tenant_id == tenant_id)
+                    .where(AccessPolicy.name.in_(policy_names))
+                )
+
+            await self._audit.log(
+                event="cp_policies_replace_started",
+                actor=CP_ACTOR,
+                target=tenant_id,
+                reason=reason,
+                replaced_count=replaced_count,
+                new_count=len(payload.policies),
+            )
+
+            for policy_in in payload.policies:
+                policy = AccessPolicy(
+                    name=policy_in.name,
+                    description=policy_in.description,
+                    effect=policy_in.effect,
+                    is_active=True,
+                    created_by=first_user_id,
+                )
+                session.add(policy)
+                await session.flush()
+                for stmt in policy_in.statements:
+                    session.add(
+                        AccessPolicyStatement(
+                            policy_id=policy.id,
+                            actions=stmt.actions,
+                            resources=stmt.resources,
+                        )
+                    )
+                policy_ids_by_name[policy_in.name] = policy.id
+                await self._audit.log(
+                    event="cp_policy_inserted",
+                    actor=CP_ACTOR,
+                    target=policy_in.name,
+                    reason=reason,
+                )
+
+            if payload.bind_to_all_users and policy_ids_by_name:
+                user_ids: list[str] = list((await session.execute(select(User.id))).scalars().all())
+                for user_id in user_ids:
+                    for policy_id in policy_ids_by_name.values():
+                        session.add(
+                            AccessPolicyBinding(
+                                policy_id=policy_id,
+                                actor_type="user",
+                                actor_id=user_id,
+                            )
+                        )
+                        bindings_created += 1
+                await self._audit.log(
+                    event="cp_policy_bindings_created",
+                    actor=CP_ACTOR,
+                    target=tenant_id,
+                    reason=reason,
+                    bindings_created=bindings_created,
+                )
+
+            await session.commit()
+
+        # Cache invalidation happens after the writer commits so concurrent
+        # readers don't see a stale-then-empty flap.
+        POLICY_CACHE.invalidate()
+
+        return SetPoliciesResponse(
+            policy_ids_by_name=policy_ids_by_name,
+            bindings_created=bindings_created,
+        )

--- a/backend/src/shu/services/policy_service.py
+++ b/backend/src/shu/services/policy_service.py
@@ -369,6 +369,14 @@ class PolicyService:
         bindings_created = 0
         policy_names = [p.name for p in payload.policies]
 
+        # Reject duplicate names up front. The per-name delete+insert would
+        # otherwise persist multiple rows for the same name while only the
+        # last id survives in policy_ids_by_name, leaving the response and
+        # downstream bindings inconsistent with the database.
+        duplicates = sorted({n for n in policy_names if policy_names.count(n) > 1})
+        if duplicates:
+            raise ValidationError(f"duplicate policy names in payload: {duplicates}")
+
         async with self._tenant_admin_svc.impersonate_tenant(tenant_id, CP_ACTOR, reason) as session:
             first_user_id = (await session.execute(select(User.id).order_by(User.id).limit(1))).scalar_one_or_none()
             if first_user_id is None:

--- a/backend/src/shu/services/prompt_service.py
+++ b/backend/src/shu/services/prompt_service.py
@@ -5,6 +5,7 @@ for the unified prompt system supporting multiple entity types.
 """
 
 import uuid
+from typing import TYPE_CHECKING
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,6 +16,7 @@ from shu.core.logging import get_logger
 from ..core.exceptions import ConflictError, NotFoundError, ShuException, ValidationError
 from ..models.model_configuration_kb_prompt import ModelConfigurationKBPrompt
 from ..models.prompt import EntityType, Prompt, PromptAssignment
+from ..schemas.cp_provisioning import SetPromptRequest, SetPromptResponse
 from ..schemas.prompt import (
     PromptAssignmentCreate,
     PromptAssignmentResponse,
@@ -25,11 +27,16 @@ from ..schemas.prompt import (
     PromptSystemStats,
     PromptUpdate,
 )
+from ..services.tenant_admin_service import CP_ACTOR
 from ..utils.prompt_utils import (
     get_citation_conflict_info,
     get_effective_reference_setting,
     has_citation_instructions,
 )
+
+if TYPE_CHECKING:
+    from ..services.audit_logger import AuditLogger
+    from ..services.tenant_admin_service import TenantAdminService
 
 logger = get_logger(__name__)
 
@@ -55,8 +62,17 @@ class PromptAlreadyExistsError(ConflictError):
 class PromptService:
     """Service for managing prompts and their assignments."""
 
-    def __init__(self, db: AsyncSession) -> None:
+    def __init__(
+        self,
+        db: AsyncSession,
+        *,
+        tenant_admin_svc: "TenantAdminService | None" = None,
+        audit_logger: "AuditLogger | None" = None,
+    ) -> None:
         self.db = db
+        # CP-only deps. Existing in-tenant callers pass `db` only.
+        self._tenant_admin_svc = tenant_admin_svc
+        self._audit = audit_logger
 
     async def create_prompt(self, prompt_data: PromptCreate) -> PromptResponse:
         """Create a new prompt.
@@ -582,3 +598,73 @@ class PromptService:
                 f"Failed to remove prompt from model config KB: {e!s}",
                 "REMOVE_MODEL_CONFIG_KB_PROMPT_ERROR",
             )
+
+    async def cp_upsert_by_name(
+        self,
+        tenant_id: str,
+        payload: SetPromptRequest,
+        reason: str,
+    ) -> SetPromptResponse:
+        """Upsert a single CP-supplied prompt by `(tenant_id, name)`.
+
+        On collision, the row's `id` is preserved so any downstream
+        `model_configurations.prompt_id` references stay valid. Writes
+        `is_system_default=True` on insert (it's the convention for
+        CP-shipped canonical prompts); we don't toggle it on subsequent
+        upserts. `entity_type` defaults to `EntityType.LLM_MODEL` when CP
+        leaves it unset — the column is NOT NULL on the DB, and llm_model
+        is the dominant CP use case.
+
+        Writes go through the model layer directly, not the in-tenant
+        `/prompts` router. The `is_system_default` 403 gate at
+        `api/prompts.py` is a tenant-admin guard against accidental edits
+        of CP-managed rows; CP itself is the writer that SETS the flag.
+        """
+        if self._tenant_admin_svc is None or self._audit is None:
+            raise RuntimeError(
+                "PromptService.cp_upsert_by_name requires tenant_admin_svc and audit_logger to be injected"
+            )
+
+        entity_type = payload.prompt.entity_type or EntityType.LLM_MODEL
+
+        async with self._tenant_admin_svc.impersonate_tenant(tenant_id, CP_ACTOR, reason) as session:
+            existing = (
+                await session.execute(
+                    select(Prompt)
+                    .where(
+                        and_(
+                            Prompt.name == payload.prompt.name,
+                            Prompt.entity_type == entity_type,
+                        )
+                    )
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+
+            if existing is None:
+                prompt = Prompt(
+                    name=payload.prompt.name,
+                    content=payload.prompt.content,
+                    entity_type=entity_type,
+                    is_system_default=True,
+                    is_active=True,
+                )
+                session.add(prompt)
+                await session.flush()
+                event = "cp_prompt_inserted"
+            else:
+                existing.content = payload.prompt.content
+                # `entity_type` is part of the natural key, so a re-call that
+                # matches the existing row by name+entity_type leaves it as-is.
+                prompt = existing
+                event = "cp_prompt_updated"
+
+            await self._audit.log(
+                event=event,
+                actor=CP_ACTOR,
+                target=payload.prompt.name,
+                reason=reason,
+            )
+            await session.commit()
+
+        return SetPromptResponse(prompt_id=prompt.id)

--- a/backend/src/shu/services/prompt_service.py
+++ b/backend/src/shu/services/prompt_service.py
@@ -607,13 +607,15 @@ class PromptService:
     ) -> SetPromptResponse:
         """Upsert a single CP-supplied prompt by `(tenant_id, name)`.
 
+        Natural key is `(tenant_id, name)` and the row is always written with
+        `entity_type=llm_model`. CP-managed prompts are pinned to llm_model
+        so the model-config resolver (which filters on the same constant)
+        cannot bind to a different-entity-type row with a colliding name.
+
         On collision, the row's `id` is preserved so any downstream
-        `model_configurations.prompt_id` references stay valid. Writes
-        `is_system_default=True` on insert (it's the convention for
-        CP-shipped canonical prompts); we don't toggle it on subsequent
-        upserts. `entity_type` defaults to `EntityType.LLM_MODEL` when CP
-        leaves it unset — the column is NOT NULL on the DB, and llm_model
-        is the dominant CP use case.
+        `model_configurations.prompt_id` references stay valid; `content`
+        is overwritten; `is_system_default` is written on insert and left
+        untouched on update.
 
         Writes go through the model layer directly, not the in-tenant
         `/prompts` router. The `is_system_default` 403 gate at
@@ -625,8 +627,6 @@ class PromptService:
                 "PromptService.cp_upsert_by_name requires tenant_admin_svc and audit_logger to be injected"
             )
 
-        entity_type = payload.prompt.entity_type or EntityType.LLM_MODEL
-
         async with self._tenant_admin_svc.impersonate_tenant(tenant_id, CP_ACTOR, reason) as session:
             existing = (
                 await session.execute(
@@ -634,7 +634,7 @@ class PromptService:
                     .where(
                         and_(
                             Prompt.name == payload.prompt.name,
-                            Prompt.entity_type == entity_type,
+                            Prompt.entity_type == EntityType.LLM_MODEL,
                         )
                     )
                     .limit(1)
@@ -645,7 +645,7 @@ class PromptService:
                 prompt = Prompt(
                     name=payload.prompt.name,
                     content=payload.prompt.content,
-                    entity_type=entity_type,
+                    entity_type=EntityType.LLM_MODEL,
                     is_system_default=True,
                     is_active=True,
                 )
@@ -654,8 +654,6 @@ class PromptService:
                 event = "cp_prompt_inserted"
             else:
                 existing.content = payload.prompt.content
-                # `entity_type` is part of the natural key, so a re-call that
-                # matches the existing row by name+entity_type leaves it as-is.
                 prompt = existing
                 event = "cp_prompt_updated"
 

--- a/backend/src/shu/services/prompt_service.py
+++ b/backend/src/shu/services/prompt_service.py
@@ -614,8 +614,9 @@ class PromptService:
 
         On collision, the row's `id` is preserved so any downstream
         `model_configurations.prompt_id` references stay valid; `content`
-        is overwritten; `is_system_default` is written on insert and left
-        untouched on update.
+        is overwritten; `is_system_default` and `is_active` are re-asserted
+        to True so a row a tenant admin had deactivated or had its flag
+        flipped gets self-healed back to the CP-managed state.
 
         Writes go through the model layer directly, not the in-tenant
         `/prompts` router. The `is_system_default` 403 gate at
@@ -654,6 +655,11 @@ class PromptService:
                 event = "cp_prompt_inserted"
             else:
                 existing.content = payload.prompt.content
+                # Re-assert the CP-managed invariants on update so a row a
+                # tenant admin had deactivated (or had its system-default
+                # flag flipped) gets self-healed back to the state CP claims.
+                existing.is_active = True
+                existing.is_system_default = True
                 prompt = existing
                 event = "cp_prompt_updated"
 

--- a/backend/src/shu/services/side_call_service.py
+++ b/backend/src/shu/services/side_call_service.py
@@ -23,14 +23,14 @@ from ..models.llm_provider import Message
 from ..models.model_configuration import ModelConfiguration
 from ..services.chat_types import ChatContext
 from ..services.model_configuration_service import ModelConfigurationService
+from ..services.side_call_settings import (
+    PROFILING_MODEL_SETTING_KEY,
+    SIDE_CALL_MODEL_SETTING_KEY,
+)
 from ..services.system_settings_service import SystemSettingsService
 from ..services.usage_recording import get_usage_recorder
 
 logger = get_logger(__name__)
-
-# Constants for side-call configuration
-SIDE_CALL_MODEL_SETTING_KEY = "side_call_model_config_id"
-PROFILING_MODEL_SETTING_KEY = "profiling_model_config_id"
 
 
 class SideCallResult:

--- a/backend/src/shu/services/side_call_settings.py
+++ b/backend/src/shu/services/side_call_settings.py
@@ -1,0 +1,4 @@
+"""Shared system-setting keys for side-call model selection."""
+
+SIDE_CALL_MODEL_SETTING_KEY = "side_call_model_config_id"
+PROFILING_MODEL_SETTING_KEY = "profiling_model_config_id"

--- a/backend/src/shu/services/tenant_admin_service.py
+++ b/backend/src/shu/services/tenant_admin_service.py
@@ -27,13 +27,32 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from shu.auth.models import User
+from shu.auth.password_auth import PasswordAuthService
+from shu.billing.state_service import BillingStateService
+from shu.core.exceptions import ConflictError
 from shu.core.logging import get_logger
 from shu.core.tenant import tenant_context_for_tenant_id
+from shu.models.tenant import Tenant
+from shu.schemas.cp_provisioning import CreateTenantRequest, CreateTenantResponse
 from shu.services.audit_logger import AuditLogger
+from shu.services.knowledge_base_service import (
+    KnowledgeBaseService,
+    resolve_personal_kb_name,
+    resolve_personal_kb_slug_token,
+)
+from shu.services.password_reset_service import PasswordResetService
 
 logger = get_logger(__name__)
+
+# Used as the `actor` field on every audit event emitted by CP-driven flows.
+# Public (no leading underscore) because the per-domain services
+# (PolicyService, PromptService, etc.) re-export it for their own cp_*
+# methods rather than redeclaring the literal. One canonical source.
+CP_ACTOR = "cp:control-plane"
 
 
 class TenantAdminService:
@@ -52,10 +71,17 @@ class TenantAdminService:
         app_session_local: async_sessionmaker[AsyncSession],
         admin_session_local: async_sessionmaker[AsyncSession],
         audit_logger: AuditLogger,
+        password_auth: PasswordAuthService | None = None,
+        password_reset: PasswordResetService | None = None,
     ) -> None:
         self._app_session_local = app_session_local
         self._admin_session_local = admin_session_local
         self._audit = audit_logger
+        # These two are only required by `create_tenant` (CP provisioning).
+        # Existing impersonate / cross_tenant_query callers don't touch them.
+        # Made keyword-only + optional so old wire-ups don't break.
+        self._password_auth = password_auth
+        self._password_reset = password_reset
 
     async def _emit_exit_audit(
         self,
@@ -172,3 +198,166 @@ class TenantAdminService:
                 target=None,
                 body_exc=body_exc,
             )
+
+    async def create_tenant(
+        self,
+        payload: CreateTenantRequest,
+        reason: str,
+    ) -> CreateTenantResponse:
+        """Seed a brand-new tenant: tenants + billing_state + first regular user.
+
+        Two transaction boundaries by necessity. The `tenants` row is a
+        global write (admin role, no RLS context), and the per-tenant rows
+        need `app.tenant_id` set so RLS WITH CHECK and the auto-stamp
+        before_flush listener cooperate. Idempotency rides on the natural
+        unique keys (tenants.id PK, billing_state.tenant_id PK, users.email
+        UNIQUE), so a CP retry after a partial failure resumes cleanly.
+
+        Stripe identity is immutable once set: re-call with a diverging
+        `stripe_customer_id` or `stripe_subscription_id` raises 409 *before*
+        `BillingStateService.update()` so we don't audit-log an overwrite we
+        then roll back.
+
+        Welcome email is once-only: re-call against an existing user row
+        returns `welcome_email_sent=False` and skips `request_reset`.
+        """
+        if self._password_auth is None or self._password_reset is None:
+            # Misconfiguration; raise so the operator sees it during a smoke
+            # test rather than after a partial provision. Distinct from 503
+            # because this is a wire-up bug, not a transient outage.
+            raise RuntimeError(
+                "TenantAdminService.create_tenant requires password_auth and password_reset to be injected"
+            )
+
+        # --- Step 1: tenants row (admin/global write, no RLS context) ---
+        async with self.cross_tenant_query(CP_ACTOR, reason) as admin_session:
+            existing_tenant = (
+                await admin_session.execute(select(Tenant).where(Tenant.id == payload.tenant_id))
+            ).scalar_one_or_none()
+
+            if existing_tenant is None:
+                admin_session.add(Tenant(id=payload.tenant_id))
+                await admin_session.commit()
+                await self._audit.log(
+                    event="cp_tenant_inserted",
+                    actor=CP_ACTOR,
+                    target=payload.tenant_id,
+                    reason=reason,
+                )
+            else:
+                await self._audit.log(
+                    event="cp_tenant_found",
+                    actor=CP_ACTOR,
+                    target=payload.tenant_id,
+                    reason=reason,
+                )
+
+        # --- Step 2: billing_state + user + welcome email (tenant-scoped) ---
+        async with self.impersonate_tenant(payload.tenant_id, CP_ACTOR, reason) as session:
+            state, billing_state_created = await BillingStateService.ensure_exists(session)
+
+            # Stripe identity is immutable. Reject before update() so we
+            # don't write an audit row for an overwrite we then have to
+            # roll back. First-time fill (existing value is NULL) is allowed.
+            if not billing_state_created:
+                conflicts: list[str] = []
+                if (
+                    state.stripe_customer_id is not None
+                    and state.stripe_customer_id != payload.billing.stripe_customer_id
+                ):
+                    conflicts.append("stripe_customer_id")
+                if (
+                    state.stripe_subscription_id is not None
+                    and state.stripe_subscription_id != payload.billing.stripe_subscription_id
+                ):
+                    conflicts.append("stripe_subscription_id")
+                if conflicts:
+                    raise ConflictError(
+                        f"Stripe identity diverges from existing billing_state: {conflicts}",
+                        details={"conflicting_fields": conflicts},
+                    )
+
+            updates: dict[str, Any] = {
+                "user_limit_enforcement": payload.billing.user_limit_enforcement,
+            }
+            if payload.billing.stripe_customer_id is not None:
+                updates["stripe_customer_id"] = payload.billing.stripe_customer_id
+            if payload.billing.stripe_subscription_id is not None:
+                updates["stripe_subscription_id"] = payload.billing.stripe_subscription_id
+            if payload.billing.billing_email is not None:
+                updates["billing_email"] = payload.billing.billing_email
+            await BillingStateService.update(
+                session,
+                updates=updates,
+                source="cp:provision",
+            )
+
+            existing_user = (
+                await session.execute(select(User).where(User.email == payload.user.email))
+            ).scalar_one_or_none()
+
+            if existing_user is not None:
+                user = existing_user
+                welcome_email_sent = False
+                await self._audit.log(
+                    event="cp_user_found",
+                    actor=CP_ACTOR,
+                    target=user.id,
+                    reason=reason,
+                )
+            else:
+                # generate_temporary_password produces a strict-policy-passing
+                # value so create_user's validate_password step is happy. We
+                # don't surface it — the user gets in via the reset email.
+                temp_password = self._password_auth.generate_temporary_password()
+                user = await self._password_auth.create_user(
+                    email=payload.user.email,
+                    password=temp_password,
+                    name=payload.user.name,
+                    role="regular_user",
+                    db=session,
+                    admin_created=True,
+                )
+                await self._audit.log(
+                    event="cp_user_inserted",
+                    actor=CP_ACTOR,
+                    target=user.id,
+                    reason=reason,
+                )
+                # Provision the user's Personal Knowledge Base. The frontend
+                # assumes one exists on first chat; the in-tenant endpoint
+                # (POST /knowledge-bases/personal) auto-provisions on demand,
+                # but that costs a round trip before first message. Seeding
+                # here removes the gap — the user lands in chat with their
+                # KB already there. `ensure_personal_knowledge_base` is
+                # idempotent, so a retry on this whole flow is safe.
+                kb_svc = KnowledgeBaseService(session)
+                await kb_svc.ensure_personal_knowledge_base(
+                    owner_id=user.id,
+                    display_name=resolve_personal_kb_name(user),
+                    slug_token=resolve_personal_kb_slug_token(user),
+                )
+                await self._audit.log(
+                    event="cp_personal_kb_ensured",
+                    actor=CP_ACTOR,
+                    target=user.id,
+                    reason=reason,
+                )
+                # request_reset runs INSIDE the impersonate transaction so an
+                # email-queue failure rolls the just-flushed user back. CP's
+                # retry then re-attempts cleanly via the existing-user path.
+                await self._password_reset.request_reset(
+                    email=payload.user.email,
+                    ip=None,
+                    db=session,
+                )
+                welcome_email_sent = True
+
+            await session.commit()
+
+        return CreateTenantResponse(
+            tenant_id=payload.tenant_id,
+            user_id=user.id,
+            welcome_email_sent=welcome_email_sent,
+            billing_state_created=billing_state_created,
+        )

--- a/backend/src/shu/services/tenant_admin_service.py
+++ b/backend/src/shu/services/tenant_admin_service.py
@@ -28,6 +28,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from shu.auth.models import User
@@ -71,15 +72,12 @@ class TenantAdminService:
         app_session_local: async_sessionmaker[AsyncSession],
         admin_session_local: async_sessionmaker[AsyncSession],
         audit_logger: AuditLogger,
-        password_auth: PasswordAuthService | None = None,
-        password_reset: PasswordResetService | None = None,
+        password_auth: PasswordAuthService,
+        password_reset: PasswordResetService,
     ) -> None:
         self._app_session_local = app_session_local
         self._admin_session_local = admin_session_local
         self._audit = audit_logger
-        # These two are only required by `create_tenant` (CP provisioning).
-        # Existing impersonate / cross_tenant_query callers don't touch them.
-        # Made keyword-only + optional so old wire-ups don't break.
         self._password_auth = password_auth
         self._password_reset = password_reset
 
@@ -206,29 +204,32 @@ class TenantAdminService:
     ) -> CreateTenantResponse:
         """Seed a brand-new tenant: tenants + billing_state + first regular user.
 
-        Two transaction boundaries by necessity. The `tenants` row is a
-        global write (admin role, no RLS context), and the per-tenant rows
-        need `app.tenant_id` set so RLS WITH CHECK and the auto-stamp
-        before_flush listener cooperate. Idempotency rides on the natural
-        unique keys (tenants.id PK, billing_state.tenant_id PK, users.email
-        UNIQUE), so a CP retry after a partial failure resumes cleanly.
+        Atomicity contract: user creation and the reset-token write live in a
+        single transaction. ``create_user`` is called with ``flush_only=True``
+        and ``request_reset`` only flushes — so an email-queue failure rolls
+        the just-flushed user back. CP's retry then re-fires the create+reset
+        path because the user row no longer exists.
+
+        Two session boundaries are still required: ``tenants`` is a global
+        write (admin role, no RLS context); the per-tenant rows need
+        ``app.tenant_id`` set so RLS WITH CHECK and the auto-stamp listener
+        cooperate. Idempotency rides on the natural unique keys (tenants.id
+        PK, billing_state.tenant_id PK, users.email UNIQUE).
 
         Stripe identity is immutable once set: re-call with a diverging
-        `stripe_customer_id` or `stripe_subscription_id` raises 409 *before*
-        `BillingStateService.update()` so we don't audit-log an overwrite we
-        then roll back.
+        ``stripe_customer_id`` or ``stripe_subscription_id`` raises 409
+        *before* ``BillingStateService.update()`` so we don't audit-log an
+        overwrite we then have to roll back.
 
         Welcome email is once-only: re-call against an existing user row
-        returns `welcome_email_sent=False` and skips `request_reset`.
-        """
-        if self._password_auth is None or self._password_reset is None:
-            # Misconfiguration; raise so the operator sees it during a smoke
-            # test rather than after a partial provision. Distinct from 503
-            # because this is a wire-up bug, not a transient outage.
-            raise RuntimeError(
-                "TenantAdminService.create_tenant requires password_auth and password_reset to be injected"
-            )
+        returns ``welcome_email_sent=False`` and skips ``request_reset``.
 
+        Personal-KB ensure runs *after* the user commit and unconditionally
+        (idempotent by owner). Running it after-commit keeps it outside the
+        user-flush rollback window, and running it on every call repairs the
+        rare case where a previous attempt committed the user but crashed
+        before the KB row was created.
+        """
         # --- Step 1: tenants row (admin/global write, no RLS context) ---
         async with self.cross_tenant_query(CP_ACTOR, reason) as admin_session:
             existing_tenant = (
@@ -310,42 +311,39 @@ class TenantAdminService:
                 # value so create_user's validate_password step is happy. We
                 # don't surface it — the user gets in via the reset email.
                 temp_password = self._password_auth.generate_temporary_password()
-                user = await self._password_auth.create_user(
-                    email=payload.user.email,
-                    password=temp_password,
-                    name=payload.user.name,
-                    role="regular_user",
-                    db=session,
-                    admin_created=True,
-                )
+                # flush_only=True keeps the user pending in this transaction
+                # so request_reset's failure rolls it back. The final commit
+                # below is the only place this user becomes durable.
+                try:
+                    user = await self._password_auth.create_user(
+                        email=payload.user.email,
+                        password=temp_password,
+                        name=payload.user.name,
+                        role="regular_user",
+                        db=session,
+                        admin_created=True,
+                        flush_only=True,
+                    )
+                except IntegrityError as exc:
+                    # users.email is globally unique. The same-tenant case was
+                    # caught by the existence check above, so reaching here
+                    # means the email belongs to a user in a different tenant
+                    # (invisible under RLS). Translate to 409 — leaking the
+                    # other tenant's user_id would be a privacy violation, so
+                    # the details echo only the email CP supplied.
+                    raise ConflictError(
+                        "user email already exists outside this tenant",
+                        details={"conflicting_fields": ["email"], "email": payload.user.email},
+                    ) from exc
                 await self._audit.log(
                     event="cp_user_inserted",
                     actor=CP_ACTOR,
                     target=user.id,
                     reason=reason,
                 )
-                # Provision the user's Personal Knowledge Base. The frontend
-                # assumes one exists on first chat; the in-tenant endpoint
-                # (POST /knowledge-bases/personal) auto-provisions on demand,
-                # but that costs a round trip before first message. Seeding
-                # here removes the gap — the user lands in chat with their
-                # KB already there. `ensure_personal_knowledge_base` is
-                # idempotent, so a retry on this whole flow is safe.
-                kb_svc = KnowledgeBaseService(session)
-                await kb_svc.ensure_personal_knowledge_base(
-                    owner_id=user.id,
-                    display_name=resolve_personal_kb_name(user),
-                    slug_token=resolve_personal_kb_slug_token(user),
-                )
-                await self._audit.log(
-                    event="cp_personal_kb_ensured",
-                    actor=CP_ACTOR,
-                    target=user.id,
-                    reason=reason,
-                )
-                # request_reset runs INSIDE the impersonate transaction so an
-                # email-queue failure rolls the just-flushed user back. CP's
-                # retry then re-attempts cleanly via the existing-user path.
+                # request_reset uses db.flush()-only (see service body); a
+                # failure here aborts the impersonate transaction and the
+                # user flush is rolled back with it.
                 await self._password_reset.request_reset(
                     email=payload.user.email,
                     ip=None,
@@ -354,6 +352,24 @@ class TenantAdminService:
                 welcome_email_sent = True
 
             await session.commit()
+
+            # KB ensure runs after the user/billing commit. It uses its own
+            # internal commit and is owner-idempotent — a retry after a
+            # crash that committed the user but never reached this point
+            # heals the missing KB. Lives inside the impersonate context so
+            # the RLS tenant scope is still active.
+            kb_svc = KnowledgeBaseService(session)
+            await kb_svc.ensure_personal_knowledge_base(
+                owner_id=user.id,
+                display_name=resolve_personal_kb_name(user),
+                slug_token=resolve_personal_kb_slug_token(user),
+            )
+            await self._audit.log(
+                event="cp_personal_kb_ensured",
+                actor=CP_ACTOR,
+                target=user.id,
+                reason=reason,
+            )
 
         return CreateTenantResponse(
             tenant_id=payload.tenant_id,

--- a/backend/src/shu/services/user_service.py
+++ b/backend/src/shu/services/user_service.py
@@ -40,10 +40,10 @@ from ..auth import JWTManager, User, UserRole
 from ..core.config import get_settings_instance
 from ..core.exceptions import ConflictError, NotFoundError
 from ..models.provider_identity import ProviderIdentity
+from ..schemas.cp_provisioning import SetUserActiveResponse
 from ..services.tenant_admin_service import CP_ACTOR
 
 if TYPE_CHECKING:
-    from ..schemas.cp_provisioning import SetUserActiveResponse
     from ..services.audit_logger import AuditLogger
     from ..services.tenant_admin_service import TenantAdminService
 
@@ -409,7 +409,7 @@ class UserService:
         reason: str,
         tenant_admin_svc: "TenantAdminService",
         audit_logger: "AuditLogger",
-    ) -> "SetUserActiveResponse":
+    ) -> SetUserActiveResponse:
         """CP-driven `users.is_active` flip on the single user in a tenant.
 
         Multi-tenants are one-user-per-customer by construction, so the
@@ -422,16 +422,17 @@ class UserService:
           is broken; refuse to guess which user CP meant. A human resolves
           the upstream condition before the kill-switch can be used.
 
+        Audit emission and the `is_active` write live in the same
+        transaction so an audit failure (fail-closed contract) rolls the
+        flip back. The user row is loaded `FOR UPDATE` so a racing INSERT
+        can't sneak a second user in between our SELECT and our write.
+
         No Stripe interaction. CP owns seat quantities externally; a
         TOS-driven deactivation keeps the seat paid so re-activation is
         a free flip.
         """
-        # Imported lazily here to avoid an import-time cycle:
-        # user_service ← ... ← cp_provisioning schemas ← .
-        from ..schemas.cp_provisioning import SetUserActiveResponse
-
         async with tenant_admin_svc.impersonate_tenant(tenant_id, CP_ACTOR, reason) as session:
-            users = list((await session.execute(select(User))).scalars().all())
+            users = list((await session.execute(select(User).with_for_update())).scalars().all())
             if len(users) == 0:
                 raise NotFoundError(f"tenant {tenant_id} has no users to (de)activate")
             if len(users) > 1:
@@ -442,15 +443,15 @@ class UserService:
                 )
             user = users[0]
             user.is_active = is_active
-            await session.commit()
 
-        await audit_logger.log(
-            event="cp_user_active_set",
-            actor=CP_ACTOR,
-            target=user.id,
-            reason=reason,
-            is_active=is_active,
-        )
+            await audit_logger.log(
+                event="cp_user_active_set",
+                actor=CP_ACTOR,
+                target=user.id,
+                reason=reason,
+                is_active=is_active,
+            )
+            await session.commit()
 
         return SetUserActiveResponse(
             user_id=user.id,

--- a/backend/src/shu/services/user_service.py
+++ b/backend/src/shu/services/user_service.py
@@ -27,7 +27,7 @@ Usage:
 
 import hashlib
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
 from sqlalchemy import func, select
@@ -38,7 +38,14 @@ from shu.core.logging import get_logger
 
 from ..auth import JWTManager, User, UserRole
 from ..core.config import get_settings_instance
+from ..core.exceptions import ConflictError, NotFoundError
 from ..models.provider_identity import ProviderIdentity
+from ..services.tenant_admin_service import CP_ACTOR
+
+if TYPE_CHECKING:
+    from ..schemas.cp_provisioning import SetUserActiveResponse
+    from ..services.audit_logger import AuditLogger
+    from ..services.tenant_admin_service import TenantAdminService
 
 logger = get_logger(__name__)
 
@@ -394,6 +401,62 @@ class UserService:
             )
 
         return user
+
+    async def cp_set_user_active(
+        self,
+        tenant_id: str,
+        is_active: bool,
+        reason: str,
+        tenant_admin_svc: "TenantAdminService",
+        audit_logger: "AuditLogger",
+    ) -> "SetUserActiveResponse":
+        """CP-driven `users.is_active` flip on the single user in a tenant.
+
+        Multi-tenants are one-user-per-customer by construction, so the
+        endpoint does not take a `user_id` — it addresses "the" user. Two
+        invariants are enforced here:
+
+        * Tenant has zero users → 404. CP must call POST /admin/cp/tenants
+          before flipping anyone active.
+        * Tenant has more than one user → 409. The multi-tenant invariant
+          is broken; refuse to guess which user CP meant. A human resolves
+          the upstream condition before the kill-switch can be used.
+
+        No Stripe interaction. CP owns seat quantities externally; a
+        TOS-driven deactivation keeps the seat paid so re-activation is
+        a free flip.
+        """
+        # Imported lazily here to avoid an import-time cycle:
+        # user_service ← ... ← cp_provisioning schemas ← .
+        from ..schemas.cp_provisioning import SetUserActiveResponse
+
+        async with tenant_admin_svc.impersonate_tenant(tenant_id, CP_ACTOR, reason) as session:
+            users = list((await session.execute(select(User))).scalars().all())
+            if len(users) == 0:
+                raise NotFoundError(f"tenant {tenant_id} has no users to (de)activate")
+            if len(users) > 1:
+                raise ConflictError(
+                    f"multi-tenant invariant violated: tenant {tenant_id} has "
+                    f"{len(users)} users; expected exactly one",
+                    details={"tenant_id": tenant_id, "user_count": len(users)},
+                )
+            user = users[0]
+            user.is_active = is_active
+            await session.commit()
+
+        await audit_logger.log(
+            event="cp_user_active_set",
+            actor=CP_ACTOR,
+            target=user.id,
+            reason=reason,
+            is_active=is_active,
+        )
+
+        return SetUserActiveResponse(
+            user_id=user.id,
+            email=user.email,
+            is_active=user.is_active,
+        )
 
 
 # Dependency provider for UserService

--- a/backend/src/tests/unit/api/admin/test_tenant_admin.py
+++ b/backend/src/tests/unit/api/admin/test_tenant_admin.py
@@ -1,0 +1,176 @@
+"""Unit tests for the CP-driven `/admin/cp/*` route handlers.
+
+Per project policy ("Unit tests call functions directly with mocked deps"),
+these tests invoke the handler coroutines as plain functions with mocked
+services. No ASGI transport, no live HMAC envelope verification — the
+HMAC dep is covered by `billing/router_envelope` tests already, and
+mounting the same dep on a new router doesn't change its behaviour.
+
+The handlers must be pure delegation: parse → call service method →
+return. These tests assert exactly that.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shu.api.admin.tenant_admin import (
+    cp_create_tenant,
+    cp_set_model_configs,
+    cp_set_policies,
+    cp_set_prompt,
+    cp_set_user_active,
+)
+from shu.schemas.cp_provisioning import (
+    BillingInput,
+    CreateTenantRequest,
+    CreateTenantResponse,
+    ModelConfigInput,
+    PolicyInput,
+    PolicyStatementInput,
+    PromptInput,
+    SetModelConfigsRequest,
+    SetModelConfigsResponse,
+    SetPoliciesRequest,
+    SetPoliciesResponse,
+    SetPromptRequest,
+    SetPromptResponse,
+    SetUserActiveRequest,
+    SetUserActiveResponse,
+    UserInput,
+)
+
+
+@pytest.mark.asyncio
+async def test_cp_create_tenant_delegates() -> None:
+    payload = CreateTenantRequest(
+        tenant_id="t-1",
+        billing=BillingInput(subscription_status="active"),
+        user=UserInput(email="u@example.com", name="Alice"),
+        reason="seed",
+    )
+    expected = CreateTenantResponse(
+        tenant_id="t-1",
+        user_id="user-1",
+        welcome_email_sent=True,
+        billing_state_created=True,
+    )
+    admin_svc = MagicMock()
+    admin_svc.create_tenant = AsyncMock(return_value=expected)
+
+    result = await cp_create_tenant(payload, admin_svc=admin_svc)
+
+    assert result is expected
+    admin_svc.create_tenant.assert_awaited_once_with(payload, "seed")
+
+
+@pytest.mark.asyncio
+async def test_cp_set_model_configs_delegates() -> None:
+    payload = SetModelConfigsRequest(
+        configs=[
+            ModelConfigInput(name="default", provider_name="openai", model_name="gpt-4")
+        ],
+        reason="set MCs",
+    )
+    expected = SetModelConfigsResponse(
+        config_ids_by_name={"default": "mc-1"},
+        side_call_model_config_id=None,
+        profiling_model_config_id=None,
+    )
+    mc_svc = MagicMock()
+    mc_svc.cp_upsert_by_name = AsyncMock(return_value=expected)
+
+    result = await cp_set_model_configs("t-1", payload, mc_svc=mc_svc)
+
+    assert result is expected
+    mc_svc.cp_upsert_by_name.assert_awaited_once_with("t-1", payload, "set MCs")
+
+
+@pytest.mark.asyncio
+async def test_cp_set_policies_delegates() -> None:
+    payload = SetPoliciesRequest(
+        policies=[
+            PolicyInput(
+                name="readers",
+                effect="allow",
+                statements=[
+                    PolicyStatementInput(actions=["kb.read"], resources=["kb:*"])
+                ],
+            )
+        ],
+        reason="set policies",
+    )
+    expected = SetPoliciesResponse(
+        policy_ids_by_name={"readers": "pol-1"},
+        bindings_created=1,
+    )
+    policy_svc = MagicMock()
+    policy_svc.cp_replace_and_bind = AsyncMock(return_value=expected)
+
+    result = await cp_set_policies("t-1", payload, policy_svc=policy_svc)
+
+    assert result is expected
+    policy_svc.cp_replace_and_bind.assert_awaited_once_with("t-1", payload, "set policies")
+
+
+@pytest.mark.asyncio
+async def test_cp_set_prompt_delegates() -> None:
+    payload = SetPromptRequest(
+        prompt=PromptInput(name="canonical", content="hello"),
+        reason="set prompt",
+    )
+    expected = SetPromptResponse(prompt_id="prompt-1")
+    prompt_svc = MagicMock()
+    prompt_svc.cp_upsert_by_name = AsyncMock(return_value=expected)
+
+    result = await cp_set_prompt("t-1", payload, prompt_svc=prompt_svc)
+
+    assert result is expected
+    prompt_svc.cp_upsert_by_name.assert_awaited_once_with("t-1", payload, "set prompt")
+
+
+@pytest.mark.asyncio
+async def test_cp_set_user_active_delegates() -> None:
+    payload = SetUserActiveRequest(is_active=False, reason="TOS")
+    expected = SetUserActiveResponse(
+        user_id="u-1", email="u@example.com", is_active=False
+    )
+    user_svc = MagicMock()
+    user_svc.cp_set_user_active = AsyncMock(return_value=expected)
+    admin_svc = MagicMock()
+    audit = MagicMock()
+
+    result = await cp_set_user_active(
+        "t-1",
+        payload,
+        user_svc=user_svc,
+        admin_svc=admin_svc,
+        audit=audit,
+    )
+
+    assert result is expected
+    user_svc.cp_set_user_active.assert_awaited_once_with(
+        "t-1",
+        False,
+        "TOS",
+        tenant_admin_svc=admin_svc,
+        audit_logger=audit,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_propagates_service_exceptions() -> None:
+    """A 404/409 raised by the service must bubble — handlers do no catching."""
+    payload = SetPromptRequest(
+        prompt=PromptInput(name="x", content="y"),
+        reason="r",
+    )
+    from shu.core.exceptions import NotFoundError
+
+    prompt_svc = MagicMock()
+    prompt_svc.cp_upsert_by_name = AsyncMock(side_effect=NotFoundError("boom"))
+
+    with pytest.raises(NotFoundError, match="boom"):
+        await cp_set_prompt("t-1", payload, prompt_svc=prompt_svc)

--- a/backend/src/tests/unit/api/admin/test_tenant_admin.py
+++ b/backend/src/tests/unit/api/admin/test_tenant_admin.py
@@ -47,7 +47,7 @@ from shu.schemas.cp_provisioning import (
 async def test_cp_create_tenant_delegates() -> None:
     payload = CreateTenantRequest(
         tenant_id="t-1",
-        billing=BillingInput(subscription_status="active"),
+        billing=BillingInput(),
         user=UserInput(email="u@example.com", name="Alice"),
         reason="seed",
     )

--- a/backend/src/tests/unit/schemas/test_cp_provisioning.py
+++ b/backend/src/tests/unit/schemas/test_cp_provisioning.py
@@ -1,9 +1,9 @@
 """Unit tests for CP provisioning schema validators.
 
 Per project policy "test our code, not the framework": only the bits we wrote
-get tests here — the `subscription_status` allowlist, the `effect` Literal
-narrowing, and the `extra="forbid"` config we set. Pydantic's StrictStr,
-default handling, and bool parsing are not retested.
+get tests here — the `effect` Literal narrowing, the `min_length=1` constraints
+on policy statements, and the `extra="forbid"` config we set. Pydantic's
+StrictStr, default handling, and bool parsing are not retested.
 """
 
 from __future__ import annotations
@@ -21,32 +21,6 @@ from shu.schemas.cp_provisioning import (
 
 def _valid_statement_kwargs() -> dict[str, object]:
     return {"actions": ["kb.read"], "resources": ["kb:*"]}
-
-
-def _valid_billing_kwargs(**overrides: object) -> dict[str, object]:
-    defaults: dict[str, object] = {"subscription_status": "active"}
-    defaults.update(overrides)
-    return defaults
-
-
-class TestBillingInputSubscriptionStatus:
-    """The custom allowlist enforced by `_validate_seed_status`."""
-
-    @pytest.mark.parametrize("status", ["active", "trialing", "pending"])
-    def test_allowed_statuses_pass(self, status: str) -> None:
-        billing = BillingInput(**_valid_billing_kwargs(subscription_status=status))
-        assert billing.subscription_status == status
-
-    @pytest.mark.parametrize("status", ["canceled", "unpaid", "past_due", "", "ACTIVE"])
-    def test_blocked_statuses_raise(self, status: str) -> None:
-        with pytest.raises(ValidationError) as exc_info:
-            BillingInput(**_valid_billing_kwargs(subscription_status=status))
-        # Surface the field name + supplied value so test failures point at
-        # the right place — guards against the validator silently widening
-        # its accepted set later.
-        msg = str(exc_info.value)
-        assert "subscription_status" in msg
-        assert status in msg or repr(status) in msg
 
 
 class TestPolicyEffectLiteral:
@@ -96,8 +70,11 @@ class TestExtraForbid:
         assert "unexpected_field" in str(exc_info.value)
 
     def test_unknown_nested_field_is_rejected(self) -> None:
+        # `subscription_status` was removed in the SHU-774 wake — sending it
+        # should now be rejected by `extra="forbid"` rather than silently
+        # accepted-then-dropped. This pins that contract.
         with pytest.raises(ValidationError) as exc_info:
             BillingInput(
-                **_valid_billing_kwargs(stripe_customer_id_typo="cus_x"),  # type: ignore[arg-type]
+                subscription_status="active",  # type: ignore[call-arg]
             )
-        assert "stripe_customer_id_typo" in str(exc_info.value)
+        assert "subscription_status" in str(exc_info.value)

--- a/backend/src/tests/unit/schemas/test_cp_provisioning.py
+++ b/backend/src/tests/unit/schemas/test_cp_provisioning.py
@@ -1,0 +1,103 @@
+"""Unit tests for CP provisioning schema validators.
+
+Per project policy "test our code, not the framework": only the bits we wrote
+get tests here — the `subscription_status` allowlist, the `effect` Literal
+narrowing, and the `extra="forbid"` config we set. Pydantic's StrictStr,
+default handling, and bool parsing are not retested.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from shu.schemas.cp_provisioning import (
+    BillingInput,
+    PolicyInput,
+    PolicyStatementInput,
+    SetUserActiveRequest,
+)
+
+
+def _valid_statement_kwargs() -> dict[str, object]:
+    return {"actions": ["kb.read"], "resources": ["kb:*"]}
+
+
+def _valid_billing_kwargs(**overrides: object) -> dict[str, object]:
+    defaults: dict[str, object] = {"subscription_status": "active"}
+    defaults.update(overrides)
+    return defaults
+
+
+class TestBillingInputSubscriptionStatus:
+    """The custom allowlist enforced by `_validate_seed_status`."""
+
+    @pytest.mark.parametrize("status", ["active", "trialing", "pending"])
+    def test_allowed_statuses_pass(self, status: str) -> None:
+        billing = BillingInput(**_valid_billing_kwargs(subscription_status=status))
+        assert billing.subscription_status == status
+
+    @pytest.mark.parametrize("status", ["canceled", "unpaid", "past_due", "", "ACTIVE"])
+    def test_blocked_statuses_raise(self, status: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            BillingInput(**_valid_billing_kwargs(subscription_status=status))
+        # Surface the field name + supplied value so test failures point at
+        # the right place — guards against the validator silently widening
+        # its accepted set later.
+        msg = str(exc_info.value)
+        assert "subscription_status" in msg
+        assert status in msg or repr(status) in msg
+
+
+class TestPolicyEffectLiteral:
+    """The Literal["allow", "deny"] narrowing on `PolicyInput.effect`."""
+
+    @pytest.mark.parametrize("effect", ["allow", "deny"])
+    def test_valid_effects_pass(self, effect: str) -> None:
+        policy = PolicyInput(
+            name="readers",
+            effect=effect,
+            statements=[PolicyStatementInput(**_valid_statement_kwargs())],
+        )
+        assert policy.effect == effect
+
+    @pytest.mark.parametrize("effect", ["permit", "ALLOW", "", "block"])
+    def test_invalid_effects_raise(self, effect: str) -> None:
+        with pytest.raises(ValidationError):
+            PolicyInput(
+                name="readers",
+                effect=effect,
+                statements=[PolicyStatementInput(**_valid_statement_kwargs())],
+            )
+
+
+class TestPolicyStatementNonEmptyLists:
+    """`min_length=1` constraints we added on actions/resources."""
+
+    def test_empty_actions_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            PolicyStatementInput(actions=[], resources=["kb:*"])
+
+    def test_empty_resources_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            PolicyStatementInput(actions=["kb.read"], resources=[])
+
+
+class TestExtraForbid:
+    """`extra="forbid"` config on every CP inbound model."""
+
+    def test_unknown_top_level_field_is_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            SetUserActiveRequest(
+                is_active=True,
+                reason="emergency lockout",
+                unexpected_field="oops",  # type: ignore[call-arg]
+            )
+        assert "unexpected_field" in str(exc_info.value)
+
+    def test_unknown_nested_field_is_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            BillingInput(
+                **_valid_billing_kwargs(stripe_customer_id_typo="cus_x"),  # type: ignore[arg-type]
+            )
+        assert "stripe_customer_id_typo" in str(exc_info.value)

--- a/backend/src/tests/unit/services/test_model_configuration_service.py
+++ b/backend/src/tests/unit/services/test_model_configuration_service.py
@@ -127,6 +127,11 @@ def _make_cp_service() -> tuple[
         tenant_admin_svc=tenant_admin_svc,
         audit_logger=audit,
     )
+    # Bypass adapter-aware override normalization by default — these tests
+    # use MagicMock providers without real `provider_definition` rows, so a
+    # real adapter lookup would KeyError. Tests that exercise normalization
+    # itself override this stub.
+    svc._normalize_parameter_overrides = MagicMock(return_value={})
     return svc, session, tenant_admin_svc, audit, session.execute
 
 

--- a/backend/src/tests/unit/services/test_model_configuration_service.py
+++ b/backend/src/tests/unit/services/test_model_configuration_service.py
@@ -40,3 +40,277 @@ class TestGetModelConfigurationLogging:
         message = warning_mock.call_args.args[0]
         assert "user-1" in message
         assert "pii@example.com" not in message
+
+
+# ---------------------------------------------------------------------------
+# cp_upsert_by_name (SHU-785) — provider resolution, idempotent upsert,
+# side-call / profiling pointer writes, batch rollback on resolution failure.
+# ---------------------------------------------------------------------------
+
+from contextlib import asynccontextmanager  # noqa: E402
+
+from shu.core.exceptions import NotFoundError  # noqa: E402
+from shu.schemas.cp_provisioning import (  # noqa: E402
+    ModelConfigInput,
+    SetModelConfigsRequest,
+)
+from shu.services.side_call_settings import (  # noqa: E402
+    PROFILING_MODEL_SETTING_KEY,
+    SIDE_CALL_MODEL_SETTING_KEY,
+)
+
+
+def _make_cfg(
+    *,
+    name: str = "default",
+    provider_name: str = "openai-prod",
+    model_name: str = "gpt-4",
+    prompt_name: str | None = None,
+    parameter_overrides: dict | None = None,
+) -> ModelConfigInput:
+    return ModelConfigInput(
+        name=name,
+        provider_name=provider_name,
+        model_name=model_name,
+        prompt_name=prompt_name,
+        parameter_overrides=parameter_overrides,
+    )
+
+
+def _make_payload(
+    *,
+    configs: list[ModelConfigInput] | None = None,
+    side_call_model_config_name: str | None = None,
+    profiling_model_config_name: str | None = None,
+) -> SetModelConfigsRequest:
+    return SetModelConfigsRequest(
+        configs=configs if configs is not None else [_make_cfg()],
+        side_call_model_config_name=side_call_model_config_name,
+        profiling_model_config_name=profiling_model_config_name,
+        reason="cp set MCs",
+    )
+
+
+def _scalar_result(value: object) -> MagicMock:
+    """Build a result object whose scalar_one_or_none() returns `value`."""
+    res = MagicMock()
+    res.scalar_one_or_none = MagicMock(return_value=value)
+    return res
+
+
+def _make_cp_service() -> tuple[
+    ModelConfigurationService,
+    MagicMock,
+    AsyncMock,
+    AsyncMock,
+    AsyncMock,
+]:
+    """Build a CP-wired ModelConfigurationService.
+
+    Returns (service, session, tenant_admin_svc, audit, session_execute).
+    Tests configure `session_execute.side_effect` to a list of result mocks
+    matching the service's SELECT order (first_user → provider → model →
+    [prompt?] → existing_mc → [pointer lookups]).
+    """
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _impersonate(tenant_id, actor, reason):
+        yield session
+
+    tenant_admin_svc = MagicMock()
+    tenant_admin_svc.impersonate_tenant = _impersonate
+
+    audit = AsyncMock()
+
+    svc = ModelConfigurationService(
+        db=MagicMock(),  # unused by cp method
+        tenant_admin_svc=tenant_admin_svc,
+        audit_logger=audit,
+    )
+    return svc, session, tenant_admin_svc, audit, session.execute
+
+
+class TestCpUpsertByName:
+    """CP-driven model_configurations upsert + system_settings pointer write."""
+
+    @pytest.mark.asyncio
+    async def test_provider_not_found_raises_and_rolls_back_batch(self) -> None:
+        svc, session, _, _, execute = _make_cp_service()
+        # Order: first_user query → provider query (returns None) → boom.
+        execute.side_effect = [
+            _scalar_result("user-1"),
+            _scalar_result(None),
+        ]
+        with pytest.raises(NotFoundError, match="llm_provider"):
+            await svc.cp_upsert_by_name(
+                "tenant-1",
+                _make_payload(),
+                reason="r",
+            )
+        session.add.assert_not_called()
+        session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prompt_name_unresolved_raises_and_rolls_back_batch(self) -> None:
+        svc, session, _, _, execute = _make_cp_service()
+        provider = MagicMock(id="prov-1")
+        execute.side_effect = [
+            _scalar_result("user-1"),
+            _scalar_result(provider),
+            _scalar_result("model-row-1"),
+            _scalar_result(None),  # prompt lookup
+        ]
+        with pytest.raises(NotFoundError, match="prompt"):
+            await svc.cp_upsert_by_name(
+                "tenant-1",
+                _make_payload(configs=[_make_cfg(prompt_name="missing")]),
+                reason="r",
+            )
+        session.add.assert_not_called()
+        session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_inserts_new_mc_and_writes_side_call_pointer(self) -> None:
+        svc, session, _, audit, execute = _make_cp_service()
+        provider = MagicMock(id="prov-1")
+
+        # The session.add will receive both the ModelConfiguration and
+        # SystemSetting rows. Capture them to inspect.
+        added: list = []
+        session.add.side_effect = lambda obj: added.append(obj)
+
+        # After session.add(mc), session.flush sets mc.id. Simulate by
+        # patching flush to set the id on the just-added MC.
+        async def _flush_side_effect() -> None:
+            if added and added[-1].__class__.__name__ == "ModelConfiguration":
+                added[-1].id = "mc-new-1"
+        session.flush.side_effect = _flush_side_effect
+
+        execute.side_effect = [
+            _scalar_result("user-1"),       # first user
+            _scalar_result(provider),       # provider lookup
+            _scalar_result("model-row-1"),  # model validation
+            _scalar_result(None),           # existing MC lookup → none → insert
+            _scalar_result(None),           # side-call SystemSetting lookup → none → insert
+        ]
+
+        resp = await svc.cp_upsert_by_name(
+            "tenant-1",
+            _make_payload(side_call_model_config_name="default"),
+            reason="r",
+        )
+
+        assert resp.config_ids_by_name == {"default": "mc-new-1"}
+        assert resp.side_call_model_config_id == "mc-new-1"
+        assert resp.profiling_model_config_id is None
+
+        # Pointer-write went to the correct system_settings key.
+        ss_rows = [o for o in added if o.__class__.__name__ == "SystemSetting"]
+        assert len(ss_rows) == 1
+        assert ss_rows[0].key == SIDE_CALL_MODEL_SETTING_KEY
+        assert ss_rows[0].value["model_config_id"] == "mc-new-1"
+
+        # Audit: per-MC insert + pointer upsert.
+        event_names = [c.kwargs.get("event") for c in audit.log.await_args_list]
+        assert "cp_model_config_inserted" in event_names
+        assert "cp_system_setting_upserted" in event_names
+
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_upsert_existing_mc_preserves_id(self) -> None:
+        svc, session, _, _, execute = _make_cp_service()
+        provider = MagicMock(id="prov-1")
+        existing_mc = MagicMock(
+            id="mc-stable-1",
+            llm_provider_id="prov-old",
+            model_name="old-model",
+        )
+
+        execute.side_effect = [
+            _scalar_result("user-1"),
+            _scalar_result(provider),
+            _scalar_result("model-row-1"),
+            _scalar_result(existing_mc),  # MC already exists
+        ]
+
+        resp = await svc.cp_upsert_by_name(
+            "tenant-1",
+            _make_payload(),
+            reason="r",
+        )
+
+        # ID is preserved on re-upsert (no new row created); mc fields are
+        # written through the model attributes, not a fresh INSERT.
+        assert resp.config_ids_by_name == {"default": "mc-stable-1"}
+        session.add.assert_not_called()  # no new MC INSERT
+        assert existing_mc.llm_provider_id == "prov-1"
+        assert existing_mc.model_name == "gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_profiling_pointer_can_reference_pre_existing_mc(self) -> None:
+        """profiling_model_config_name need not be in the current `configs` batch."""
+        svc, session, _, _, execute = _make_cp_service()
+        provider = MagicMock(id="prov-1")
+
+        # Set up flush to assign an id when an MC is added.
+        added: list = []
+        session.add.side_effect = lambda obj: added.append(obj)
+
+        async def _flush_side_effect() -> None:
+            if added and added[-1].__class__.__name__ == "ModelConfiguration":
+                added[-1].id = "mc-new-1"
+        session.flush.side_effect = _flush_side_effect
+
+        execute.side_effect = [
+            _scalar_result("user-1"),       # first user
+            _scalar_result(provider),       # provider lookup
+            _scalar_result("model-row-1"),  # model validation
+            _scalar_result(None),           # existing MC lookup → none → insert
+            # profiling_model_config_name="legacy-mc" not in batch — lookup tenant
+            _scalar_result("mc-legacy-1"),
+            _scalar_result(None),           # profiling SystemSetting upsert (insert)
+        ]
+
+        resp = await svc.cp_upsert_by_name(
+            "tenant-1",
+            _make_payload(profiling_model_config_name="legacy-mc"),
+            reason="r",
+        )
+
+        assert resp.profiling_model_config_id == "mc-legacy-1"
+        # Pointer goes into the profiling key, not side-call.
+        ss_rows = [o for o in added if o.__class__.__name__ == "SystemSetting"]
+        assert any(s.key == PROFILING_MODEL_SETTING_KEY for s in ss_rows)
+
+    @pytest.mark.asyncio
+    async def test_pointer_to_unknown_mc_name_raises(self) -> None:
+        svc, _, _, _, execute = _make_cp_service()
+        provider = MagicMock(id="prov-1")
+
+        execute.side_effect = [
+            _scalar_result("user-1"),
+            _scalar_result(provider),
+            _scalar_result("model-row-1"),
+            _scalar_result(None),           # MC insert path
+            _scalar_result(None),           # side-call name lookup → not found
+        ]
+
+        with pytest.raises(NotFoundError, match="model_configuration"):
+            await svc.cp_upsert_by_name(
+                "tenant-1",
+                _make_payload(side_call_model_config_name="nope"),
+                reason="r",
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_deps_raises_runtime_error(self) -> None:
+        """Calling without injected tenant_admin_svc / audit is a wire-up bug."""
+        svc = ModelConfigurationService(db=MagicMock())
+        with pytest.raises(RuntimeError, match="tenant_admin_svc and audit_logger"):
+            await svc.cp_upsert_by_name("tenant-1", _make_payload(), reason="r")

--- a/backend/src/tests/unit/services/test_model_configuration_service.py
+++ b/backend/src/tests/unit/services/test_model_configuration_service.py
@@ -1,10 +1,17 @@
 """Unit tests for ModelConfigurationService."""
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from shu.core.exceptions import NotFoundError
+from shu.schemas.cp_provisioning import ModelConfigInput, SetModelConfigsRequest
 from shu.services.model_configuration_service import ModelConfigurationService
+from shu.services.side_call_settings import (
+    PROFILING_MODEL_SETTING_KEY,
+    SIDE_CALL_MODEL_SETTING_KEY,
+)
 
 
 class TestGetModelConfigurationLogging:
@@ -46,18 +53,6 @@ class TestGetModelConfigurationLogging:
 # cp_upsert_by_name (SHU-785) — provider resolution, idempotent upsert,
 # side-call / profiling pointer writes, batch rollback on resolution failure.
 # ---------------------------------------------------------------------------
-
-from contextlib import asynccontextmanager  # noqa: E402
-
-from shu.core.exceptions import NotFoundError  # noqa: E402
-from shu.schemas.cp_provisioning import (  # noqa: E402
-    ModelConfigInput,
-    SetModelConfigsRequest,
-)
-from shu.services.side_call_settings import (  # noqa: E402
-    PROFILING_MODEL_SETTING_KEY,
-    SIDE_CALL_MODEL_SETTING_KEY,
-)
 
 
 def _make_cfg(

--- a/backend/src/tests/unit/services/test_policy_service.py
+++ b/backend/src/tests/unit/services/test_policy_service.py
@@ -519,3 +519,238 @@ class TestGetEffectivePolicies:
 
         assert response.user_id == "user-1"
         assert len(response.policies) == 1
+
+
+# ---------------------------------------------------------------------------
+# cp_replace_and_bind (SHU-785) — wipe-and-replace semantics, bindings,
+# cache invalidation.
+# ---------------------------------------------------------------------------
+
+from contextlib import asynccontextmanager  # noqa: E402
+
+from shu.schemas.cp_provisioning import (  # noqa: E402
+    PolicyInput as CpPolicyInput,
+    PolicyStatementInput as CpPolicyStatementInput,
+    SetPoliciesRequest,
+)
+from shu.services.policy_service import PolicyService  # noqa: E402
+
+
+def _cp_payload(
+    *,
+    policies: list[CpPolicyInput] | None = None,
+    bind_to_all_users: bool = True,
+) -> SetPoliciesRequest:
+    if policies is None:
+        policies = [
+            CpPolicyInput(
+                name="readers",
+                effect="allow",
+                statements=[CpPolicyStatementInput(actions=["kb.read"], resources=["kb:*"])],
+            )
+        ]
+    return SetPoliciesRequest(
+        policies=policies,
+        bind_to_all_users=bind_to_all_users,
+        reason="cp set policies",
+    )
+
+
+def _cp_session_and_svc(
+    *,
+    first_user_id: str | None = "user-1",
+    replaced_count: int = 0,
+    all_user_ids: list[str] | None = None,
+    payload_has_policies: bool = True,
+) -> tuple[PolicyService, MagicMock, AsyncMock]:
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    def _scalar(v):
+        r = MagicMock()
+        r.scalar_one_or_none = MagicMock(return_value=v)
+        r.scalar = MagicMock(return_value=v)
+        r.scalars = MagicMock(
+            return_value=MagicMock(
+                all=MagicMock(return_value=v if isinstance(v, list) else [])
+            )
+        )
+        return r
+
+    # SELECT order the service makes:
+    # 1. first_user lex query
+    # 2. (if payload has policies) count(*) for replaced_count audit
+    # 3. (if payload has policies) delete(AccessPolicy) execute — no scalar usage
+    # 4. (if bind_to_all_users and policies were inserted) select all User.id
+    results = [_scalar(first_user_id)]
+    if payload_has_policies:
+        results.append(_scalar(replaced_count))
+        results.append(_scalar(None))
+    if all_user_ids is not None:
+        results.append(_scalar(all_user_ids))
+    session.execute.side_effect = results
+
+    @asynccontextmanager
+    async def _impersonate(tenant_id, actor, reason):
+        yield session
+
+    tenant_admin_svc = MagicMock()
+    tenant_admin_svc.impersonate_tenant = _impersonate
+
+    audit = AsyncMock()
+
+    svc = PolicyService(
+        db=MagicMock(),
+        tenant_admin_svc=tenant_admin_svc,
+        audit_logger=audit,
+    )
+    return svc, session, audit
+
+
+class TestCpReplaceAndBind:
+    @pytest.mark.asyncio
+    async def test_no_users_raises_404(self) -> None:
+        svc, _, _ = _cp_session_and_svc(first_user_id=None)
+        with pytest.raises(NotFoundError, match="no users"):
+            await svc.cp_replace_and_bind(
+                "tenant-1", _cp_payload(), reason="r"
+            )
+
+    @pytest.mark.asyncio
+    async def test_replace_named_policies_with_bindings(self) -> None:
+        svc, session, audit = _cp_session_and_svc(
+            first_user_id="user-1",
+            replaced_count=2,  # two policies with these names existed before
+            all_user_ids=["user-1", "user-2"],
+        )
+
+        flushed_ids = iter(["pol-new-1", "pol-new-2"])
+        added_rows: list = []
+        session.add.side_effect = lambda obj: added_rows.append(obj)
+
+        async def _flush_side_effect() -> None:
+            for obj in reversed(added_rows):
+                if obj.__class__.__name__ == "AccessPolicy" and getattr(obj, "id", None) is None:
+                    obj.id = next(flushed_ids)
+                    return
+
+        session.flush.side_effect = _flush_side_effect
+
+        with patch("shu.services.policy_service.POLICY_CACHE.invalidate") as inv:
+            resp = await svc.cp_replace_and_bind(
+                "tenant-1",
+                _cp_payload(
+                    policies=[
+                        CpPolicyInput(
+                            name="readers",
+                            effect="allow",
+                            statements=[
+                                CpPolicyStatementInput(actions=["kb.read"], resources=["kb:*"])
+                            ],
+                        ),
+                        CpPolicyInput(
+                            name="writers",
+                            effect="allow",
+                            statements=[
+                                CpPolicyStatementInput(actions=["kb.write"], resources=["kb:*"])
+                            ],
+                        ),
+                    ]
+                ),
+                reason="r",
+            )
+
+        assert resp.policy_ids_by_name == {"readers": "pol-new-1", "writers": "pol-new-2"}
+        assert resp.bindings_created == 4  # 2 policies × 2 users
+
+        policies_added = [o for o in added_rows if o.__class__.__name__ == "AccessPolicy"]
+        assert all(p.created_by == "user-1" for p in policies_added)
+
+        session.commit.assert_awaited_once()
+        inv.assert_called_once()
+
+        events = [c.kwargs.get("event") for c in audit.log.await_args_list]
+        # New event name: "replace_started" with replaced_count + new_count
+        # instead of the old "wiped" semantic.
+        assert "cp_policies_replace_started" in events
+        replace_event = next(
+            c for c in audit.log.await_args_list
+            if c.kwargs.get("event") == "cp_policies_replace_started"
+        )
+        assert replace_event.kwargs["replaced_count"] == 2
+        assert replace_event.kwargs["new_count"] == 2
+        assert events.count("cp_policy_inserted") == 2
+        assert "cp_policy_bindings_created" in events
+
+    @pytest.mark.asyncio
+    async def test_bind_to_all_users_false_skips_bindings(self) -> None:
+        svc, session, _ = _cp_session_and_svc(
+            first_user_id="user-1",
+            replaced_count=0,
+            all_user_ids=None,
+        )
+
+        added_rows: list = []
+        session.add.side_effect = lambda obj: added_rows.append(obj)
+
+        async def _flush_side_effect() -> None:
+            for obj in reversed(added_rows):
+                if obj.__class__.__name__ == "AccessPolicy" and getattr(obj, "id", None) is None:
+                    obj.id = "pol-1"
+                    return
+
+        session.flush.side_effect = _flush_side_effect
+
+        with patch("shu.services.policy_service.POLICY_CACHE.invalidate"):
+            resp = await svc.cp_replace_and_bind(
+                "tenant-1",
+                _cp_payload(bind_to_all_users=False),
+                reason="r",
+            )
+
+        assert resp.bindings_created == 0
+        binding_rows = [o for o in added_rows if o.__class__.__name__ == "AccessPolicyBinding"]
+        assert binding_rows == []
+
+    @pytest.mark.asyncio
+    async def test_empty_policy_set_is_noop_no_destructive_delete(self) -> None:
+        """Empty payload is a no-op — does NOT wipe the tenant's existing
+        policies. Critical safety invariant for silo deployments where the
+        tenant IS the database; an unfiltered wipe would erase the customer.
+        """
+        svc, session, audit = _cp_session_and_svc(
+            first_user_id="user-1",
+            payload_has_policies=False,  # no COUNT/DELETE expected
+            all_user_ids=None,
+        )
+        with patch("shu.services.policy_service.POLICY_CACHE.invalidate") as inv:
+            resp = await svc.cp_replace_and_bind(
+                "tenant-1",
+                _cp_payload(policies=[]),
+                reason="r",
+            )
+        assert resp.policy_ids_by_name == {}
+        assert resp.bindings_created == 0
+        # No COUNT or DELETE query fired — only the first_user lookup.
+        assert session.execute.call_count == 1
+
+        events = [c.kwargs.get("event") for c in audit.log.await_args_list]
+        # The replace_started audit STILL fires so the empty-payload call is
+        # auditable, but with replaced_count=0 and new_count=0.
+        assert events.count("cp_policies_replace_started") == 1
+        replace_event = next(
+            c for c in audit.log.await_args_list
+            if c.kwargs.get("event") == "cp_policies_replace_started"
+        )
+        assert replace_event.kwargs["replaced_count"] == 0
+        assert replace_event.kwargs["new_count"] == 0
+        inv.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_deps_raises_runtime_error(self) -> None:
+        svc = PolicyService(db=MagicMock())
+        with pytest.raises(RuntimeError, match="tenant_admin_svc and audit_logger"):
+            await svc.cp_replace_and_bind("tenant-1", _cp_payload(), reason="r")

--- a/backend/src/tests/unit/services/test_policy_service.py
+++ b/backend/src/tests/unit/services/test_policy_service.py
@@ -12,6 +12,7 @@ Tests cover:
 - get_effective_policies: resolves group memberships
 """
 
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -29,6 +30,11 @@ from shu.schemas.access_policy import (
     EffectivePoliciesResponse,
     PolicyInput,
     StatementInput,
+)
+from shu.schemas.cp_provisioning import (
+    PolicyInput as CpPolicyInput,
+    PolicyStatementInput as CpPolicyStatementInput,
+    SetPoliciesRequest,
 )
 from shu.services.policy_service import PolicyService
 
@@ -522,18 +528,10 @@ class TestGetEffectivePolicies:
 
 
 # ---------------------------------------------------------------------------
-# cp_replace_and_bind (SHU-785) — wipe-and-replace semantics, bindings,
-# cache invalidation.
+# cp_replace_and_bind (SHU-785) — per-name surgical replace, bindings,
+# cache invalidation. Policies not in the payload are left untouched;
+# empty list is a no-op (silo-safety guard).
 # ---------------------------------------------------------------------------
-
-from contextlib import asynccontextmanager  # noqa: E402
-
-from shu.schemas.cp_provisioning import (  # noqa: E402
-    PolicyInput as CpPolicyInput,
-    PolicyStatementInput as CpPolicyStatementInput,
-    SetPoliciesRequest,
-)
-from shu.services.policy_service import PolicyService  # noqa: E402
 
 
 def _cp_payload(

--- a/backend/src/tests/unit/services/test_prompt_service.py
+++ b/backend/src/tests/unit/services/test_prompt_service.py
@@ -1,0 +1,128 @@
+"""Unit tests for PromptService — currently scoped to the CP provisioning path.
+
+Older PromptService coverage lives in `tests/unit/api/test_prompts.py` (the
+generalized prompt API tests). This file adds tests for the CP-driven
+upsert added under SHU-785.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shu.models.prompt import EntityType
+from shu.schemas.cp_provisioning import PromptInput, SetPromptRequest
+from shu.services.prompt_service import PromptService
+
+
+def _payload(
+    *,
+    name: str = "tenant-default",
+    content: str = "You are a careful assistant.",
+    entity_type: str | None = None,
+) -> SetPromptRequest:
+    return SetPromptRequest(
+        prompt=PromptInput(name=name, content=content, entity_type=entity_type),
+        reason="cp set prompt",
+    )
+
+
+def _make_cp_service(
+    *,
+    existing_prompt: object | None = None,
+) -> tuple[PromptService, MagicMock, AsyncMock]:
+    session = MagicMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none = MagicMock(return_value=existing_prompt)
+    session.execute = AsyncMock(return_value=existing_result)
+
+    @asynccontextmanager
+    async def _impersonate(tenant_id, actor, reason):
+        yield session
+
+    tenant_admin_svc = MagicMock()
+    tenant_admin_svc.impersonate_tenant = _impersonate
+
+    audit = AsyncMock()
+
+    svc = PromptService(
+        db=MagicMock(),
+        tenant_admin_svc=tenant_admin_svc,
+        audit_logger=audit,
+    )
+    return svc, session, audit
+
+
+class TestCpUpsertByName:
+    @pytest.mark.asyncio
+    async def test_inserts_new_prompt_with_is_system_default_true(self) -> None:
+        svc, session, audit = _make_cp_service(existing_prompt=None)
+
+        # Capture the inserted row + assign an id on flush.
+        added: list = []
+        session.add.side_effect = lambda obj: added.append(obj)
+
+        async def _flush() -> None:
+            if added and added[-1].id is None:
+                added[-1].id = "prompt-new-1"
+        session.flush.side_effect = _flush
+
+        resp = await svc.cp_upsert_by_name("tenant-1", _payload(), reason="r")
+
+        assert resp.prompt_id == "prompt-new-1"
+        assert len(added) == 1
+        inserted = added[0]
+        assert inserted.is_system_default is True
+        assert inserted.is_active is True
+        assert inserted.entity_type == EntityType.LLM_MODEL  # default
+        session.commit.assert_awaited_once()
+
+        events = [c.kwargs.get("event") for c in audit.log.await_args_list]
+        assert events == ["cp_prompt_inserted"]
+
+    @pytest.mark.asyncio
+    async def test_upsert_existing_preserves_id_and_updates_content(self) -> None:
+        existing = MagicMock(id="prompt-stable-1", content="old")
+        svc, session, audit = _make_cp_service(existing_prompt=existing)
+
+        resp = await svc.cp_upsert_by_name(
+            "tenant-1",
+            _payload(content="new content"),
+            reason="r",
+        )
+
+        assert resp.prompt_id == "prompt-stable-1"  # id preserved
+        assert existing.content == "new content"
+        session.add.assert_not_called()  # no new INSERT
+        events = [c.kwargs.get("event") for c in audit.log.await_args_list]
+        assert events == ["cp_prompt_updated"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_entity_type_is_respected(self) -> None:
+        svc, session, _ = _make_cp_service(existing_prompt=None)
+        added: list = []
+        session.add.side_effect = lambda obj: added.append(obj)
+
+        async def _flush() -> None:
+            if added and added[-1].id is None:
+                added[-1].id = "prompt-1"
+        session.flush.side_effect = _flush
+
+        await svc.cp_upsert_by_name(
+            "tenant-1",
+            _payload(entity_type=EntityType.KNOWLEDGE_BASE),
+            reason="r",
+        )
+        assert added[0].entity_type == EntityType.KNOWLEDGE_BASE
+
+    @pytest.mark.asyncio
+    async def test_missing_deps_raises_runtime_error(self) -> None:
+        svc = PromptService(db=MagicMock())
+        with pytest.raises(RuntimeError, match="tenant_admin_svc and audit_logger"):
+            await svc.cp_upsert_by_name("tenant-1", _payload(), reason="r")

--- a/backend/src/tests/unit/services/test_prompt_service.py
+++ b/backend/src/tests/unit/services/test_prompt_service.py
@@ -21,10 +21,9 @@ def _payload(
     *,
     name: str = "tenant-default",
     content: str = "You are a careful assistant.",
-    entity_type: str | None = None,
 ) -> SetPromptRequest:
     return SetPromptRequest(
-        prompt=PromptInput(name=name, content=content, entity_type=entity_type),
+        prompt=PromptInput(name=name, content=content),
         reason="cp set prompt",
     )
 
@@ -104,7 +103,12 @@ class TestCpUpsertByName:
         assert events == ["cp_prompt_updated"]
 
     @pytest.mark.asyncio
-    async def test_explicit_entity_type_is_respected(self) -> None:
+    async def test_existence_lookup_filters_by_llm_model_entity_type(self) -> None:
+        """The upsert lookup MUST filter on entity_type=llm_model so that a
+        prompt sharing the same name in a different entity_type can't be
+        accidentally targeted. Without this filter, the MC resolver's
+        prompt_name lookup would have the same ambiguity from the read side.
+        """
         svc, session, _ = _make_cp_service(existing_prompt=None)
         added: list = []
         session.add.side_effect = lambda obj: added.append(obj)
@@ -112,14 +116,13 @@ class TestCpUpsertByName:
         async def _flush() -> None:
             if added and added[-1].id is None:
                 added[-1].id = "prompt-1"
+
         session.flush.side_effect = _flush
 
-        await svc.cp_upsert_by_name(
-            "tenant-1",
-            _payload(entity_type=EntityType.KNOWLEDGE_BASE),
-            reason="r",
-        )
-        assert added[0].entity_type == EntityType.KNOWLEDGE_BASE
+        await svc.cp_upsert_by_name("tenant-1", _payload(), reason="r")
+
+        # Newly inserted prompt is pinned to LLM_MODEL.
+        assert added[0].entity_type == EntityType.LLM_MODEL
 
     @pytest.mark.asyncio
     async def test_missing_deps_raises_runtime_error(self) -> None:

--- a/backend/src/tests/unit/services/test_prompt_service.py
+++ b/backend/src/tests/unit/services/test_prompt_service.py
@@ -11,6 +11,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 from shu.models.prompt import EntityType
 from shu.schemas.cp_provisioning import PromptInput, SetPromptRequest
@@ -123,6 +124,20 @@ class TestCpUpsertByName:
 
         # Newly inserted prompt is pinned to LLM_MODEL.
         assert added[0].entity_type == EntityType.LLM_MODEL
+
+        # Inspect the lookup query itself — the mock returns existing_prompt
+        # unconditionally, so we can't rely on it to apply the filter. Compile
+        # the captured Select and verify the entity_type=llm_model predicate
+        # is actually present in the WHERE clause.
+        executed = session.execute.await_args.args[0]
+        compiled_sql = str(
+            executed.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        assert "entity_type" in compiled_sql
+        assert "'llm_model'" in compiled_sql
 
     @pytest.mark.asyncio
     async def test_missing_deps_raises_runtime_error(self) -> None:

--- a/backend/src/tests/unit/services/test_tenant_admin_service.py
+++ b/backend/src/tests/unit/services/test_tenant_admin_service.py
@@ -248,3 +248,278 @@ async def test_aborted_audit_failure_does_not_mask_original_exception() -> None:
     with pytest.raises(_OriginalError):
         async with svc.impersonate_tenant("tenant-X", "actor-1", "ticket"):
             raise _OriginalError("the real reason this failed")
+
+
+# ---------------------------------------------------------------------------
+# create_tenant (SHU-785) — covers happy path, idempotency, and the Stripe
+# identity-immutability 409 path.
+# ---------------------------------------------------------------------------
+
+
+from unittest.mock import patch  # noqa: E402
+
+from shu.auth.password_auth import PasswordAuthService  # noqa: E402
+from shu.billing.state_service import BillingStateService  # noqa: E402
+from shu.core.exceptions import ConflictError  # noqa: E402
+from shu.schemas.cp_provisioning import (  # noqa: E402
+    BillingInput,
+    CreateTenantRequest,
+    UserInput,
+)
+from shu.services.password_reset_service import PasswordResetService  # noqa: E402
+
+
+def _make_billing(**overrides: Any) -> BillingInput:
+    defaults: dict[str, Any] = {"subscription_status": "active"}
+    defaults.update(overrides)
+    return BillingInput(**defaults)
+
+
+def _make_payload(
+    *,
+    tenant_id: str = "tenant-1",
+    email: str = "user@example.com",
+    **billing_overrides: Any,
+) -> CreateTenantRequest:
+    return CreateTenantRequest(
+        tenant_id=tenant_id,
+        billing=_make_billing(**billing_overrides),
+        user=UserInput(email=email, name="Alice"),
+        reason="seed test",
+    )
+
+
+def _make_create_tenant_svc(
+    *,
+    existing_tenant: Any = None,
+    existing_user: Any = None,
+) -> tuple[TenantAdminService, MagicMock, MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Build a TenantAdminService wired with mocks for create_tenant.
+
+    Returns (svc, audit, admin_session, app_session, password_auth, password_reset).
+    The audit mock and per-session mocks let individual tests assert call patterns.
+    """
+    app_factory, app_session = _stub_session_factory()
+    admin_factory, admin_session = _stub_session_factory()
+    audit = AsyncMock()
+
+    tenant_result = MagicMock()
+    tenant_result.scalar_one_or_none = MagicMock(return_value=existing_tenant)
+    admin_session.execute = AsyncMock(return_value=tenant_result)
+    admin_session.add = MagicMock()
+    admin_session.commit = AsyncMock()
+
+    user_result = MagicMock()
+    user_result.scalar_one_or_none = MagicMock(return_value=existing_user)
+    app_session.execute = AsyncMock(return_value=user_result)
+    app_session.commit = AsyncMock()
+
+    password_auth = MagicMock(spec=PasswordAuthService)
+    password_auth.generate_temporary_password = MagicMock(return_value="TempPass1!")
+    new_user = MagicMock()
+    new_user.id = "user-uuid-1"
+    password_auth.create_user = AsyncMock(return_value=new_user)
+
+    password_reset = MagicMock(spec=PasswordResetService)
+    password_reset.request_reset = AsyncMock()
+
+    svc = TenantAdminService(
+        app_session_local=app_factory,
+        admin_session_local=admin_factory,
+        audit_logger=audit,
+        password_auth=password_auth,
+        password_reset=password_reset,
+    )
+    return svc, audit, admin_session, app_session, password_auth, password_reset
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_happy_path() -> None:
+    """All three steps fire in order; response carries the right flags."""
+    svc, audit, admin_session, app_session, password_auth, password_reset = (
+        _make_create_tenant_svc()
+    )
+    fresh_state = MagicMock()
+    fresh_state.stripe_customer_id = None
+    fresh_state.stripe_subscription_id = None
+
+    with (
+        patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
+        patch.object(BillingStateService, "update", new_callable=AsyncMock) as update,
+    ):
+        ensure_exists.return_value = (fresh_state, True)
+
+        response = await svc.create_tenant(
+            _make_payload(stripe_customer_id="cus_123"),
+            reason="seed test",
+        )
+
+    assert response.tenant_id == "tenant-1"
+    assert response.user_id == "user-uuid-1"
+    assert response.welcome_email_sent is True
+    assert response.billing_state_created is True
+
+    # Tenant row was inserted (admin session got an `add` + commit).
+    admin_session.add.assert_called_once()
+    admin_session.commit.assert_awaited_once()
+
+    # billing_state went through the service path, not direct ORM.
+    ensure_exists.assert_awaited_once()
+    update.assert_awaited_once()
+    update_kwargs = update.await_args.kwargs
+    assert update_kwargs["updates"]["stripe_customer_id"] == "cus_123"
+    assert update_kwargs["updates"]["user_limit_enforcement"] == "hard"
+    assert update_kwargs["source"] == "cp:provision"
+
+    # User created with admin_created=True so the first-user auto-promote
+    # path can't fire.
+    password_auth.create_user.assert_awaited_once()
+    create_kwargs = password_auth.create_user.await_args.kwargs
+    assert create_kwargs["admin_created"] is True
+    assert create_kwargs["role"] == "regular_user"
+
+    # Welcome email queued.
+    password_reset.request_reset.assert_awaited_once()
+
+    # All emitted audit events must come from the CP actor.
+    actors = {call.kwargs.get("actor") for call in audit.log.await_args_list}
+    assert actors == {"cp:control-plane"}
+
+    events = [call.kwargs.get("event") for call in audit.log.await_args_list]
+    # Both context-manager open audits, the per-step inserts, and the
+    # exit close events should all have fired.
+    assert "cp_tenant_inserted" in events
+    assert "cp_user_inserted" in events
+    assert "impersonate_tenant_open" in events
+    assert "cross_tenant_query_open" in events
+
+    # Per-step inserts (not the open/close lifecycle events) carry the
+    # caller-supplied reason. The lifecycle events deliberately don't —
+    # `_emit_exit_audit` doesn't pass reason on close/abort.
+    per_step_reasons = {
+        call.kwargs.get("reason")
+        for call in audit.log.await_args_list
+        if call.kwargs.get("event", "").startswith("cp_")
+    }
+    assert per_step_reasons == {"seed test"}
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_idempotent_when_tenant_and_user_already_exist() -> None:
+    """Re-call against a fully-seeded tenant is a no-op for inserts and emails."""
+    existing_tenant = MagicMock()
+    existing_tenant.id = "tenant-1"
+    existing_user = MagicMock()
+    existing_user.id = "user-existing-1"
+
+    svc, _, admin_session, _, password_auth, password_reset = _make_create_tenant_svc(
+        existing_tenant=existing_tenant,
+        existing_user=existing_user,
+    )
+    existing_state = MagicMock()
+    existing_state.stripe_customer_id = "cus_123"
+    existing_state.stripe_subscription_id = None
+
+    with (
+        patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
+        patch.object(BillingStateService, "update", new_callable=AsyncMock),
+    ):
+        ensure_exists.return_value = (existing_state, False)
+
+        response = await svc.create_tenant(
+            _make_payload(stripe_customer_id="cus_123"),
+            reason="seed retry",
+        )
+
+    assert response.user_id == "user-existing-1"
+    assert response.welcome_email_sent is False
+    assert response.billing_state_created is False
+
+    # Tenant row NOT inserted (we already had it).
+    admin_session.add.assert_not_called()
+    # New user NOT created and reset email NOT re-sent.
+    password_auth.create_user.assert_not_awaited()
+    password_reset.request_reset.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_409_on_diverging_stripe_customer_id() -> None:
+    """Existing non-None stripe_customer_id with diverging payload raises BEFORE update()."""
+    svc, _, _, _, _, _ = _make_create_tenant_svc()
+    existing_state = MagicMock()
+    existing_state.stripe_customer_id = "cus_OLD"
+    existing_state.stripe_subscription_id = None
+
+    with (
+        patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
+        patch.object(BillingStateService, "update", new_callable=AsyncMock) as update,
+    ):
+        ensure_exists.return_value = (existing_state, False)
+
+        with pytest.raises(ConflictError) as exc_info:
+            await svc.create_tenant(
+                _make_payload(stripe_customer_id="cus_NEW"),
+                reason="retry",
+            )
+
+    # update() must not run — we don't want to overwrite Stripe identity
+    # then have to roll it back.
+    update.assert_not_awaited()
+    assert "stripe_customer_id" in exc_info.value.details["conflicting_fields"]
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_first_time_fill_stripe_id_is_allowed() -> None:
+    """Existing row has NULL stripe_customer_id; payload supplies one. update() runs."""
+    svc, _, _, _, _, _ = _make_create_tenant_svc()
+    half_filled_state = MagicMock()
+    half_filled_state.stripe_customer_id = None
+    half_filled_state.stripe_subscription_id = None
+
+    with (
+        patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
+        patch.object(BillingStateService, "update", new_callable=AsyncMock) as update,
+    ):
+        ensure_exists.return_value = (half_filled_state, False)
+
+        await svc.create_tenant(
+            _make_payload(stripe_customer_id="cus_FILL"),
+            reason="fill in",
+        )
+
+    update.assert_awaited_once()
+    assert update.await_args.kwargs["updates"]["stripe_customer_id"] == "cus_FILL"
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_request_reset_failure_propagates() -> None:
+    """If request_reset raises, the exception bubbles — the impersonate context's
+    transaction rollback happens via the session __aexit__ on the way out."""
+    svc, _, _, _, _, password_reset = _make_create_tenant_svc()
+    password_reset.request_reset.side_effect = RuntimeError("email queue down")
+    fresh_state = MagicMock()
+    fresh_state.stripe_customer_id = None
+    fresh_state.stripe_subscription_id = None
+
+    with (
+        patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
+        patch.object(BillingStateService, "update", new_callable=AsyncMock),
+    ):
+        ensure_exists.return_value = (fresh_state, True)
+
+        with pytest.raises(RuntimeError, match="email queue down"):
+            await svc.create_tenant(_make_payload(), reason="seed test")
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_without_injected_password_services_raises() -> None:
+    """Wire-up bug surfaces with RuntimeError, not a partial provision."""
+    app_factory, _ = _stub_session_factory()
+    admin_factory, _ = _stub_session_factory()
+    svc = TenantAdminService(
+        app_session_local=app_factory,
+        admin_session_local=admin_factory,
+        audit_logger=AsyncMock(),
+    )
+    with pytest.raises(RuntimeError, match="password_auth and password_reset"):
+        await svc.create_tenant(_make_payload(), reason="seed test")

--- a/backend/src/tests/unit/services/test_tenant_admin_service.py
+++ b/backend/src/tests/unit/services/test_tenant_admin_service.py
@@ -10,12 +10,21 @@ Coverage focus:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from shu.auth.password_auth import PasswordAuthService
+from shu.billing.state_service import BillingStateService
+from shu.core.exceptions import ConflictError
 from shu.core.tenant import tenant_context
+from shu.schemas.cp_provisioning import (
+    BillingInput,
+    CreateTenantRequest,
+    UserInput,
+)
 from shu.services.audit_logger import AuditLogEmitError
+from shu.services.password_reset_service import PasswordResetService
 from shu.services.tenant_admin_service import TenantAdminService
 
 
@@ -34,6 +43,29 @@ def _stub_session_factory() -> tuple[MagicMock, MagicMock]:
     return factory, session
 
 
+def _build_svc(
+    *,
+    app_factory: MagicMock,
+    admin_factory: MagicMock,
+    audit: AsyncMock,
+    password_auth: MagicMock | None = None,
+    password_reset: MagicMock | None = None,
+) -> TenantAdminService:
+    """Construct a TenantAdminService with all required deps.
+
+    The non-CP tests (impersonate_tenant / cross_tenant_query) don't exercise
+    the password collaborators but the constructor requires them — pass
+    plain ``MagicMock()`` placeholders when the test doesn't care.
+    """
+    return TenantAdminService(
+        app_session_local=app_factory,
+        admin_session_local=admin_factory,
+        audit_logger=audit,
+        password_auth=password_auth or MagicMock(spec=PasswordAuthService),
+        password_reset=password_reset or MagicMock(spec=PasswordResetService),
+    )
+
+
 @pytest.mark.asyncio
 async def test_impersonate_tenant_sets_context_during_session() -> None:
     """Inside the contextmanager the tenant_context ContextVar must be the target."""
@@ -41,11 +73,7 @@ async def test_impersonate_tenant_sets_context_during_session() -> None:
     admin_factory, _ = _stub_session_factory()
     audit = AsyncMock()
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     # The autouse conftest fixture pre-sets tenant_context to a default
     # value, so we snapshot it and assert restoration relative to that
@@ -70,11 +98,7 @@ async def test_impersonate_tenant_audits_open_before_session_opens() -> None:
     audit = AsyncMock()
     audit.log.side_effect = AuditLogEmitError("transport down")
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     pre_context = tenant_context.get(None)
     with pytest.raises(AuditLogEmitError):
@@ -93,11 +117,7 @@ async def test_impersonate_tenant_emits_open_and_close_records() -> None:
     admin_factory, _ = _stub_session_factory()
     audit = AsyncMock()
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     async with svc.impersonate_tenant("tenant-X", "actor-1", "ticket 7"):
         pass
@@ -121,11 +141,7 @@ async def test_cross_tenant_query_uses_admin_factory_and_no_context() -> None:
     admin_factory, admin_session = _stub_session_factory()
     audit = AsyncMock()
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     # The cross-tenant path must not *change* the context — whatever the
     # caller had set going in remains set throughout, because BYPASSRLS
@@ -148,11 +164,7 @@ async def test_cross_tenant_query_audits_open_before_session_opens() -> None:
     audit = AsyncMock()
     audit.log.side_effect = AuditLogEmitError("transport down")
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     with pytest.raises(AuditLogEmitError):
         async with svc.cross_tenant_query("actor-1", "usage report Q1"):
@@ -177,11 +189,7 @@ async def test_impersonate_tenant_emits_aborted_event_when_body_raises() -> None
     admin_factory, _ = _stub_session_factory()
     audit = AsyncMock()
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     class _CustomError(RuntimeError):
         pass
@@ -204,11 +212,7 @@ async def test_cross_tenant_query_emits_aborted_event_when_body_raises() -> None
     admin_factory, _ = _stub_session_factory()
     audit = AsyncMock()
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     class _CustomError(RuntimeError):
         pass
@@ -236,11 +240,7 @@ async def test_aborted_audit_failure_does_not_mask_original_exception() -> None:
     # First call (open) succeeds; second call (aborted) raises.
     audit.log.side_effect = [None, AuditLogEmitError("transport hiccup on close")]
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
-    )
+    svc = _build_svc(app_factory=app_factory, admin_factory=admin_factory, audit=audit)
 
     class _OriginalError(RuntimeError):
         pass
@@ -251,26 +251,13 @@ async def test_aborted_audit_failure_does_not_mask_original_exception() -> None:
 
 
 # ---------------------------------------------------------------------------
-# create_tenant (SHU-785) — covers happy path, idempotency, and the Stripe
-# identity-immutability 409 path.
+# create_tenant (SHU-785) — covers happy path, idempotency, the Stripe
+# identity-immutability 409 path, and the atomic-rollback contract.
 # ---------------------------------------------------------------------------
 
 
-from unittest.mock import patch  # noqa: E402
-
-from shu.auth.password_auth import PasswordAuthService  # noqa: E402
-from shu.billing.state_service import BillingStateService  # noqa: E402
-from shu.core.exceptions import ConflictError  # noqa: E402
-from shu.schemas.cp_provisioning import (  # noqa: E402
-    BillingInput,
-    CreateTenantRequest,
-    UserInput,
-)
-from shu.services.password_reset_service import PasswordResetService  # noqa: E402
-
-
 def _make_billing(**overrides: Any) -> BillingInput:
-    defaults: dict[str, Any] = {"subscription_status": "active"}
+    defaults: dict[str, Any] = {}
     defaults.update(overrides)
     return BillingInput(**defaults)
 
@@ -323,19 +310,36 @@ def _make_create_tenant_svc(
     password_reset = MagicMock(spec=PasswordResetService)
     password_reset.request_reset = AsyncMock()
 
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=audit,
+    svc = _build_svc(
+        app_factory=app_factory,
+        admin_factory=admin_factory,
+        audit=audit,
         password_auth=password_auth,
         password_reset=password_reset,
     )
     return svc, audit, admin_session, app_session, password_auth, password_reset
 
 
+def _patch_kb_ensure() -> Any:
+    """Patch the personal-KB ensure call inside create_tenant.
+
+    create_tenant invokes ``KnowledgeBaseService(...).ensure_personal_knowledge_base``
+    unconditionally after the user/billing commit (idempotent self-heal on
+    retry). Tests patch the class at the import site so the side-effects of
+    real KB creation (slug generation, defaults lookup, ORM flush) don't
+    leak into the unit test.
+    """
+    kb_svc_mock = MagicMock()
+    kb_svc_mock.ensure_personal_knowledge_base = AsyncMock()
+    return patch(
+        "shu.services.tenant_admin_service.KnowledgeBaseService",
+        return_value=kb_svc_mock,
+    ), kb_svc_mock
+
+
 @pytest.mark.asyncio
 async def test_create_tenant_happy_path() -> None:
-    """All three steps fire in order; response carries the right flags."""
+    """All four steps fire in order; response carries the right flags."""
     svc, audit, admin_session, app_session, password_auth, password_reset = (
         _make_create_tenant_svc()
     )
@@ -343,9 +347,11 @@ async def test_create_tenant_happy_path() -> None:
     fresh_state.stripe_customer_id = None
     fresh_state.stripe_subscription_id = None
 
+    kb_patcher, kb_svc_mock = _patch_kb_ensure()
     with (
         patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
         patch.object(BillingStateService, "update", new_callable=AsyncMock) as update,
+        kb_patcher,
     ):
         ensure_exists.return_value = (fresh_state, True)
 
@@ -372,14 +378,25 @@ async def test_create_tenant_happy_path() -> None:
     assert update_kwargs["source"] == "cp:provision"
 
     # User created with admin_created=True so the first-user auto-promote
-    # path can't fire.
+    # path can't fire. flush_only=True keeps user pending until commit so
+    # a request_reset failure rolls it back (atomicity contract).
     password_auth.create_user.assert_awaited_once()
     create_kwargs = password_auth.create_user.await_args.kwargs
     assert create_kwargs["admin_created"] is True
     assert create_kwargs["role"] == "regular_user"
+    assert create_kwargs["flush_only"] is True
 
-    # Welcome email queued.
+    # Welcome email queued, INSIDE the impersonate txn so a failure rolls
+    # the just-flushed user back.
     password_reset.request_reset.assert_awaited_once()
+
+    # Personal KB ensured AFTER the user commit, idempotent on retry.
+    kb_svc_mock.ensure_personal_knowledge_base.assert_awaited_once()
+
+    # The atomic-commit-then-KB-then-end ordering: app_session.commit must
+    # fire once (the user/reset commit). KB ensure runs after that — its
+    # own internal commit is the responsibility of the KB service.
+    app_session.commit.assert_awaited_once()
 
     # All emitted audit events must come from the CP actor.
     actors = {call.kwargs.get("actor") for call in audit.log.await_args_list}
@@ -390,6 +407,7 @@ async def test_create_tenant_happy_path() -> None:
     # exit close events should all have fired.
     assert "cp_tenant_inserted" in events
     assert "cp_user_inserted" in events
+    assert "cp_personal_kb_ensured" in events
     assert "impersonate_tenant_open" in events
     assert "cross_tenant_query_open" in events
 
@@ -420,9 +438,11 @@ async def test_create_tenant_idempotent_when_tenant_and_user_already_exist() -> 
     existing_state.stripe_customer_id = "cus_123"
     existing_state.stripe_subscription_id = None
 
+    kb_patcher, kb_svc_mock = _patch_kb_ensure()
     with (
         patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
         patch.object(BillingStateService, "update", new_callable=AsyncMock),
+        kb_patcher,
     ):
         ensure_exists.return_value = (existing_state, False)
 
@@ -440,6 +460,9 @@ async def test_create_tenant_idempotent_when_tenant_and_user_already_exist() -> 
     # New user NOT created and reset email NOT re-sent.
     password_auth.create_user.assert_not_awaited()
     password_reset.request_reset.assert_not_awaited()
+    # KB ensure DOES fire on the existing-user path — it's idempotent and
+    # repairs the rare crash-after-user-commit-before-KB case.
+    kb_svc_mock.ensure_personal_knowledge_base.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -476,9 +499,11 @@ async def test_create_tenant_first_time_fill_stripe_id_is_allowed() -> None:
     half_filled_state.stripe_customer_id = None
     half_filled_state.stripe_subscription_id = None
 
+    kb_patcher, _ = _patch_kb_ensure()
     with (
         patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
         patch.object(BillingStateService, "update", new_callable=AsyncMock) as update,
+        kb_patcher,
     ):
         ensure_exists.return_value = (half_filled_state, False)
 
@@ -492,34 +517,88 @@ async def test_create_tenant_first_time_fill_stripe_id_is_allowed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_tenant_request_reset_failure_propagates() -> None:
-    """If request_reset raises, the exception bubbles — the impersonate context's
-    transaction rollback happens via the session __aexit__ on the way out."""
-    svc, _, _, _, _, password_reset = _make_create_tenant_svc()
+async def test_create_tenant_request_reset_failure_rolls_back_user_and_skips_kb() -> None:
+    """request_reset failure rolls back the just-flushed user, never commits,
+    and never reaches the post-commit KB ensure.
+
+    This is the atomicity contract: a partial provision (user committed
+    without a reset email queued) is the failure mode we explicitly do not
+    want — the user would exist in the DB with no way to log in.
+    """
+    svc, _, _, app_session, password_auth, password_reset = _make_create_tenant_svc()
     password_reset.request_reset.side_effect = RuntimeError("email queue down")
     fresh_state = MagicMock()
     fresh_state.stripe_customer_id = None
     fresh_state.stripe_subscription_id = None
 
+    kb_patcher, kb_svc_mock = _patch_kb_ensure()
     with (
         patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
         patch.object(BillingStateService, "update", new_callable=AsyncMock),
+        kb_patcher,
     ):
         ensure_exists.return_value = (fresh_state, True)
 
         with pytest.raises(RuntimeError, match="email queue down"):
             await svc.create_tenant(_make_payload(), reason="seed test")
 
+    # create_user was called with flush_only=True — the user was never
+    # committed. The impersonate context closes without our final
+    # session.commit() running, so the flushed user rolls back.
+    password_auth.create_user.assert_awaited_once()
+    assert password_auth.create_user.await_args.kwargs["flush_only"] is True
+    app_session.commit.assert_not_awaited()
+
+    # KB ensure runs AFTER the user commit. Since the commit never
+    # happened, KB ensure must not have fired either.
+    kb_svc_mock.ensure_personal_knowledge_base.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_tenant_cross_tenant_email_collision_raises_conflict() -> None:
+    """If create_user's flush hits a UNIQUE violation (email exists in a
+    different tenant — invisible under RLS), translate to a 409 ConflictError
+    rather than letting the IntegrityError surface as a 500.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    svc, _, _, _, password_auth, _ = _make_create_tenant_svc()
+    password_auth.create_user.side_effect = IntegrityError(
+        statement="INSERT INTO users", params=None, orig=Exception("dup")
+    )
+    fresh_state = MagicMock()
+    fresh_state.stripe_customer_id = None
+    fresh_state.stripe_subscription_id = None
+
+    kb_patcher, _ = _patch_kb_ensure()
+    with (
+        patch.object(BillingStateService, "ensure_exists", new_callable=AsyncMock) as ensure_exists,
+        patch.object(BillingStateService, "update", new_callable=AsyncMock),
+        kb_patcher,
+    ):
+        ensure_exists.return_value = (fresh_state, True)
+
+        with pytest.raises(ConflictError) as exc_info:
+            await svc.create_tenant(_make_payload(), reason="cross-tenant email")
+
+    # The 409 body leaks only what CP supplied. Echoing the other tenant's
+    # user id here would be a privacy violation.
+    assert exc_info.value.details["conflicting_fields"] == ["email"]
+    assert exc_info.value.details["email"] == "user@example.com"
+
 
 @pytest.mark.asyncio
 async def test_create_tenant_without_injected_password_services_raises() -> None:
-    """Wire-up bug surfaces with RuntimeError, not a partial provision."""
+    """Wire-up bug surfaces at construction (TypeError), not at first call.
+
+    The CP collaborators are required kwargs on ``__init__`` so this
+    misconfiguration can never reach a request handler.
+    """
     app_factory, _ = _stub_session_factory()
     admin_factory, _ = _stub_session_factory()
-    svc = TenantAdminService(
-        app_session_local=app_factory,
-        admin_session_local=admin_factory,
-        audit_logger=AsyncMock(),
-    )
-    with pytest.raises(RuntimeError, match="password_auth and password_reset"):
-        await svc.create_tenant(_make_payload(), reason="seed test")
+    with pytest.raises(TypeError, match="password_auth"):
+        TenantAdminService(  # type: ignore[call-arg]
+            app_session_local=app_factory,
+            admin_session_local=admin_factory,
+            audit_logger=AsyncMock(),
+        )

--- a/backend/src/tests/unit/services/test_user_service.py
+++ b/backend/src/tests/unit/services/test_user_service.py
@@ -45,3 +45,117 @@ class TestIsActive:
         """First-user activation is unchanged when auto_activate is enabled."""
         user_service.settings.auto_activate_users = True
         assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=True) is True
+
+
+# ---------------------------------------------------------------------------
+# cp_set_user_active (SHU-785) — the CP kill-switch.
+# ---------------------------------------------------------------------------
+
+from contextlib import asynccontextmanager  # noqa: E402
+from unittest.mock import AsyncMock  # noqa: E402
+
+from shu.core.exceptions import ConflictError, NotFoundError  # noqa: E402
+
+
+def _wire_cp(users: list[object]) -> tuple[MagicMock, AsyncMock]:
+    """Build (tenant_admin_svc, audit) wired to a session whose User SELECT
+    returns `users`."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=users)))
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _impersonate(tenant_id, actor, reason):
+        yield session
+
+    tenant_admin_svc = MagicMock()
+    tenant_admin_svc.impersonate_tenant = _impersonate
+
+    audit = AsyncMock()
+    return tenant_admin_svc, audit
+
+
+class TestCpSetUserActive:
+    @pytest.mark.asyncio
+    async def test_flip_to_true_activates_single_user(self) -> None:
+        user = MagicMock(id="user-1", email="u@example.com", is_active=False)
+        tenant_admin, audit = _wire_cp([user])
+
+        resp = await UserService().cp_set_user_active(
+            "tenant-1",
+            is_active=True,
+            reason="reactivate after TOS resolution",
+            tenant_admin_svc=tenant_admin,
+            audit_logger=audit,
+        )
+
+        assert user.is_active is True
+        assert resp.user_id == "user-1"
+        assert resp.is_active is True
+        audit.log.assert_awaited_once()
+        assert audit.log.await_args.kwargs["event"] == "cp_user_active_set"
+        assert audit.log.await_args.kwargs["is_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_flip_to_false_deactivates_single_user(self) -> None:
+        user = MagicMock(id="user-1", email="u@example.com", is_active=True)
+        tenant_admin, audit = _wire_cp([user])
+
+        resp = await UserService().cp_set_user_active(
+            "tenant-1",
+            is_active=False,
+            reason="TOS violation",
+            tenant_admin_svc=tenant_admin,
+            audit_logger=audit,
+        )
+
+        assert user.is_active is False
+        assert resp.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_zero_users_raises_404(self) -> None:
+        tenant_admin, audit = _wire_cp([])
+        with pytest.raises(NotFoundError, match="no users"):
+            await UserService().cp_set_user_active(
+                "tenant-1",
+                is_active=True,
+                reason="r",
+                tenant_admin_svc=tenant_admin,
+                audit_logger=audit,
+            )
+        audit.log.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_more_than_one_user_raises_409(self) -> None:
+        users = [
+            MagicMock(id="user-1", email="a@example.com", is_active=True),
+            MagicMock(id="user-2", email="b@example.com", is_active=True),
+        ]
+        tenant_admin, audit = _wire_cp(users)
+        with pytest.raises(ConflictError) as exc_info:
+            await UserService().cp_set_user_active(
+                "tenant-1",
+                is_active=False,
+                reason="r",
+                tenant_admin_svc=tenant_admin,
+                audit_logger=audit,
+            )
+        assert exc_info.value.details["user_count"] == 2
+        audit.log.assert_not_awaited()
+        assert all(u.is_active is True for u in users)
+
+    @pytest.mark.asyncio
+    async def test_idempotent_reflip_still_audits(self) -> None:
+        """No-state-change case still emits an audit event so the call is recorded."""
+        user = MagicMock(id="user-1", email="u@example.com", is_active=True)
+        tenant_admin, audit = _wire_cp([user])
+        await UserService().cp_set_user_active(
+            "tenant-1",
+            is_active=True,
+            reason="redundant retry",
+            tenant_admin_svc=tenant_admin,
+            audit_logger=audit,
+        )
+        audit.log.assert_awaited_once()

--- a/backend/src/tests/unit/services/test_user_service.py
+++ b/backend/src/tests/unit/services/test_user_service.py
@@ -1,10 +1,12 @@
 """Unit tests for UserService.is_active() with auto_activate_users setting."""
 
-from unittest.mock import MagicMock
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from shu.auth.models import UserRole
+from shu.core.exceptions import ConflictError, NotFoundError
 from shu.services.user_service import UserService
 
 
@@ -50,11 +52,6 @@ class TestIsActive:
 # ---------------------------------------------------------------------------
 # cp_set_user_active (SHU-785) — the CP kill-switch.
 # ---------------------------------------------------------------------------
-
-from contextlib import asynccontextmanager  # noqa: E402
-from unittest.mock import AsyncMock  # noqa: E402
-
-from shu.core.exceptions import ConflictError, NotFoundError  # noqa: E402
 
 
 def _wire_cp(users: list[object]) -> tuple[MagicMock, AsyncMock]:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Control-Plane admin provisioning API with endpoints to create tenants, manage model configurations, set access policies, configure prompts, and control user account states.

* **Bug Fixes**
  * Fixed database schema by removing unintended global unique constraints on tenant-scoped columns and converting them to non-unique indexes to preserve query performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->