### PR TITLE
Shu 803 stop button and partial usage fidelity

### DIFF
--- a/backend/src/shu/core/model_pricing.py
+++ b/backend/src/shu/core/model_pricing.py
@@ -180,7 +180,12 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
     """
     from shu.models.llm_provider import LLMModel
 
-    result = await db.execute(select(LLMModel.model_name))
+    # DISTINCT: model_name has no unique constraint — the same name can be
+    # registered under multiple providers (e.g. ``gpt-4`` on OpenAI direct
+    # and via an Azure proxy). Without DISTINCT the loop would run twice for
+    # the same name, double-counting ``updated``/``cleared`` and producing a
+    # bogus AC9i collision WARN that lists the same name twice.
+    result = await db.execute(select(LLMModel.model_name).distinct())
     db_model_names = [row[0] for row in result.all()]
 
     updated = 0

--- a/backend/src/shu/core/model_pricing.py
+++ b/backend/src/shu/core/model_pricing.py
@@ -33,6 +33,7 @@ Usage:
     # -> {"input": Decimal("0.000001"), "output": Decimal("0.000005")}
 """
 
+import re
 from decimal import Decimal
 
 from sqlalchemy import select, update
@@ -41,6 +42,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from shu.core.logging import get_logger
 
 logger = get_logger(__name__)
+
+# SHU-803 AC9d: regex used by ``_normalize_model_key`` to strip provider
+# prefixes (``vendor/``) and tier suffixes (``:nitro``, ``:free``, etc.)
+# before comparing against MODEL_PRICING. Compiled once at import time.
+_PROVIDER_PREFIX_RE = re.compile(r"^[^/]+/")
+_TIER_SUFFIX_RE = re.compile(r":[^/:]+$")
 
 _MTOK = Decimal("1000000")
 
@@ -83,56 +90,131 @@ MODEL_PRICING: dict[str, dict[str, Decimal]] = {
 }
 
 
+def _normalize_model_key(name: str) -> str:
+    """SHU-803 AC9d: collapse OpenRouter-style slugs to a MODEL_PRICING-comparable key.
+
+    OpenRouter exposes the same underlying model under a vendor-prefixed,
+    tier-suffixed slug (``google/gemma-4-31b-it:nitro``) while
+    ``MODEL_PRICING`` uses bare upstream names (``gemma-4-31B-it``).
+    Exact-string lookup misses those slugs and the DB-rate-fallback path
+    in ``usage_recording.py`` lands cost=0 even when tokens are counted
+    correctly — the billing-evasion abuse vector this AC closes.
+
+    Normalization rules (applied in order):
+    1. Strip a leading ``vendor/`` prefix (one slash; anything before the
+       slash is dropped). Matches OpenRouter / OpenAI-compatible gateway
+       conventions.
+    2. Strip a trailing ``:tier`` suffix (``:nitro``, ``:free``, ``:beta``,
+       etc.). Tier variants share rates with the base model.
+    3. Lowercase. ``gemma-4-31B-it`` and ``gemma-4-31b-it`` are the same
+       model to operators; case differences are a footgun.
+
+    The normalized form is used as a FALLBACK only — exact matches in
+    ``MODEL_PRICING`` still win, so an operator who wants a vendor-specific
+    rate can keep the slug verbatim in MODEL_PRICING and it will resolve
+    via the exact-match path.
+    """
+    if not name:
+        return name
+    normalized = _PROVIDER_PREFIX_RE.sub("", name, count=1)
+    normalized = _TIER_SUFFIX_RE.sub("", normalized, count=1)
+    return normalized.lower()
+
+
+# SHU-803 AC9d: precomputed normalized-key map. Built at module load so the
+# hot lookup path stays O(1). Keyed by the normalized form of every
+# MODEL_PRICING key; values are references into MODEL_PRICING itself so
+# updates to ``MODEL_PRICING`` propagate automatically (Python dict values
+# are shared references).
+_NORMALIZED_PRICING: dict[str, dict[str, Decimal]] = {
+    _normalize_model_key(name): pricing for name, pricing in MODEL_PRICING.items()
+}
+
+
 def get_pricing(model_name: str) -> dict[str, Decimal] | None:
     """Look up per-unit pricing for a model name. Returns None if unknown.
 
     Unit is per-token for chat/embedding models and per-page for ocr models,
     matching ``llm_models.model_type``.
+
+    Lookup strategy (SHU-803 AC9d):
+    1. Exact match against ``MODEL_PRICING``. Preserves the pre-existing
+       behavior for any operator who keeps slug-verbatim keys.
+    2. Normalized fallback via ``_normalize_model_key``. Covers the
+       OpenRouter slug case (``google/gemma-4-31b-it:nitro`` resolves to
+       the ``gemma-4-31B-it`` rates).
     """
-    return MODEL_PRICING.get(model_name)
+    pricing = MODEL_PRICING.get(model_name)
+    if pricing is not None:
+        return pricing
+    return _NORMALIZED_PRICING.get(_normalize_model_key(model_name))
 
 
 async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
     """Push reference pricing into llm_models rows.
 
-    For every model_name in MODEL_PRICING that exists in llm_models, sets
-    cost_per_input_unit and cost_per_output_unit. Models not in the
-    reference dict are left untouched.
+    For every ``llm_models.model_name`` that resolves to a MODEL_PRICING
+    entry (exact or normalized — see :func:`get_pricing`), sets
+    ``cost_per_input_unit`` and ``cost_per_output_unit``. Models that
+    don't resolve are left untouched.
+
+    SHU-803 AC9d: iteration is over DB model names (not MODEL_PRICING
+    keys) so OpenRouter slugs like ``google/gemma-4-31b-it:nitro``
+    pick up rates via the normalized fallback. The pre-fix exact-string
+    iteration left those rows NULL and the DB-rate fallback computed
+    cost=0.
+
+    SHU-803 AC9i: any case where two distinct DB model_name values
+    resolve to the same MODEL_PRICING entry *via the normalized fallback*
+    (i.e. neither matched exactly) logs a WARN naming both. Tier variants
+    that share rates by design (``...:nitro`` and ``...:free``) are the
+    common case and the WARN is informational — operators add explicit
+    MODEL_PRICING entries if they want the variants priced differently.
 
     Returns {"updated": N, "cleared": N, "skipped": N}:
       - updated: row written with non-zero rates.
-      - cleared: row explicitly NULLed because the reference pricing is zero
-        (demote-to-free case — prevents stale rates from a prior sync leaking
-        into DB-rate-fallback cost math).
-      - skipped: model_name was in MODEL_PRICING but not found in llm_models.
+      - cleared: row explicitly NULLed because reference pricing is zero
+        (demote-to-free case — prevents stale rates from a prior sync
+        leaking into DB-rate-fallback cost math).
+      - skipped: db model_name didn't resolve to any MODEL_PRICING entry.
     """
     from shu.models.llm_provider import LLMModel
 
-    # Get all model names currently in the DB
     result = await db.execute(select(LLMModel.model_name))
-    db_model_names = {row[0] for row in result.all()}
+    db_model_names = [row[0] for row in result.all()]
 
     updated = 0
     cleared = 0
-    skipped = 0
+    skipped: list[str] = []
+    # SHU-803 AC9i: track DB names that resolved via the normalized fallback,
+    # keyed by the normalized key they hit. Collisions (>1 db_name per key)
+    # are logged after the sync loop.
+    normalized_collisions: dict[str, list[str]] = {}
 
-    for model_name, pricing in MODEL_PRICING.items():
-        if model_name not in db_model_names:
-            skipped += 1
+    for db_model_name in db_model_names:
+        # Exact match first (preserves pre-fix behavior for any operator
+        # who keeps slug-verbatim MODEL_PRICING keys).
+        pricing = MODEL_PRICING.get(db_model_name)
+        if pricing is None:
+            normalized_key = _normalize_model_key(db_model_name)
+            pricing = _NORMALIZED_PRICING.get(normalized_key)
+            if pricing is not None:
+                normalized_collisions.setdefault(normalized_key, []).append(db_model_name)
+
+        if pricing is None:
+            skipped.append(db_model_name)
             continue
 
         # Zero-cost models (local/self-hosted) should have NULL rate columns so
         # "has pricing" checks (IS NOT NULL) are truthful. If a model used to be
         # paid and got demoted to free in model_pricing.py, a bare `continue`
         # here would leave stale non-null rates in the DB and the fallback cost
-        # math would keep billing the old rates. Explicitly NULL the columns so
-        # the source-of-truth change actually lands. Explicit equality (not
-        # Python truthiness) avoids the Decimal-falsiness foot-gun that bit us
-        # in the cost-contract fallback (now in services/usage_recording.py).
+        # math would keep billing the old rates. Explicit equality (not Python
+        # truthiness) avoids the Decimal-falsiness foot-gun.
         if pricing["input"] == 0 and pricing["output"] == 0:
             await db.execute(
                 update(LLMModel)
-                .where(LLMModel.model_name == model_name)
+                .where(LLMModel.model_name == db_model_name)
                 .values(
                     cost_per_input_unit=None,
                     cost_per_output_unit=None,
@@ -143,7 +225,7 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
 
         await db.execute(
             update(LLMModel)
-            .where(LLMModel.model_name == model_name)
+            .where(LLMModel.model_name == db_model_name)
             .values(
                 cost_per_input_unit=pricing["input"],
                 cost_per_output_unit=pricing["output"],
@@ -152,10 +234,28 @@ async def sync_pricing_to_db(db: AsyncSession) -> dict[str, int]:
         updated += 1
 
     await db.commit()
+
+    # SHU-803 AC9i: surface multi-db-name-to-one-pricing-key cases. Tier
+    # variants are the expected common case (``...:nitro`` and ``...:free``
+    # both normalize to the base); the WARN is informational so operators
+    # can confirm the resolution matches intent.
+    for normalized_key, db_names in normalized_collisions.items():
+        if len(db_names) > 1:
+            logger.warning(
+                "Pricing-lookup normalization collision: %d DB model_name values "
+                "resolved to MODEL_PRICING key %r via normalization fallback. "
+                "If these should be priced differently, add explicit MODEL_PRICING "
+                "entries. Names: %s",
+                len(db_names),
+                normalized_key,
+                ", ".join(db_names),
+            )
+
     logger.info(
-        "Model pricing sync complete: %d updated, %d cleared, %d skipped (not in DB)",
+        "Model pricing sync complete: %d updated, %d cleared, %d skipped (no MODEL_PRICING match): %s",
         updated,
         cleared,
+        len(skipped),
         skipped,
     )
-    return {"updated": updated, "cleared": cleared, "skipped": skipped}
+    return {"updated": updated, "cleared": cleared, "skipped": len(skipped)}

--- a/backend/src/shu/services/chat_service.py
+++ b/backend/src/shu/services/chat_service.py
@@ -175,6 +175,28 @@ class VariantStreamResult:
     # (`shutdown_aborted`) or a stuck upstream (`exception`).
     drain_audit: dict[str, Any] = field(default_factory=dict)
 
+    # SHU-803 follow-up: handoff from terminate-time early-persist into
+    # finalize. When the `on_terminate_signal` callback in
+    # `_stream_variant_phase` runs successfully, the partial assistant
+    # Message row is written at signal time (created_at = signal moment)
+    # so a navigation-driven refetch during drain sees the partial
+    # immediately and a follow-up message sent before drain completes
+    # orders correctly. `_finalize_variant_phase` reads these to decide
+    # UPDATE-existing vs. INSERT-new at drain-finish.
+    #
+    # Both fields are None when:
+    #   - the stream completed naturally (no terminate signal), OR
+    #   - the early-persist callback raised (defensive fallback — finalize
+    #     runs its existing INSERT path so the row still lands at drain-
+    #     finish, just with the pre-fix temporal ordering caveat).
+    #
+    # `early_persisted_variant_index` is needed alongside the id because
+    # the regen path computes the new variant_index from a sibling-max
+    # query at INSERT time — finalize can't recover that index from
+    # `regen_lineage` alone, and we don't want to re-query.
+    early_persisted_message_id: str | None = None
+    early_persisted_variant_index: int | None = None
+
 
 @dataclass
 class RegenLineageInfo:

--- a/backend/src/shu/services/chat_service.py
+++ b/backend/src/shu/services/chat_service.py
@@ -159,6 +159,22 @@ class VariantStreamResult:
     terminated: bool = False
     partial_usage_unavailable: bool = False
 
+    # SHU-803 AC9g: audit fields recorded on the LLMUsage row's
+    # `request_metadata` for terminated streams. Empty dict on the
+    # non-terminated paths; populated by `_call_provider` when drain
+    # runs (after a user_terminated or shutdown signal).
+    #
+    # Keys:
+    #   drain_outcome: Literal["final_event", "done", "exception",
+    #       "shutdown_aborted"] — how drain exited.
+    #   cancel_attempted: bool — whether `adapter.cancel()` was spawned.
+    #   cancel_succeeded: bool — whether it returned True (2xx response).
+    #
+    # Ops uses these to distinguish a clean drain (`final_event` /
+    # `done` — usage captured normally) from a shutdown-truncated drain
+    # (`shutdown_aborted`) or a stuck upstream (`exception`).
+    drain_audit: dict[str, Any] = field(default_factory=dict)
+
 
 @dataclass
 class RegenLineageInfo:

--- a/backend/src/shu/services/chat_streaming.py
+++ b/backend/src/shu/services/chat_streaming.py
@@ -119,6 +119,27 @@ class StreamLifecycle:
     user_id: str
     conversation_id: str
     event: asyncio.Event = field(default_factory=asyncio.Event)
+    # SHU-803 follow-up: dedicated event that fires ONLY when the
+    # lifecycle reason resolves to an intentional stop
+    # (``user_terminated`` or ``shutdown``). ``client_disconnected``
+    # leaves this event unset.
+    #
+    # Rationale: ``_iter_with_signal_break`` races provider chunks
+    # against an event so the consumer loop wakes on a stop signal
+    # without waiting for the next provider chunk. Racing against
+    # ``self.event`` (which fires on ANY signal) breaks for the
+    # disconnect-then-stop sequence: ``client_disconnected`` sets
+    # ``self.event``, the wrapper yields its one-shot sentinel,
+    # ``_call_provider`` ignores it because the reason isn't intentional,
+    # and the wrapper switches to plain chunk-yielding. A later
+    # ``user_terminated`` / ``shutdown`` upgrades ``self.reason`` but
+    # ``self.event`` is already set — so the wrapper is no longer
+    # racing and a silent provider can block until the next chunk
+    # (or the httpx 120s read timeout). Racing against this dedicated
+    # event closes that window: ``client_disconnected`` doesn't fire
+    # it, and the eventual intentional-stop signal sets it for the
+    # first time, waking the wrapper.
+    intentional_stop_event: asyncio.Event = field(default_factory=asyncio.Event)
     reason: StreamLifecycleReason | None = None
     # SHU-803: separate flag tracking whether shutdown was signaled. Cannot
     # be derived from `reason` alone because the priority-based `signal()`
@@ -176,6 +197,15 @@ class StreamLifecycle:
         # Always set the event so consumers blocked on `await event.wait()`
         # wake up even when this call didn't change the reason.
         self.event.set()
+        # SHU-803 follow-up: separately fire the intentional-stop event
+        # iff the RESOLVED reason (after priority resolution) is an
+        # intentional stop. Disconnect-only paths leave this event
+        # unset. A later user_terminate / shutdown upgrade fires it
+        # for the first time even when the main event is already set
+        # from the prior disconnect — that's the load-bearing property
+        # this event was added for. Idempotent like ``event.set()``.
+        if self.reason in ("user_terminated", "shutdown"):
+            self.intentional_stop_event.set()
         return accepted
 
     def resolved_reason(self) -> StreamLifecycleReason:
@@ -344,6 +374,157 @@ async def periodic_in_flight_streams_size_log(
             )
         except Exception as e:
             logger.warning(f"in_flight_streams size log error: {e}")
+
+
+# SHU-803 follow-up: sentinel yielded by ``_iter_with_signal_break`` exactly
+# once when ``lifecycle.event`` fires before the next provider chunk
+# arrives. Identity-checked via ``is`` so it can never collide with any
+# real provider event value. Module-level so callers can import for
+# pattern matching.
+_SIGNAL_SENTINEL: object = object()
+
+
+async def _iter_with_signal_break(  # noqa: PLR0912
+    stream: Any, signal_event: asyncio.Event
+) -> AsyncGenerator[Any, None]:
+    """Async-iterator wrapper that races provider chunks against a signal.
+
+    Wraps the provider stream so the consumer loop observes a
+    ``user_terminated`` / ``shutdown`` signal WITHOUT having to wait
+    for the next provider chunk to arrive. The base SHU-803 design
+    checked ``lifecycle.event.is_set()`` at the top of each
+    ``async for`` iteration — fine when the provider streams steadily,
+    but if the provider goes quiet after the user clicks Stop (slow
+    network, rate-limit pause, reasoning model thinking, hung HTTP
+    read), the signal isn't observed until the next chunk arrives.
+    In that gap the early-persist callback hasn't fired, so a refetch
+    or follow-up message during the gap reintroduces the
+    vanishing-content + temporal-ordering races SHU-803's early-persist
+    guarantee is meant to prevent.
+
+    Behavior:
+
+    - Until the signal fires: each next-chunk read races
+      ``signal_event.wait()``. If the chunk wins, yield it normally.
+    - The MOMENT the signal fires (with no chunk pending or before the
+      pending chunk arrives): yield ``_SIGNAL_SENTINEL`` exactly once.
+      The caller's loop body inspects this and triggers its existing
+      terminate path (which then fires the early-persist callback,
+      sets ``draining=True``, etc.) BEFORE the next provider chunk
+      arrives.
+    - After the sentinel: continue yielding provider chunks normally
+      (the drain consumes them silently). A pending chunk task
+      started before the signal is preserved across the sentinel
+      yield, so we don't drop the next provider event.
+
+    Robustness: pending tasks (next-chunk + signal-wait) are tracked
+    and cancelled in a ``finally`` block so an early consumer exit
+    (the for-loop ``break``s out of drain mode on ``ProviderFinalEventResult``,
+    for example) doesn't leak orphaned asyncio tasks. Cancellation
+    exceptions on the awaited cleanup are absorbed since cleanup is
+    best-effort.
+
+    Args:
+        stream: The provider-side async iterator (return value of
+            ``await client.chat_completion(...)``).
+        signal_event: Typically ``lifecycle.event`` — the
+            ``asyncio.Event`` the terminate POST / shutdown drain
+            sets when the signal lands.
+
+    Yields:
+        Provider chunks (passed through unchanged), plus exactly one
+        ``_SIGNAL_SENTINEL`` if the signal fires before stream
+        completion.
+
+    """
+    aiter = stream.__aiter__()
+    pending_chunk: asyncio.Task | None = None
+    signal_task: asyncio.Task | None = None
+    signal_yielded = False
+    try:
+        while True:
+            # Case A: we've already yielded the sentinel once. Resume
+            # normal chunk-yielding so drain consumes whatever the
+            # provider emits next.
+            if signal_yielded:
+                if pending_chunk is None:
+                    pending_chunk = asyncio.create_task(aiter.__anext__())
+                try:
+                    chunk = await pending_chunk
+                except StopAsyncIteration:
+                    pending_chunk = None
+                    return
+                pending_chunk = None
+                yield chunk
+                continue
+
+            # Case B: signal is set BEFORE we have a chance to race
+            # chunk-vs-signal. This happens when the terminate POST
+            # lands in the brief window between handleStreamingResponse
+            # starting and the wrapper's first iteration — e.g., the
+            # user clicked Stop immediately after `stream_start`
+            # arrived but before the provider emitted its first content
+            # chunk. Yield the sentinel right now: blocking on
+            # ``await pending_chunk`` would defeat the wrapper's whole
+            # point (it'd wait for a chunk that may never arrive while
+            # the caller's lifecycle check sits unreachable).
+            if signal_event.is_set():
+                signal_yielded = True
+                yield _SIGNAL_SENTINEL
+                continue
+
+            # Case C: race chunk-vs-signal. The normal hot path.
+            if pending_chunk is None:
+                pending_chunk = asyncio.create_task(aiter.__anext__())
+            if signal_task is None:
+                signal_task = asyncio.create_task(signal_event.wait())
+
+            done, _pending = await asyncio.wait(
+                {pending_chunk, signal_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if pending_chunk in done:
+                # Chunk arrived first (the normal hot path). The signal
+                # may also be done if it fired in the same tick — we
+                # don't yield the sentinel in that case because the
+                # caller's existing lifecycle.event.is_set() check
+                # will fire on this iteration anyway.
+                try:
+                    chunk = pending_chunk.result()
+                except StopAsyncIteration:
+                    pending_chunk = None
+                    return
+                pending_chunk = None
+                yield chunk
+            else:
+                # Signal fired without a chunk. Yield the sentinel exactly
+                # once. ``pending_chunk`` stays alive; we'll resolve it
+                # on the next iteration via the signal_yielded branch.
+                signal_yielded = True
+                yield _SIGNAL_SENTINEL
+    finally:
+        # Best-effort cleanup of orphaned tasks. Cancelling and absorbing
+        # is necessary because (a) consumers may break out of the for-loop
+        # mid-iteration (e.g., drain breaks on ``ProviderFinalEventResult``),
+        # leaving these tasks alive and producing "Task exception was
+        # never retrieved" warnings; (b) the next-chunk task wraps an
+        # HTTP read so cancellation closes the underlying connection,
+        # which is the right behavior on consumer abort anyway.
+        for task in (pending_chunk, signal_task):
+            if task is not None and not task.done():
+                task.cancel()
+        for task in (pending_chunk, signal_task):
+            if task is not None:
+                try:
+                    await task
+                except (StopAsyncIteration, asyncio.CancelledError):
+                    pass
+                except Exception:
+                    # Cleanup is best-effort; provider HTTP errors during
+                    # the cancellation of a pending chunk read are noise
+                    # at this point — the caller has already moved on.
+                    pass
 
 
 @dataclass
@@ -625,7 +806,16 @@ class EnsembleStreamingHelper:
         heartbeat_last_emit: datetime | None = None
 
         try:
-            async for stream_event in await client.chat_completion(
+            # SHU-803 follow-up: wrap the provider stream so the terminate
+            # signal is observed without waiting for the next chunk to
+            # arrive. The wrapper yields _SIGNAL_SENTINEL exactly once
+            # when ``lifecycle.event`` fires before a pending chunk
+            # resolves — that drives the existing terminate-detection
+            # block below to fire immediately (and run early-persist),
+            # rather than blocking inside ``await __anext__()`` for the
+            # provider to emit again. See ``_iter_with_signal_break``
+            # docstring for the full rationale.
+            provider_stream = await client.chat_completion(
                 messages=messages,
                 model=inputs.model.model_name,
                 stream=allowed_to_stream,
@@ -633,11 +823,25 @@ class EnsembleStreamingHelper:
                 llm_params=llm_params,
                 return_as_stream=True,  # We always stream to our frontends
                 tools_enabled=tools_enabled,
-            ):
+            )
+            # SHU-803 follow-up: race against the INTENTIONAL-stop event,
+            # not the omnibus ``lifecycle.event``. A ``client_disconnected``
+            # sets the omnibus event but does NOT signal we should drain
+            # (disconnect-survival lets the stream finish naturally). If
+            # the wrapper raced the omnibus event, a disconnect would
+            # consume its one-shot sentinel and a LATER user_terminate /
+            # shutdown couldn't wake the silent-provider race anymore.
+            # The dedicated event fires only on user_terminated /
+            # shutdown — including the case where an earlier disconnect
+            # already set the omnibus event.
+            async for stream_event in _iter_with_signal_break(provider_stream, lifecycle.intentional_stop_event):
                 # ===== SHU-803: terminate-signal state transition =====
                 # Between-events check. Only intentional stops short-circuit —
                 # ``client_disconnected`` lets the LLM run to its natural end
                 # so the full response lands (the SHU-802 headline behavior).
+                # When ``stream_event is _SIGNAL_SENTINEL`` this branch is the
+                # ENTIRE handling — we then ``continue`` past chunk-processing
+                # since the sentinel is not a real provider event.
                 if not draining and lifecycle.event.is_set() and lifecycle.reason in ("user_terminated", "shutdown"):
                     terminated = True
                     if lifecycle.reason == "shutdown" or lifecycle.shutdown_signaled:
@@ -701,6 +905,15 @@ class EnsembleStreamingHelper:
                     )
                     # Fall through to silent-consume branch — this very event
                     # might be a Final (provider was about to finish anyway).
+
+                # SHU-803 follow-up: skip the rest of the loop body when this
+                # iteration was driven by the signal sentinel (no actual
+                # provider event to process). The terminate-detection block
+                # above already handled the state transition; falling through
+                # to drain-mode or normal-mode handling would treat the
+                # sentinel object as a provider event and crash.
+                if stream_event is _SIGNAL_SENTINEL:
+                    continue
 
                 # ===== SHU-803: drain mode silent-consume =====
                 if draining:

--- a/backend/src/shu/services/chat_streaming.py
+++ b/backend/src/shu/services/chat_streaming.py
@@ -1,6 +1,6 @@
 import asyncio
 import uuid
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -548,6 +548,7 @@ class EnsembleStreamingHelper:
         tools_enabled: bool,
         lifecycle: "StreamLifecycle",
         content_accumulator: list[str],
+        on_terminate_signal: Callable[[], Awaitable[None]] | None = None,
     ) -> tuple[ProviderResponseEvent | None, list[ChatMessage] | None, bool, dict[str, Any]]:
         """Stream provider responses for a single model variant and enqueue interim events to the provided queue.
 
@@ -570,6 +571,14 @@ class EnsembleStreamingHelper:
                 content-delta strings are appended in order. The list is the source of truth
                 for partial content on early termination — `"".join(content_accumulator)` gives
                 whatever the provider had emitted before the break.
+            on_terminate_signal (Optional[Callable[[], Awaitable[None]]]): SHU-803 follow-up.
+                One-shot callback invoked when a ``user_terminated`` signal is detected and
+                BEFORE the silent drain begins. Caller closes over ``content_accumulator`` and
+                the variant context, writes the partial Message row in its own session, and
+                stores the assigned id back via a caller-managed holder. Any exception is
+                caught and swallowed — drain proceeds normally and finalize falls back to its
+                existing INSERT-at-drain-finish path. Not invoked on ``shutdown`` (the lifespan
+                drain budget is too tight to pay for an extra DB round-trip per stream).
 
         Returns
         -------
@@ -650,6 +659,38 @@ class EnsembleStreamingHelper:
                     drain_start_ts = datetime.now(UTC)
                     heartbeat_last_emit = drain_start_ts
                     cancel_task = asyncio.create_task(client.provider_adapter.cancel())
+
+                    # SHU-803 follow-up: fire the early-persist callback
+                    # BEFORE the drain starts consuming silently. The callback
+                    # writes the partial Message row to DB at signal time so
+                    # (a) a navigation refetch during the (possibly minute-
+                    # long) drain sees the persisted partial, and (b) a
+                    # follow-up user message sent before drain finishes orders
+                    # correctly by `created_at`. The callback owns its own
+                    # session (no entanglement with the stream task), captures
+                    # `content_accumulator` from the caller scope, and stores
+                    # the assigned id back via a caller-managed holder.
+                    #
+                    # Defensive: ANY exception in the callback is logged and
+                    # swallowed. On callback failure, `early_persisted_message_id`
+                    # stays None on the result, finalize falls through to its
+                    # existing INSERT path at drain-finish, and the user
+                    # observes today's behavior (vanishing-content + ordering
+                    # race during drain). The drain itself is unaffected, so
+                    # billing fidelity is preserved.
+                    if on_terminate_signal is not None:
+                        try:
+                            await on_terminate_signal()
+                        except Exception:
+                            logger.warning(
+                                "Early-persist callback raised; finalize will INSERT at drain-finish",
+                                extra={
+                                    "model": inputs.model.model_name,
+                                    "variant_index": variant_index,
+                                },
+                                exc_info=True,
+                            )
+
                     logger.info(
                         "drain_started",
                         extra={
@@ -857,6 +898,9 @@ class EnsembleStreamingHelper:
         inputs: "ModelExecutionInputs",
         queue: asyncio.Queue,
         conversation_id: str,
+        parent_message_id: str,
+        use_parent_as_message_id: bool,
+        regen_lineage: "RegenLineageInfo | None",
         force_no_streaming: bool,
         start_time: datetime,
         lifecycle: "StreamLifecycle",
@@ -982,6 +1026,156 @@ class EnsembleStreamingHelper:
             # `_call_provider` only when terminated; empty dict otherwise.
             drain_audit: dict[str, Any] = {}
 
+            # SHU-803 follow-up: terminate-time early-persist holder. The
+            # `on_terminate_signal` callback below stamps the assigned
+            # message_id + variant_index here when it commits successfully.
+            # `_finalize_variant_phase` reads these via the returned
+            # VariantStreamResult to decide UPDATE-existing vs. INSERT-new.
+            # Empty dict on (a) natural completion (callback never fires) or
+            # (b) callback failure (callback returns cleanly without stamping).
+            early_state: dict[str, Any] = {}
+
+            async def on_terminate_signal() -> None:
+                """SHU-803 follow-up: write the partial assistant Message at terminate-signal time.
+
+                Lifted from the regen-aware INSERT block in
+                `_finalize_variant_phase` (lines that handle assigned_message_id /
+                variant_index assignment + regen lineage backfill + IntegrityError
+                retry). Runs in its own fresh session — completely independent of
+                the stream task's session lifecycle. Captures `content_accumulator`,
+                `client`, lifecycle, regen_lineage, and the variant context from
+                the enclosing scope.
+
+                Side effect on success: ``early_state["message_id"]`` and
+                ``early_state["variant_index"]`` are set. On any failure
+                (regen retry exhaustion, transient DB error), returns cleanly
+                without stamping so `_finalize_variant_phase` falls through to
+                its existing INSERT-at-drain-finish path.
+
+                Does NOT write LLMUsage — that stays with finalize after drain
+                exits, so usage tokens reflect drain's final snapshot.
+                """
+                partial_content = "".join(content_accumulator).strip()
+                try:
+                    partial_usage_at_signal = client.provider_adapter.get_partial_usage_snapshot()
+                except Exception:
+                    partial_usage_at_signal = {}
+                partial_usage_unavailable_at_signal = not partial_usage_at_signal
+
+                base_metadata: dict[str, Any] = dict(config_metadata)
+                base_metadata["response_time_ms"] = (datetime.now(UTC) - start_time).total_seconds() * 1000
+                base_metadata["streamed"] = True
+                base_metadata["has_citations"] = False
+                base_metadata["stream_state"] = lifecycle.resolved_reason()
+                if partial_usage_unavailable_at_signal:
+                    base_metadata["partial_usage_unavailable"] = True
+
+                session_factory = get_async_session_local()
+                attempt = 0
+                while True:
+                    attempt += 1
+                    now_signal = datetime.now(UTC)
+                    try:
+                        async with session_factory() as session:
+                            # Regen-only: legacy backfill of original target's
+                            # lineage + compute new variant_index from sibling-max.
+                            # Mirrors the same block in `_finalize_variant_phase`.
+                            if regen_lineage:
+                                target_row = (
+                                    await session.execute(
+                                        select(Message).where(Message.id == regen_lineage.target_message_id)
+                                    )
+                                ).scalar_one_or_none()
+                                if target_row and target_row.parent_message_id is None:
+                                    target_row.parent_message_id = regen_lineage.root_id
+                                    if target_row.id == regen_lineage.root_id:
+                                        target_row.variant_index = 0
+                                sibling_rows = (
+                                    await session.execute(
+                                        select(Message.variant_index).where(
+                                            Message.parent_message_id == regen_lineage.root_id
+                                        )
+                                    )
+                                ).all()
+                                existing_indices = [vi for (vi,) in sibling_rows if vi is not None]
+                                assigned_variant_index = (max(existing_indices) + 1) if existing_indices else 1
+                                assigned_parent_message_id = regen_lineage.root_id
+                                assigned_message_id = str(uuid.uuid4())
+                                metadata_dict = {
+                                    **base_metadata,
+                                    "regenerated": True,
+                                    "regenerated_from_message_id": regen_lineage.target_message_id,
+                                }
+                            else:
+                                assigned_variant_index = variant_index
+                                assigned_parent_message_id = parent_message_id
+                                assigned_message_id = (
+                                    parent_message_id
+                                    if use_parent_as_message_id and variant_index == 0
+                                    else str(uuid.uuid4())
+                                )
+                                metadata_dict = dict(base_metadata)
+
+                            assistant_msg = Message(
+                                id=assigned_message_id,
+                                conversation_id=conversation_id,
+                                role="assistant",
+                                content=partial_content,
+                                model_id=inputs.model.id,
+                                message_metadata=metadata_dict,
+                                parent_message_id=assigned_parent_message_id,
+                                variant_index=assigned_variant_index,
+                            )
+                            session.add(assistant_msg)
+                            await session.flush()
+
+                            # Bump conversation.updated_at at signal time so the
+                            # conversation sorts to top of "recently updated"
+                            # immediately. Finalize's UPDATE branch SKIPS this
+                            # bump to avoid double-write (the cosmetic ordering
+                            # is already correct after this commit).
+                            await session.execute(
+                                update(Conversation)
+                                .where(Conversation.id == conversation_id)
+                                .values(updated_at=now_signal)
+                            )
+
+                            await session.commit()
+                            early_state["message_id"] = assigned_message_id
+                            early_state["variant_index"] = assigned_variant_index
+                            logger.info(
+                                "Early-persist of terminated variant succeeded",
+                                extra={
+                                    "phase": "early_persist_terminated",
+                                    "conversation_id": conversation_id,
+                                    "variant_index": assigned_variant_index,
+                                    "message_id": assigned_message_id,
+                                    "attempt": attempt,
+                                    "regen": regen_lineage is not None,
+                                },
+                            )
+                        # success — exit retry loop
+                        return
+                    except IntegrityError as ie:
+                        # Same retry semantics as `_finalize_variant_phase`:
+                        # regen races on (parent_message_id, variant_index)
+                        # UNIQUE; non-regen path should never trip this.
+                        # Exhausting the budget here returns cleanly (no
+                        # stamping) so finalize falls through to its INSERT
+                        # path at drain-finish.
+                        if not regen_lineage or attempt >= REGEN_MAX_ATTEMPTS:
+                            logger.error(
+                                "Early-persist IntegrityError after %d attempts (regen=%s): %s",
+                                attempt,
+                                regen_lineage is not None,
+                                ie,
+                            )
+                            return
+                        logger.info(
+                            "Early-persist regen variant_index conflict on attempt %d; retrying",
+                            attempt,
+                        )
+
             # We loop until the agents are done pulling what they need to pull.
             while True:
                 (
@@ -1002,6 +1196,7 @@ class EnsembleStreamingHelper:
                     tools_enabled=tools_enabled,
                     lifecycle=lifecycle,
                     content_accumulator=content_accumulator,
+                    on_terminate_signal=on_terminate_signal,
                 )
                 # SHU-802: user_terminated / shutdown short-circuits the tool
                 # loop too — once the lifecycle is signalled we stop calling
@@ -1063,6 +1258,11 @@ class EnsembleStreamingHelper:
                     model_name_for_event=model_display_name,
                     final_event_type="final_message",
                     drain_audit=drain_audit,
+                    # SHU-803 follow-up: hand off the early-persisted ids
+                    # (if the callback committed successfully) so finalize
+                    # takes the UPDATE-existing branch instead of INSERT.
+                    early_persisted_message_id=early_state.get("message_id"),
+                    early_persisted_variant_index=early_state.get("variant_index"),
                 )
 
             if final_message_event is None:
@@ -1239,6 +1439,172 @@ class EnsembleStreamingHelper:
 
         if result.success:
             assert result.full_content is not None, "VariantStreamResult.success requires full_content"
+
+            # SHU-803 follow-up: UPDATE-existing branch. When the
+            # terminate-time `on_terminate_signal` callback in
+            # `_stream_variant_phase` committed the partial Message at
+            # signal time, this branch only needs to refine the
+            # `partial_usage_unavailable` flag (drain may have captured
+            # usage that wasn't available at signal time) and INSERT
+            # the LLMUsage row. No Message INSERT, no retry loop (the
+            # UNIQUE-constrained columns don't change on UPDATE), and
+            # no `conversation.updated_at` bump (already done at signal
+            # time — bumping again would be cosmetic noise).
+            if result.early_persisted_message_id is not None:
+                early_msg_id = result.early_persisted_message_id
+                early_variant_index = (
+                    result.early_persisted_variant_index
+                    if result.early_persisted_variant_index is not None
+                    else variant_index
+                )
+                early_assistant_msg_loaded: Message | None = None
+                try:
+                    async with session_factory() as session:
+                        # Refine partial_usage_unavailable based on drain-
+                        # final state. At signal time we may not have had
+                        # usage yet (flag=True); drain might have captured
+                        # the end-of-stream usage chunk between then and
+                        # now (flag should flip to False).
+                        existing_msg = (
+                            await session.execute(select(Message).where(Message.id == early_msg_id))
+                        ).scalar_one_or_none()
+                        if existing_msg is not None:
+                            metadata_now = dict(existing_msg.message_metadata or {})
+                            if result.partial_usage_unavailable:
+                                metadata_now["partial_usage_unavailable"] = True
+                            else:
+                                metadata_now.pop("partial_usage_unavailable", None)
+                            existing_msg.message_metadata = metadata_now
+                            # SQLAlchemy doesn't deep-diff JSON columns by
+                            # default; flag the attribute as modified so the
+                            # UPDATE actually emits.
+                            from sqlalchemy.orm.attributes import flag_modified
+
+                            flag_modified(existing_msg, "message_metadata")
+
+                        # Insert LLMUsage with drain-final state.
+                        # Terminated streams record success=False with the
+                        # interrupted error message (matches the existing
+                        # INSERT branch). Drain audit goes on
+                        # request_metadata for ops grep.
+                        early_request_metadata: dict[str, Any] | None = (
+                            dict(result.drain_audit) if result.drain_audit else None
+                        )
+                        await get_usage_recorder().record(
+                            provider_id=inputs.model.provider_id,
+                            model_id=inputs.model.id,
+                            request_type="chat",
+                            input_tokens=result.usage.get("input_tokens", 0),
+                            output_tokens=result.usage.get("output_tokens", 0),
+                            total_cost=safe_decimal(result.usage.get("cost")),
+                            user_id=str(conversation_owner_id) if conversation_owner_id else None,
+                            response_time_ms=result.metadata.get("response_time_ms"),
+                            success=False,
+                            error_message=f"Stream interrupted: {lifecycle.resolved_reason()}",
+                            request_metadata=early_request_metadata,
+                            session=session,
+                        )
+
+                        await session.commit()
+
+                        # Post-commit reload with relationships for SSE.
+                        try:
+                            stmt = (
+                                select(Message)
+                                .where(Message.id == early_msg_id)
+                                .options(
+                                    selectinload(Message.model),
+                                    selectinload(Message.conversation),
+                                    selectinload(Message.attachments),
+                                )
+                            )
+                            early_assistant_msg_loaded = (await session.execute(stmt)).scalar_one()
+                        except Exception as reload_exc:
+                            logger.warning(
+                                "Post-commit reload failed on early-persist UPDATE; "
+                                "emitting final_message with degraded relationship metadata.",
+                                extra={
+                                    "phase": "finalize_post_commit_reload_failed",
+                                    "conversation_id": conversation_id,
+                                    "variant_index": early_variant_index,
+                                    "error_type": type(reload_exc).__name__,
+                                },
+                                exc_info=True,
+                            )
+                            early_assistant_msg_loaded = existing_msg
+                except Exception as exc:
+                    # LLMUsage INSERT or session commit failed. The Message
+                    # row from early-persist is already committed — user
+                    # content is preserved; we have a billing-data gap.
+                    # Log ERROR for ops grep and best-effort reload the
+                    # Message for the SSE event so the consumer doesn't
+                    # hang waiting for a terminal event.
+                    logger.error(
+                        "Variant finalize UPDATE-on-early-persist rolled back; " "Message persists, LLMUsage missing",
+                        extra={
+                            "phase": "finalize_rollback",
+                            "conversation_id": conversation_id,
+                            "variant_index": early_variant_index,
+                            "error_type": type(exc).__name__,
+                            "early_persisted": True,
+                            "elapsed_ms": (datetime.now(UTC) - finalize_phase_start).total_seconds() * 1000,
+                        },
+                        exc_info=True,
+                    )
+                    try:
+                        async with session_factory() as session_reload:
+                            stmt = (
+                                select(Message)
+                                .where(Message.id == early_msg_id)
+                                .options(
+                                    selectinload(Message.model),
+                                    selectinload(Message.conversation),
+                                    selectinload(Message.attachments),
+                                )
+                            )
+                            early_assistant_msg_loaded = (await session_reload.execute(stmt)).scalar_one_or_none()
+                    except Exception:
+                        early_assistant_msg_loaded = None
+
+                if early_assistant_msg_loaded is None:
+                    # Catastrophic: can't load the early-persisted row.
+                    # Emit a terminal error event so the SSE consumer
+                    # exits its `queue.get()` loop.
+                    await queue.put(
+                        self._create_error_event(
+                            "An internal error prevented loading your response. Please try again.",
+                            early_variant_index,
+                            inputs,
+                            model_snapshot,
+                            model_display_name,
+                        )
+                    )
+                else:
+                    await queue.put(
+                        ProviderResponseEvent(
+                            type=result.final_event_type or "final_message",
+                            content=serialize_message_for_sse(early_assistant_msg_loaded),
+                            variant_index=early_variant_index,
+                            model_configuration_id=getattr(inputs.model_configuration, "id", None),
+                            model_configuration=model_snapshot or None,
+                            model_name=result.model_name_for_event,
+                            model_display_name=model_display_name,
+                        )
+                    )
+                logger.info(
+                    "Variant finalize phase complete",
+                    extra={
+                        "phase": "finalize_complete",
+                        "conversation_id": conversation_id,
+                        "variant_index": early_variant_index,
+                        "success": early_assistant_msg_loaded is not None,
+                        "lifecycle_reason": lifecycle.resolved_reason(),
+                        "terminated": True,
+                        "early_persisted": True,
+                        "elapsed_ms": (datetime.now(UTC) - finalize_phase_start).total_seconds() * 1000,
+                    },
+                )
+                return
 
             # Retry loop only matters for the regen path; for the non-regen
             # path the variant_index is fixed by the ensemble loop counter
@@ -1693,6 +2059,9 @@ class EnsembleStreamingHelper:
                     inputs=inputs,
                     queue=queue,
                     conversation_id=conversation_id,
+                    parent_message_id=parent_message_id,
+                    use_parent_as_message_id=use_parent_as_message_id,
+                    regen_lineage=regen_lineage,
                     force_no_streaming=force_no_streaming,
                     start_time=start_time,
                     lifecycle=lifecycle,

--- a/backend/src/shu/services/chat_streaming.py
+++ b/backend/src/shu/services/chat_streaming.py
@@ -730,7 +730,7 @@ class EnsembleStreamingHelper:
         lifecycle: "StreamLifecycle",
         content_accumulator: list[str],
         on_terminate_signal: Callable[[], Awaitable[None]] | None = None,
-    ) -> tuple[ProviderResponseEvent | None, list[ChatMessage] | None, bool, dict[str, Any]]:
+    ) -> tuple[ProviderResponseEvent | None, list[ChatMessage] | None, bool, dict[str, Any], dict[str, Any]]:
         """Stream provider responses for a single model variant and enqueue interim events to the provided queue.
 
         Parameters

--- a/backend/src/shu/services/chat_streaming.py
+++ b/backend/src/shu/services/chat_streaming.py
@@ -120,6 +120,19 @@ class StreamLifecycle:
     conversation_id: str
     event: asyncio.Event = field(default_factory=asyncio.Event)
     reason: StreamLifecycleReason | None = None
+    # SHU-803: separate flag tracking whether shutdown was signaled. Cannot
+    # be derived from `reason` alone because the priority-based `signal()`
+    # treats `user_terminated` and `shutdown` as the same tier (both
+    # intentional stops), so a `shutdown` arriving AFTER `user_terminated`
+    # leaves `reason="user_terminated"` unchanged. The drain loop in
+    # `_call_provider` reads this flag between events as the SIGTERM
+    # escape valve — without it, an in-flight drain following a
+    # user-terminate has no way to detect shutdown and would only exit
+    # via cancellation propagation at the lifespan-drain timeout (which
+    # bypasses the shielded finalize since `_call_provider` itself is
+    # not shielded). Set by `signal_shutdown_to_in_flight_streams` and
+    # by `drain_in_flight_streams`; checked by the drain loop.
+    shutdown_signaled: bool = False
     # SHU-802: cleanup callback. Set by the endpoint when it registers the
     # lifecycle in `app.state.in_flight_streams`; invoked by the per-stream
     # supervisor when all variant tasks have completed (registry pop). The
@@ -230,6 +243,10 @@ async def drain_in_flight_streams(
         return 0
 
     for lc in lifecycles:
+        # SHU-803: set the drain-escape-valve flag before signaling so the
+        # drain loop's between-events check observes it. Idempotent — set
+        # may already be True from the SIGTERM handler having fired first.
+        lc.shutdown_signaled = True
         lc.signal("shutdown")
 
     supervise_tasks = [lc.supervise_task for lc in lifecycles if lc.supervise_task is not None]
@@ -289,6 +306,11 @@ def signal_shutdown_to_in_flight_streams(registry: dict[str, StreamLifecycle]) -
     """
     lifecycles = list(registry.values())
     for lc in lifecycles:
+        # SHU-803: set the drain-escape-valve flag before signaling so any
+        # in-flight `_call_provider` drain loop can exit gracefully on its
+        # next between-events check, allowing the shielded finalize to
+        # commit before lifespan-drain cancellation propagates.
+        lc.shutdown_signaled = True
         lc.signal("shutdown")
     return len(lifecycles)
 
@@ -512,7 +534,7 @@ class EnsembleStreamingHelper:
                     },
                 )
 
-    async def _call_provider(
+    async def _call_provider(  # noqa: PLR0912, PLR0915
         self,
         *,
         client: UnifiedLLMClient,
@@ -551,17 +573,21 @@ class EnsembleStreamingHelper:
 
         Returns
         -------
-            tuple[Optional[ProviderResponseEvent], Optional[List[ChatMessage]], bool, dict[str, Any]]:
+            tuple[Optional[ProviderResponseEvent], Optional[List[ChatMessage]], bool, dict[str, Any], dict[str, Any]]:
                 final_message_event: The provider's final event (content or error) if produced, otherwise None.
                 followup_messages: Additional messages emitted by the provider (e.g., from a tool call) to be sent back for follow-up, or None.
                 terminated: SHU-802. True if the loop exited early because the lifecycle was
                     signalled with ``user_terminated`` / ``shutdown``; the caller transitions
                     to finalize with the partial content from ``content_accumulator``.
                 partial_usage: SHU-802. Snapshot of ``client.provider_adapter.get_partial_usage_snapshot()``
-                    at the break point — populated only when ``terminated`` is True. Empty dict on
-                    natural completion (the final event's metadata carries the natural-end usage).
-                    See AC10: the LLMUsage row for an interrupted stream records these tokens when
-                    the provider had emitted usage events before the break.
+                    at drain exit (or at break for shutdown-on-entry) — populated only when ``terminated``
+                    is True. Empty dict on natural completion (the final event's metadata carries the
+                    natural-end usage). See AC10: the LLMUsage row for an interrupted stream records
+                    these tokens when the provider had emitted usage events before the break.
+                drain_audit: SHU-803 AC9g. Audit fields stamped on the LLMUsage row's
+                    ``request_metadata`` for terminated streams. Empty dict on the non-terminated path.
+                    Keys: ``drain_outcome`` ∈ {``final_event``, ``done``, ``exception``, ``shutdown_aborted``},
+                    ``cancel_attempted: bool``, ``cancel_succeeded: bool``.
 
         """
         final_message_event: ProviderFinalEventResult | None = None
@@ -569,76 +595,158 @@ class EnsembleStreamingHelper:
         llm_params = None
         terminated = False
         partial_usage: dict[str, Any] = {}
+        drain_audit: dict[str, Any] = {}
 
-        async for stream_event in await client.chat_completion(
-            messages=messages,
-            model=inputs.model.model_name,
-            stream=allowed_to_stream,
-            model_overrides=inputs.model_configuration.parameter_overrides or None,
-            llm_params=llm_params,
-            return_as_stream=True,  # We always stream to our frontends
-            tools_enabled=tools_enabled,
-        ):
-            # SHU-802: between-events terminate check. Only intentional stops
-            # short-circuit — `client_disconnected` lets the LLM run to its
-            # natural end so the full response lands (the headline bug-fix
-            # behavior). The check fires BEFORE event processing so we don't
-            # enqueue a stale delta after the user has hit Stop. Latency from
-            # terminate-POST → break is gated by the provider's inter-chunk
-            # interval: the provider has to deliver the next chunk before we
-            # can observe the event, so a slow provider extends the window.
-            # This matches the design decision around per-provider
-            # partial-usage accuracy in H4.
-            if lifecycle.event.is_set() and lifecycle.reason in ("user_terminated", "shutdown"):
-                terminated = True
-                # SHU-802 AC10: capture whatever provider-reported usage has
-                # accumulated up to this point so the LLMUsage row for the
-                # interrupted stream records real tokens instead of zeros.
-                # Empty dict (no usage emitted yet) flips partial_usage_unavailable
-                # on in finalize.
-                try:
-                    partial_usage = client.provider_adapter.get_partial_usage_snapshot()
-                except Exception as snapshot_exc:
-                    # Snapshot failure must not mask the terminate path. Log
-                    # and fall through with an empty snapshot — the existing
-                    # partial_usage_unavailable=True path then applies.
-                    logger.warning(
-                        "Failed to capture partial usage on terminate: %s",
-                        snapshot_exc,
-                        exc_info=True,
+        # SHU-803 AC9c: drain-after-terminate state. Once a ``user_terminated``
+        # signal lands, we transition to drain mode: stop forwarding content
+        # deltas to the SSE queue and stop appending to ``content_accumulator``
+        # (so the user sees the stream stop immediately and the persisted
+        # ``Message.content`` matches what was on screen), but keep consuming
+        # the upstream HTTP stream silently to capture the eventual usage
+        # event. End-only-usage providers (OpenAI Chat Completions /
+        # OpenRouter / Responses API) emit usage in their final chunk; drain
+        # ensures the LLMUsage row records what the provider actually billed.
+        # Uncapped by wall-clock (per ticket revision) — the implicit upper
+        # bound is the httpx ``SHU_LLM_STREAMING_READ_TIMEOUT=120s``
+        # inter-chunk read timeout. SIGTERM escape valve handled via
+        # ``lifecycle.shutdown_signaled`` between-events check.
+        draining = False
+        cancel_task: asyncio.Task[bool] | None = None
+        drain_start_ts: datetime | None = None
+        heartbeat_last_emit: datetime | None = None
+
+        try:
+            async for stream_event in await client.chat_completion(
+                messages=messages,
+                model=inputs.model.model_name,
+                stream=allowed_to_stream,
+                model_overrides=inputs.model_configuration.parameter_overrides or None,
+                llm_params=llm_params,
+                return_as_stream=True,  # We always stream to our frontends
+                tools_enabled=tools_enabled,
+            ):
+                # ===== SHU-803: terminate-signal state transition =====
+                # Between-events check. Only intentional stops short-circuit —
+                # ``client_disconnected`` lets the LLM run to its natural end
+                # so the full response lands (the SHU-802 headline behavior).
+                if not draining and lifecycle.event.is_set() and lifecycle.reason in ("user_terminated", "shutdown"):
+                    terminated = True
+                    if lifecycle.reason == "shutdown" or lifecycle.shutdown_signaled:
+                        # Shutdown entry: don't drain. Lifespan drain has a
+                        # wall-clock budget (5s default) — spending it on per-
+                        # stream drains would risk SIGKILL before finalize
+                        # commits. Snapshot now and break.
+                        drain_audit = {
+                            "drain_outcome": "shutdown_aborted",
+                            "cancel_attempted": False,
+                            "cancel_succeeded": False,
+                        }
+                        break
+                    # ``user_terminated`` entry: enter drain mode and spawn
+                    # cancel concurrently. The cancel races drain — whichever
+                    # ends generation faster wins. A False / no-op cancel
+                    # (most adapters) just means drain runs to natural end.
+                    draining = True
+                    drain_start_ts = datetime.now(UTC)
+                    heartbeat_last_emit = drain_start_ts
+                    cancel_task = asyncio.create_task(client.provider_adapter.cancel())
+                    logger.info(
+                        "drain_started",
+                        extra={
+                            "model": inputs.model.model_name,
+                            "adapter_type": type(client.provider_adapter).__name__,
+                            "variant_index": variant_index,
+                        },
                     )
-                    partial_usage = {}
-                break
+                    # Fall through to silent-consume branch — this very event
+                    # might be a Final (provider was about to finish anyway).
 
-            stream_event: ProviderEventResult = stream_event  # noqa: PLW0127, PLW2901 # typing for easier understanding
-            logger.debug("EVENT %s", stream_event)
-            if isinstance(stream_event, ProviderToolCallEventResult) and tools_enabled:
-                followup_messages = stream_event.additional_messages
-                if stream_event.content:
+                # ===== SHU-803: drain mode silent-consume =====
+                if draining:
+                    # SIGTERM escape valve. ``shutdown_signaled`` is set on
+                    # the lifecycle by ``signal_shutdown_to_in_flight_streams``
+                    # / ``drain_in_flight_streams``; it's a separate flag from
+                    # ``reason`` because priority semantics treat
+                    # user_terminated and shutdown as equal tier (a shutdown
+                    # after user_terminated does NOT update ``reason``).
+                    # Without this flag the drain would only exit via the
+                    # lifespan-drain cancellation propagation, which bypasses
+                    # the shielded finalize.
+                    if lifecycle.shutdown_signaled:
+                        drain_audit["drain_outcome"] = "shutdown_aborted"
+                        break
+                    # Heartbeat every 30s of drain wall-clock. Operators grep
+                    # ``drain_in_progress`` to distinguish "drain working as
+                    # designed for a slow response" from "drain stuck."
+                    now = datetime.now(UTC)
+                    if heartbeat_last_emit is not None and (now - heartbeat_last_emit).total_seconds() >= 30:
+                        logger.info(
+                            "drain_in_progress",
+                            extra={
+                                "elapsed_seconds": (now - drain_start_ts).total_seconds()
+                                if drain_start_ts is not None
+                                else None,
+                                "model": inputs.model.model_name,
+                                "adapter_type": type(client.provider_adapter).__name__,
+                                "variant_index": variant_index,
+                            },
+                        )
+                        heartbeat_last_emit = now
+                    # Final-event detection — capture the natural end of the
+                    # stream (the OpenAI Responses ``response.completed``
+                    # path; Anthropic ``message_delta`` with end_turn). The
+                    # adapter's ``handle_provider_event`` has already run
+                    # for this chunk inside ``_stream_response``, so any
+                    # usage event in the same chunk has been stashed into
+                    # adapter internal state — the post-loop snapshot picks
+                    # it up.
+                    if isinstance(stream_event, ProviderFinalEventResult):
+                        drain_audit["drain_outcome"] = "final_event"
+                        break
+                    # All other events (content deltas, reasoning deltas,
+                    # tool-call deltas) are silently dropped during drain.
+                    continue
+
+                # ===== Normal mode: existing SHU-802 event handling =====
+                stream_event: ProviderEventResult = stream_event  # noqa: PLW0127, PLW2901 # typing for easier understanding
+                logger.debug("EVENT %s", stream_event)
+                if isinstance(stream_event, ProviderToolCallEventResult) and tools_enabled:
+                    followup_messages = stream_event.additional_messages
+                    if stream_event.content:
+                        await queue.put(
+                            ProviderResponseEvent(
+                                type="reasoning_delta",
+                                content=f"{stream_event.content}\n",
+                                variant_index=variant_index,
+                                model_configuration_id=getattr(inputs.model_configuration, "id", None),
+                                model_configuration=model_snapshot,
+                                model_name=model_display_name,
+                                model_display_name=model_display_name,
+                            )
+                        )
+                elif (
+                    isinstance(stream_event, (ProviderContentDeltaEventResult, ProviderReasoningDeltaEventResult))
+                    and stream_event.content
+                ):
+                    # SHU-802: accumulate content-delta strings so finalize can
+                    # persist partial content if the stream is terminated. We
+                    # only track ContentDelta (not ReasoningDelta) since the
+                    # assistant Message.content field holds final answer text,
+                    # not reasoning traces.
+                    if isinstance(stream_event, ProviderContentDeltaEventResult):
+                        content_accumulator.append(stream_event.content)
                     await queue.put(
-                        ProviderResponseEvent(
-                            type="reasoning_delta",
-                            content=f"{stream_event.content}\n",
-                            variant_index=variant_index,
-                            model_configuration_id=getattr(inputs.model_configuration, "id", None),
-                            model_configuration=model_snapshot,
-                            model_name=model_display_name,
-                            model_display_name=model_display_name,
+                        ProviderResponseEvent.from_provider_event_result(
+                            stream_event,
+                            variant_index,
+                            getattr(inputs.model_configuration, "id", None),
+                            model_snapshot or None,
+                            model_display_name,
+                            inputs.model.model_name,
                         )
                     )
-            elif (
-                isinstance(stream_event, (ProviderContentDeltaEventResult, ProviderReasoningDeltaEventResult))
-                and stream_event.content
-            ):
-                # SHU-802: accumulate content-delta strings so finalize can
-                # persist partial content if the stream is terminated. We
-                # only track ContentDelta (not ReasoningDelta) since the
-                # assistant Message.content field holds final answer text,
-                # not reasoning traces.
-                if isinstance(stream_event, ProviderContentDeltaEventResult):
-                    content_accumulator.append(stream_event.content)
-                await queue.put(
-                    ProviderResponseEvent.from_provider_event_result(
+                elif isinstance(stream_event, (ProviderFinalEventResult, ProviderErrorEventResult)):
+                    final_message_event = ProviderResponseEvent.from_provider_event_result(
                         stream_event,
                         variant_index,
                         getattr(inputs.model_configuration, "id", None),
@@ -646,18 +754,101 @@ class EnsembleStreamingHelper:
                         model_display_name,
                         inputs.model.model_name,
                     )
+        except Exception as exc:
+            # SHU-803 AC9c: an exception during drain (httpx ReadTimeout
+            # after 120s of upstream silence, network teardown, etc.) is
+            # caught and folded into ``drain_outcome="exception"`` so
+            # finalize commits with whatever usage was captured up to
+            # the exception. Exceptions before drain entry are re-raised
+            # for the existing error-handling paths in
+            # ``_stream_variant_phase``.
+            if draining:
+                drain_audit["drain_outcome"] = "exception"
+                drain_audit["drain_exception_type"] = type(exc).__name__
+                logger.warning(
+                    "drain_exception",
+                    extra={
+                        "model": inputs.model.model_name,
+                        "error_type": type(exc).__name__,
+                        "variant_index": variant_index,
+                    },
+                    exc_info=True,
                 )
-            elif isinstance(stream_event, (ProviderFinalEventResult, ProviderErrorEventResult)):
-                final_message_event = ProviderResponseEvent.from_provider_event_result(
-                    stream_event,
-                    variant_index,
-                    getattr(inputs.model_configuration, "id", None),
-                    model_snapshot or None,
-                    model_display_name,
-                    inputs.model.model_name,
+            else:
+                raise
+
+        # ===== SHU-803: post-drain wrapup =====
+        # On either drain path (user_terminated drain or shutdown
+        # immediate break) we need: a final usage snapshot from the
+        # adapter, an awaited cancel_task with bounded timeout, and
+        # the drain_audit dict populated for finalize to stamp on the
+        # LLMUsage row's request_metadata (AC9g).
+        if draining or terminated:
+            # If we drained through to natural [DONE] without ever
+            # seeing a ProviderFinalEventResult AND no exception fired,
+            # drain_outcome wasn't set inside the loop — that's the
+            # "done" case (typical for OpenAI Chat Completions where
+            # the usage chunk is the last chunk before [DONE], and the
+            # adapter consumes it via handle_provider_event but never
+            # yields a Final).
+            drain_audit.setdefault("drain_outcome", "done")
+
+            # Await the cancel task with a tight timeout. ResponsesAdapter
+            # cancel() has its own 2s httpx timeout so this rarely waits
+            # the full 2s here; the cap is belt-and-suspenders for an
+            # adapter that ignored the contract.
+            if cancel_task is not None:
+                drain_audit["cancel_attempted"] = True
+                try:
+                    cancel_succeeded = await asyncio.wait_for(cancel_task, timeout=2.0)
+                    drain_audit["cancel_succeeded"] = bool(cancel_succeeded)
+                except TimeoutError:
+                    cancel_task.cancel()
+                    drain_audit["cancel_succeeded"] = False
+                except Exception:
+                    # Cancel contract says implementations MUST NOT raise;
+                    # fold any escape into a False return so the
+                    # finalize-side request_metadata stays clean.
+                    drain_audit["cancel_succeeded"] = False
+            else:
+                drain_audit.setdefault("cancel_attempted", False)
+                drain_audit.setdefault("cancel_succeeded", False)
+
+            # Final usage snapshot. The adapter override flushes any
+            # pending ``_latest_usage_event`` into ``self.usage`` and
+            # returns a copy — idempotent, so a re-snapshot here over
+            # the same internal state is safe. Captures any usage event
+            # consumed silently during drain.
+            try:
+                partial_usage = client.provider_adapter.get_partial_usage_snapshot()
+            except Exception as snapshot_exc:
+                logger.warning(
+                    "Failed to capture partial usage on drain exit: %s",
+                    snapshot_exc,
+                    exc_info=True,
+                )
+                partial_usage = {}
+
+            # Drain duration log on exit (only when we actually entered
+            # the drain loop — shutdown_aborted-on-entry skips this).
+            if drain_start_ts is not None:
+                drain_elapsed = (datetime.now(UTC) - drain_start_ts).total_seconds()
+                logger.info(
+                    "drain_completed",
+                    extra={
+                        "drain_outcome": drain_audit.get("drain_outcome"),
+                        "drain_elapsed_seconds": drain_elapsed,
+                        "model": inputs.model.model_name,
+                        "adapter_type": type(client.provider_adapter).__name__,
+                        "variant_index": variant_index,
+                        "cancel_attempted": drain_audit.get("cancel_attempted"),
+                        "cancel_succeeded": drain_audit.get("cancel_succeeded"),
+                        "partial_input_tokens": partial_usage.get("input_tokens", 0),
+                        "partial_output_tokens": partial_usage.get("output_tokens", 0),
+                    },
                 )
 
-        return final_message_event, followup_messages, terminated, partial_usage
+        return final_message_event, followup_messages, terminated, partial_usage, drain_audit
 
     async def _stream_variant_phase(  # noqa: PLR0912, PLR0915
         self,
@@ -786,10 +977,20 @@ class EnsembleStreamingHelper:
             # before the break — finalize flags this with
             # `partial_usage_unavailable=True`.
             partial_usage: dict[str, Any] = {}
+            # SHU-803 AC9g: drain audit fields stamped on the LLMUsage row's
+            # request_metadata for terminated streams. Populated by
+            # `_call_provider` only when terminated; empty dict otherwise.
+            drain_audit: dict[str, Any] = {}
 
             # We loop until the agents are done pulling what they need to pull.
             while True:
-                final_message_event, additional_messages, terminated, partial_usage = await self._call_provider(
+                (
+                    final_message_event,
+                    additional_messages,
+                    terminated,
+                    partial_usage,
+                    drain_audit,
+                ) = await self._call_provider(
                     client=client,
                     messages=call_messages,
                     inputs=inputs,
@@ -861,6 +1062,7 @@ class EnsembleStreamingHelper:
                     usage=partial_usage,
                     model_name_for_event=model_display_name,
                     final_event_type="final_message",
+                    drain_audit=drain_audit,
                 )
 
             if final_message_event is None:
@@ -1138,6 +1340,16 @@ class EnsembleStreamingHelper:
                         else:
                             usage_success = True
                             usage_error_message = None
+                        # SHU-803 AC9g: stamp drain audit fields on the
+                        # LLMUsage row's request_metadata for terminated
+                        # streams so ops can distinguish a clean drain
+                        # (final_event / done) from a shutdown-truncated
+                        # one (shutdown_aborted) or a stuck upstream
+                        # (exception). Non-terminated rows skip this —
+                        # request_metadata stays None.
+                        request_metadata: dict[str, Any] | None = None
+                        if result.terminated and result.drain_audit:
+                            request_metadata = dict(result.drain_audit)
                         await get_usage_recorder().record(
                             provider_id=inputs.model.provider_id,
                             model_id=inputs.model.id,
@@ -1149,6 +1361,7 @@ class EnsembleStreamingHelper:
                             response_time_ms=result.metadata.get("response_time_ms"),
                             success=usage_success,
                             error_message=usage_error_message,
+                            request_metadata=request_metadata,
                             session=session,
                         )
 

--- a/backend/src/shu/services/providers/adapter_base.py
+++ b/backend/src/shu/services/providers/adapter_base.py
@@ -408,6 +408,33 @@ class BaseProviderAdapter:
         else:
             self.usage = self._aggregate_usage(self.usage, usage_dict)
 
+    async def cancel(self) -> bool:
+        """SHU-803 AC9e: best-effort upstream cancellation.
+
+        Default returns ``False`` (no-op). Override in adapters whose
+        underlying provider exposes a real cancel API — for example
+        ``ResponsesAdapter`` POSTs to ``/responses/{id}/cancel`` because
+        the OpenAI Responses API keeps generating server-side after
+        stream close (and billing continues) unless the cancel endpoint
+        is hit.
+
+        Returns ``True`` when the cancel request succeeded (2xx),
+        ``False`` if the adapter doesn't support cancellation OR the
+        attempt failed for any reason (network error, non-2xx, exception).
+        Callers MUST fall through to the drain path regardless of return
+        value — cancel is racing drain in the SHU-803 design and a False
+        return simply means we proceed without the explicit cancel
+        signal. For providers that respect stream-close as cancel
+        (Anthropic, Gemini), the drain loop closes the HTTP stream
+        naturally when it exits, which is the cancel signal.
+
+        Must NOT raise — exceptions are logged inside the implementation
+        and folded into a ``False`` return so the consumer loop's
+        ``asyncio.gather(cancel_task, drain_task)`` doesn't surface a
+        cancel-side exception as the gather result.
+        """
+        return False
+
     def get_partial_usage_snapshot(self) -> UsageDict:
         """SHU-802: return cumulative usage seen so far on a partial stream.
 

--- a/backend/src/shu/services/providers/adapters/anthropic_adapter.py
+++ b/backend/src/shu/services/providers/adapters/anthropic_adapter.py
@@ -605,7 +605,31 @@ class AnthropicAdapter(BaseProviderAdapter):
             return ProviderContentDeltaEventResult(content=content_delta)
 
         if "usage" in chunk:
-            self._latest_usage_event = chunk
+            # SHU-803 AC9b: MERGE the chunk's usage with the prior
+            # ``_latest_usage_event`` (if any) so a later ``message_delta``
+            # (top-level usage carrying only output_tokens) does NOT
+            # overwrite the ``input_tokens`` Anthropic emitted earlier
+            # in ``message_start``. Without the merge, a stream that
+            # naturally completes records ``input_tokens=0`` on the
+            # ``LLMUsage`` row because ``_extract_usage`` reads whatever
+            # the LAST usage-bearing chunk was — and message_delta is
+            # always last.
+            existing_usage = (self._latest_usage_event or {}).get("usage") or {}
+            new_usage = chunk.get("usage") or {}
+            merged_usage = {**existing_usage, **new_usage}
+            self._latest_usage_event = {**chunk, "usage": merged_usage}
+        elif (
+            chunk.get("type") == "message_start"
+            and isinstance(chunk.get("message"), dict)
+            and "usage" in chunk["message"]
+        ):
+            # SHU-803 AC9b: Anthropic emits initial input_tokens on `message_start`
+            # with usage nested under `message`, not top-level. Without this branch
+            # `_latest_usage_event` stays None and a terminate before any
+            # `message_delta` lands loses input_tokens entirely. Normalize the
+            # shape so `_extract_usage` (which jmespath-searches the top-level
+            # `usage` key) sees it the same as a `message_delta` chunk.
+            self._latest_usage_event = {"usage": chunk["message"]["usage"]}
 
         _, index, start_event = jmespath.search(
             "type=='content_block_start' && content_block.type == 'tool_use' && *", chunk

--- a/backend/src/shu/services/providers/adapters/responses_adapter.py
+++ b/backend/src/shu/services/providers/adapters/responses_adapter.py
@@ -278,14 +278,19 @@ class ResponsesAdapter(BaseProviderAdapter):
         return parts
 
     async def handle_provider_event(self, chunk: dict[str, Any]) -> ProviderEventResult | None:  # noqa: PLR0912
-        # SHU-803 AC9e: capture response.id from the first `response.created`
-        # event so a subsequent `cancel()` call can address the right
-        # in-flight run. The OpenAI Responses API emits this as the first
-        # event in the stream, so a terminate firing AFTER any content
-        # delta is guaranteed to have an id available. If terminate fires
-        # BEFORE `response.created` lands (extremely tight race window),
-        # `cancel()` no-ops and drain still captures the eventual usage.
-        if chunk.get("type") == "response.created" and self._response_id is None:
+        # SHU-803 AC9e: capture response.id on every `response.created`
+        # event so `cancel()` targets the currently in-flight run. The
+        # adapter instance is reused across tool-call follow-up turns in
+        # ``_stream_variant_phase`` — each turn opens a fresh stream and
+        # emits a NEW ``response.created`` with a new id. A first-wins
+        # guard here would leave ``_response_id`` pointing at the long-
+        # completed first-turn id, so a user clicking Stop on a tool-
+        # using assistant's final answer would POST to the wrong
+        # /responses/{id}/cancel endpoint and the live stream would keep
+        # billing. If terminate fires BEFORE `response.created` lands
+        # (extremely tight race window), `cancel()` no-ops and drain
+        # still captures the eventual usage.
+        if chunk.get("type") == "response.created":
             response_id = jmespath.search("response.id", chunk)
             if isinstance(response_id, str) and response_id:
                 self._response_id = response_id

--- a/backend/src/shu/services/providers/adapters/responses_adapter.py
+++ b/backend/src/shu/services/providers/adapters/responses_adapter.py
@@ -59,14 +59,13 @@ class ResponsesAdapter(BaseProviderAdapter):
         # in-flight run. Stays None until that event lands; `cancel()`
         # returns False (no-op) if invoked before the id is known.
         self._response_id: str | None = None
-        # SHU-803 AC9e: lazily-initialized httpx client for the cancel
-        # POST. Created on first `cancel()` call rather than in __init__
-        # so streams that never get user-terminated don't pay the cost
-        # of an httpx instance they never use. Lifetime is bounded by
-        # the adapter instance (which is per-stream per-variant), so we
-        # don't explicitly close it — GC handles cleanup when the
-        # variant task ends.
-        self._cancel_client: httpx.AsyncClient | None = None
+        # SHU-803 AC9e: optional transport injection for the cancel POST.
+        # Production code leaves this None; ``cancel()`` constructs an
+        # ``httpx.AsyncClient`` inside an ``async with`` so the client is
+        # deterministically closed (no GC-time "Unclosed AsyncClient"
+        # warning). Tests pre-install an ``httpx.MockTransport`` here to
+        # intercept the cancel POST without patching ``httpx`` globally.
+        self._cancel_transport: httpx.AsyncBaseTransport | None = None
 
     # General provider information
     def get_provider_information(self) -> ProviderInformation:
@@ -129,8 +128,11 @@ class ResponsesAdapter(BaseProviderAdapter):
           (terminate fired before ``response.created`` landed — extremely
           rare race). The drain path still captures usage if the
           provider eventually emits ``response.completed``.
-        - Lazily creates ``self._cancel_client`` on first call to avoid
-          paying for an httpx instance on streams that never terminate.
+        - Constructs the httpx client inside ``async with`` so it is
+          deterministically closed when the POST completes (no GC-time
+          "Unclosed AsyncClient" warnings). The adapter is per-stream
+          per-variant and cancel() runs at most once per stream — there
+          is no reuse to optimize for.
         - 2-second timeout — the cancel POST should be quick or fall
           through to drain. The consumer loop races this with drain
           via ``asyncio.gather`` so a slow cancel does not block the
@@ -148,9 +150,6 @@ class ResponsesAdapter(BaseProviderAdapter):
             # Drain still runs and captures usage if it eventually lands.
             return False
 
-        if self._cancel_client is None:
-            self._cancel_client = httpx.AsyncClient(timeout=2.0)
-
         base_url = self.get_field_with_override("get_api_base_url")
         if not base_url:
             # Mis-configured adapter — without a base URL we can't
@@ -162,8 +161,16 @@ class ResponsesAdapter(BaseProviderAdapter):
         auth_def = self.get_authorization_header() or {}
         headers = auth_def.get("headers") or {}
 
+        # SHU-803 AC9e: ``async with`` so the client (and its connection
+        # pool) is closed before this coroutine returns. The adapter is
+        # short-lived (one stream / variant) and cancel() runs at most
+        # once per stream, so there is no client reuse to optimize for.
         try:
-            response = await self._cancel_client.post(cancel_url, headers=headers)
+            async with httpx.AsyncClient(
+                transport=self._cancel_transport,
+                timeout=2.0,
+            ) as client:
+                response = await client.post(cancel_url, headers=headers)
         except Exception as exc:
             # Network failure, DNS, TLS, whatever — fall through to drain.
             # Log to telemetry; consumer loop doesn't care which side failed.

--- a/backend/src/shu/services/providers/adapters/responses_adapter.py
+++ b/backend/src/shu/services/providers/adapters/responses_adapter.py
@@ -2,6 +2,7 @@ import copy
 import json
 from typing import Any
 
+import httpx
 import jmespath
 
 from shu.core.logging import get_logger
@@ -26,6 +27,24 @@ from ..adapter_base import (
 
 logger = get_logger(__name__)
 
+# SHU-803 AC9j: tracks provider IDs that have already produced one
+# INFO-level cancel-attempt-failed log. Subsequent failures from the
+# same provider escalate to WARN — operators get one breadcrumb the
+# first time a Responses-shaped gateway doesn't honor the cancel
+# endpoint, then a louder signal if it keeps happening (suggesting they
+# should configure that provider as completions-shape instead).
+# Module-level so it survives across adapter instances; in tests, the
+# `_reset_cancel_failure_tracking` helper clears it.
+_CANCEL_FAILURE_LOGGED_PROVIDERS: set[str] = set()
+
+
+def _reset_cancel_failure_tracking() -> None:
+    """SHU-803: test-only helper to clear the module-level
+    `_CANCEL_FAILURE_LOGGED_PROVIDERS` set between tests. Not part of
+    the public API; production code never calls this.
+    """
+    _CANCEL_FAILURE_LOGGED_PROVIDERS.clear()
+
 
 class ResponsesAdapter(BaseProviderAdapter):
     """Base adapter for providers implementing the OpenAI Responses API contract."""
@@ -35,6 +54,19 @@ class ResponsesAdapter(BaseProviderAdapter):
         self.function_call_messages: list[dict[str, Any]] = []
         self.function_call_reasoning_messages: list[dict[str, Any]] = []
         self._streamed_text: list[str] = []
+        # SHU-803 AC9e: response.id captured from the first
+        # `response.created` SSE event so `cancel()` can address the right
+        # in-flight run. Stays None until that event lands; `cancel()`
+        # returns False (no-op) if invoked before the id is known.
+        self._response_id: str | None = None
+        # SHU-803 AC9e: lazily-initialized httpx client for the cancel
+        # POST. Created on first `cancel()` call rather than in __init__
+        # so streams that never get user-terminated don't pay the cost
+        # of an httpx instance they never use. Lifetime is bounded by
+        # the adapter instance (which is per-stream per-variant), so we
+        # don't explicitly close it — GC handles cleanup when the
+        # variant task ends.
+        self._cancel_client: httpx.AsyncClient | None = None
 
     # General provider information
     def get_provider_information(self) -> ProviderInformation:
@@ -81,6 +113,110 @@ class ResponsesAdapter(BaseProviderAdapter):
             args_dict = {}
 
         return ToolCallInstructions(plugin_name=plugin_name, operation=op, args_dict=args_dict)
+
+    async def cancel(self) -> bool:
+        """SHU-803 AC9e: POST to `/responses/{id}/cancel`.
+
+        The OpenAI Responses API does NOT respect stream-close as a
+        cancel signal — the run keeps executing server-side and billing
+        continues until either the run completes naturally or the
+        explicit cancel endpoint is hit. This override implements the
+        cancel endpoint so user-terminate actually stops the bill.
+
+        Behavior:
+
+        - Returns ``False`` immediately if ``_response_id`` is not set
+          (terminate fired before ``response.created`` landed — extremely
+          rare race). The drain path still captures usage if the
+          provider eventually emits ``response.completed``.
+        - Lazily creates ``self._cancel_client`` on first call to avoid
+          paying for an httpx instance on streams that never terminate.
+        - 2-second timeout — the cancel POST should be quick or fall
+          through to drain. The consumer loop races this with drain
+          via ``asyncio.gather`` so a slow cancel does not block the
+          drain (Phase 2.2 decision in the SHU-803 game-plan).
+        - Returns ``True`` on 2xx response, ``False`` on any other
+          status or exception. Non-2xx triggers SHU-803 AC9j logging:
+          INFO first-time-per-provider, WARN on subsequent failures
+          (signaling the gateway probably doesn't honor the cancel
+          endpoint and should be configured as completions-shape).
+        - Never raises — exceptions are caught and folded into a
+          ``False`` return per the BaseProviderAdapter contract.
+        """
+        if not self._response_id:
+            # No `response.created` event yet — nothing to cancel.
+            # Drain still runs and captures usage if it eventually lands.
+            return False
+
+        if self._cancel_client is None:
+            self._cancel_client = httpx.AsyncClient(timeout=2.0)
+
+        base_url = self.get_field_with_override("get_api_base_url")
+        if not base_url:
+            # Mis-configured adapter — without a base URL we can't
+            # construct the cancel endpoint. Log and fall through.
+            logger.warning("ResponsesAdapter.cancel: get_api_base_url returned no value; skipping cancel POST")
+            return False
+
+        cancel_url = f"{base_url.rstrip('/')}/responses/{self._response_id}/cancel"
+        auth_def = self.get_authorization_header() or {}
+        headers = auth_def.get("headers") or {}
+
+        try:
+            response = await self._cancel_client.post(cancel_url, headers=headers)
+        except Exception as exc:
+            # Network failure, DNS, TLS, whatever — fall through to drain.
+            # Log to telemetry; consumer loop doesn't care which side failed.
+            self._log_cancel_failure(
+                status_code=None,
+                error=str(exc),
+                cancel_url=cancel_url,
+            )
+            return False
+
+        if 200 <= response.status_code < 300:
+            return True
+
+        self._log_cancel_failure(
+            status_code=response.status_code,
+            error=None,
+            cancel_url=cancel_url,
+        )
+        return False
+
+    def _log_cancel_failure(
+        self,
+        *,
+        status_code: int | None,
+        error: str | None,
+        cancel_url: str,
+    ) -> None:
+        """SHU-803 AC9j: emit INFO the first time a provider's cancel
+        endpoint fails, then WARN on subsequent failures from the same
+        provider. Operators get one breadcrumb when a Responses-shaped
+        gateway doesn't honor the cancel endpoint, then a louder signal
+        if it keeps happening (suggesting they should configure that
+        provider as completions-shape instead).
+        """
+        provider_id = str(getattr(self.provider, "id", "") or cancel_url)
+        already_logged = provider_id in _CANCEL_FAILURE_LOGGED_PROVIDERS
+        level = logger.warning if already_logged else logger.info
+        if status_code is not None:
+            level(
+                "ResponsesAdapter.cancel: non-2xx response from %s (status=%d). "
+                "If this provider doesn't honor the cancel endpoint, configure "
+                "it as completions-shape so the consumer loop relies on drain "
+                "alone instead.",
+                cancel_url,
+                status_code,
+            )
+        else:
+            level(
+                "ResponsesAdapter.cancel: HTTP error contacting %s: %s. " "Drain will still attempt to capture usage.",
+                cancel_url,
+                error,
+            )
+        _CANCEL_FAILURE_LOGGED_PROVIDERS.add(provider_id)
 
     def _extract_usage(self, path: str, chunk) -> None:
         usage = jmespath.search(path, chunk) or {}
@@ -134,7 +270,19 @@ class ResponsesAdapter(BaseProviderAdapter):
 
         return parts
 
-    async def handle_provider_event(self, chunk: dict[str, Any]) -> ProviderEventResult | None:
+    async def handle_provider_event(self, chunk: dict[str, Any]) -> ProviderEventResult | None:  # noqa: PLR0912
+        # SHU-803 AC9e: capture response.id from the first `response.created`
+        # event so a subsequent `cancel()` call can address the right
+        # in-flight run. The OpenAI Responses API emits this as the first
+        # event in the stream, so a terminate firing AFTER any content
+        # delta is guaranteed to have an id available. If terminate fires
+        # BEFORE `response.created` lands (extremely tight race window),
+        # `cancel()` no-ops and drain still captures the eventual usage.
+        if chunk.get("type") == "response.created" and self._response_id is None:
+            response_id = jmespath.search("response.id", chunk)
+            if isinstance(response_id, str) and response_id:
+                self._response_id = response_id
+
         incomplete_response = jmespath.search(
             "type=='response.incomplete' && response.incomplete_details.reason", chunk
         )

--- a/backend/src/tests/integ/helpers/stub_provider_stream.py
+++ b/backend/src/tests/integ/helpers/stub_provider_stream.py
@@ -1,0 +1,438 @@
+"""SHU-803 AC10: test helper that stubs the upstream LLM stream.
+
+The integration tests for the real-partial-usage capture path (the
+SHU-803 abuse-vector close-out) need to feed deterministic chunk
+sequences shaped exactly like each provider's wire protocol
+(Anthropic ``message_start`` / ``message_delta``, Gemini cumulative
+``usageMetadata``, OpenAI Chat Completions end-only ``usage``,
+OpenAI Responses ``response.completed``) to the REAL adapter's
+``handle_provider_event`` method. Mocking handle_provider_event would
+defeat the point of these tests — they exist to validate the
+capture logic against the actual chunk shapes.
+
+The implementation strategy: monkey-patch
+:meth:`UnifiedLLMClient._stream_response` (the inner streaming method
+that does the upstream HTTP request and iterates SSE lines) with a
+stub that yields events from the test's chunk fixture. Everything
+above ``_stream_response`` (the ``chat_completion`` plumbing, the
+retry layer, ``_call_provider``'s drain loop, ``_finalize_variant_phase``'s
+LLMUsage writes) runs unchanged — the test validates the entire chain
+minus the HTTP transport.
+
+Per-chunk delays let tests position the terminate POST precisely
+between chunks (e.g., AFTER ``message_start`` but BEFORE the first
+``message_delta`` for the Anthropic pre-delta scenario).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from unittest.mock import patch
+
+from shu.llm.client import UnifiedLLMClient
+from shu.services.providers.adapter_base import (
+    ProviderContentDeltaEventResult,
+    ProviderErrorEventResult,
+    ProviderEventResult,
+    ProviderFinalEventResult,
+    ProviderReasoningDeltaEventResult,
+)
+
+
+@dataclass
+class StubChunk:
+    """A single upstream chunk yielded to the adapter's ``handle_provider_event``.
+
+    Attributes:
+        data: The raw chunk dict — shape determined by the provider's
+            streaming protocol (e.g. Anthropic's ``{"type": "message_start",
+            "message": {"usage": {...}}}``).
+        delay_seconds: Wall-clock delay BEFORE this chunk is fed. Used to
+            position a terminate POST between specific chunks. Default
+            ``0.0`` means no pause; tests typically set ~0.3s on the
+            chunk immediately AFTER the position they want terminate to
+            land at (the test's poll-and-terminate cycle takes ~50ms, so
+            a 300ms gap is comfortable).
+    """
+
+    data: dict[str, Any]
+    delay_seconds: float = 0.0
+
+
+@dataclass
+class StubStreamFixture:
+    """Configured chunk sequence + optional per-fixture knobs.
+
+    The stub patches ``_stream_response`` to iterate ``chunks`` and feed
+    each one to the adapter's ``handle_provider_event``. After the chunk
+    loop the stub also calls ``finalize_provider_events`` to mimic the
+    real ``_stream_response`` flow (tool-call follow-ups, late final
+    events, etc.).
+    """
+
+    chunks: list[StubChunk] = field(default_factory=list)
+
+
+@contextmanager
+def stub_provider_stream(fixture: StubStreamFixture):
+    """Install the chunk-based stub for the duration of the with-block.
+
+    Patches :meth:`UnifiedLLMClient._stream_response` at the class level
+    so any ``UnifiedLLMClient`` instance constructed inside the with-block
+    uses the stub. Tests using this helper MUST drive a single stream
+    per fixture — concurrent variants in an ensemble would share the
+    same chunks (probably not what you want; SHU-803 tests use
+    single-variant configurations).
+
+    Yields ``None``. The fixture is closure-captured by the stub method.
+    """
+
+    async def stub_stream_response(
+        self: UnifiedLLMClient,
+        payload: dict[str, Any],
+        model: str,
+        start_time: datetime,
+        request_timeout: float | None = None,
+    ) -> AsyncGenerator[ProviderEventResult, None]:
+        """Faithful replica of :meth:`UnifiedLLMClient._stream_response`
+        minus the HTTP transport. Feeds each fixture chunk to the real
+        adapter's ``handle_provider_event``, then runs
+        ``finalize_provider_events`` after the loop. Mirrors the
+        content-delta-yields-immediately / final-yields-at-end ordering
+        the production method uses so ``_call_provider`` upstream sees
+        an indistinguishable event sequence.
+        """
+        final_event: ProviderEventResult | None = None
+
+        for chunk in fixture.chunks:
+            if chunk.delay_seconds > 0:
+                await asyncio.sleep(chunk.delay_seconds)
+            else:
+                # Yield control even on zero-delay chunks so the event
+                # loop can interleave the terminate POST polling task.
+                await asyncio.sleep(0)
+
+            provider_event = await self.provider_adapter.handle_provider_event(chunk.data)
+            if provider_event:
+                if isinstance(
+                    provider_event,
+                    (ProviderContentDeltaEventResult, ProviderReasoningDeltaEventResult),
+                ):
+                    yield provider_event
+                elif isinstance(provider_event, (ProviderFinalEventResult, ProviderErrorEventResult)):
+                    # Captured for end-of-stream emission, matching the
+                    # production semantics in _stream_response.
+                    final_event = provider_event
+
+        # Mirror production: drain finalize events after the chunk loop.
+        # Tool-call results land here; late finals captured too.
+        finalize_events = await self.provider_adapter.finalize_provider_events() or []
+        for event in finalize_events:
+            if isinstance(event, (ProviderFinalEventResult, ProviderErrorEventResult)):
+                final_event = event
+                continue
+            yield event
+
+        if final_event is not None:
+            yield final_event
+
+    with patch.object(UnifiedLLMClient, "_stream_response", new=stub_stream_response):
+        yield
+
+
+# -----------------------------------------------------------------------------
+# Per-provider canned chunk shapes for the SHU-803 AC10 integration tests.
+# Each helper returns a StubStreamFixture targeting one of the four protocols.
+# Tests typically inject a 300ms delay on the chunk BEFORE the natural
+# terminate-fire point so the test's terminate POST lands between chunks
+# rather than racing the next handle_provider_event.
+# -----------------------------------------------------------------------------
+
+
+def anthropic_message_start_then_delta_fixture(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    text_content: str = "Hello, world.",
+    delay_before_message_delta_s: float = 0.3,
+) -> StubStreamFixture:
+    """Anthropic shape: message_start (nested usage with input_tokens),
+    content_block_start, content_block_delta with text, message_delta
+    (top-level usage with output_tokens), message_stop.
+
+    The ``delay_before_message_delta_s`` parameter positions the
+    terminate POST. By default (0.3s) the POST has comfortable time to
+    land AFTER the first content_block_delta but BEFORE message_delta —
+    so the test asserting "terminate AFTER message_delta" needs to
+    structure its timing accordingly (see the AC10 tests).
+    """
+    return StubStreamFixture(
+        chunks=[
+            StubChunk(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_stub",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-stub",
+                        "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+                    },
+                },
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": text_content}},
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                    "usage": {"output_tokens": output_tokens},
+                },
+                delay_seconds=delay_before_message_delta_s,
+            ),
+            StubChunk({"type": "message_stop"}, delay_seconds=0.05),
+        ]
+    )
+
+
+def anthropic_pre_delta_fixture(*, input_tokens: int, delay_before_first_content_s: float = 0.4) -> StubStreamFixture:
+    """Anthropic shape positioned so terminate fires AFTER message_start
+    but BEFORE the first content_block_delta lands. The pre-delta gap
+    is the load-bearing window for asserting input_tokens > 0 with
+    output_tokens == 0.
+    """
+    return StubStreamFixture(
+        chunks=[
+            StubChunk(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_stub",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-stub",
+                        "usage": {"input_tokens": input_tokens, "output_tokens": 0},
+                    },
+                },
+                delay_seconds=0.0,
+            ),
+            # Big pause here — terminate POST lands during this gap.
+            StubChunk(
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+                delay_seconds=delay_before_first_content_s,
+            ),
+            StubChunk(
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hi."}},
+                delay_seconds=0.0,
+            ),
+            # No message_delta here — fixture ends before output_tokens
+            # would have been emitted. Drain sees end-of-stream and exits.
+        ]
+    )
+
+
+def gemini_cumulative_usage_fixture(
+    *,
+    final_prompt_tokens: int,
+    final_candidates_tokens: int,
+    text_content: str = "Hi.",
+    delay_before_final_chunk_s: float = 0.3,
+) -> StubStreamFixture:
+    """Gemini shape: every chunk carries ``usageMetadata`` cumulative-to-date.
+    Tests asserting the snapshot reflects the LAST-seen counts.
+    """
+    return StubStreamFixture(
+        chunks=[
+            StubChunk(
+                {
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": text_content[:1]}], "role": "model"},
+                            "index": 0,
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": final_prompt_tokens,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": final_prompt_tokens + 1,
+                    },
+                },
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": text_content[1:]}], "role": "model"},
+                            "index": 0,
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": final_prompt_tokens,
+                        "candidatesTokenCount": final_candidates_tokens,
+                        "totalTokenCount": final_prompt_tokens + final_candidates_tokens,
+                    },
+                },
+                delay_seconds=delay_before_final_chunk_s,
+            ),
+        ]
+    )
+
+
+def openai_completions_end_usage_fixture(
+    *,
+    prompt_tokens: int,
+    completion_tokens: int,
+    text_content: str = "Final answer.",
+    wire_cost: str | None = None,
+    delay_before_usage_chunk_s: float = 0.3,
+) -> StubStreamFixture:
+    """OpenAI Chat Completions shape (also OpenRouter / LM Studio / Ollama):
+    content chunks, then a final ``usage`` chunk before ``[DONE]``.
+
+    The ``wire_cost`` argument controls whether the usage chunk carries
+    ``usage.cost`` (the OpenRouter authoritative-wire-cost path) — pass
+    a stringified Decimal to populate it, or None to omit (the DB-rate
+    fallback path AC9d covers).
+    """
+    usage_chunk_usage: dict[str, Any] = {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+    }
+    if wire_cost is not None:
+        usage_chunk_usage["cost"] = wire_cost
+
+    return StubStreamFixture(
+        chunks=[
+            StubChunk(
+                {
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {"index": 0, "delta": {"role": "assistant", "content": text_content[:5]}, "finish_reason": None}
+                    ],
+                },
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {
+                    "object": "chat.completion.chunk",
+                    "choices": [
+                        {"index": 0, "delta": {"content": text_content[5:]}, "finish_reason": None}
+                    ],
+                },
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {
+                    "object": "chat.completion.chunk",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                },
+                delay_seconds=delay_before_usage_chunk_s,
+            ),
+            StubChunk(
+                {
+                    "object": "chat.completion.chunk",
+                    "choices": [],
+                    "usage": usage_chunk_usage,
+                },
+                delay_seconds=0.0,
+            ),
+        ]
+    )
+
+
+@contextmanager
+def stub_responses_cancel_transport(handler):
+    """Pre-install an ``httpx.MockTransport``-backed ``_cancel_client`` on
+    every ``ResponsesAdapter`` instance constructed inside the with-block.
+
+    Used by the AC10 ``test_terminate_responses_cancel_called_via_mock_transport``
+    integration test to assert the cancel POST URL ends in
+    ``/responses/{id}/cancel``. The handler closure captures each
+    intercepted request so the test can introspect them.
+
+    This patches ``ResponsesAdapter.__init__`` rather than ``httpx.AsyncClient``
+    so the test framework's own httpx clients (used for SSE streaming etc.)
+    are unaffected — only adapter-owned cancel clients get the mock transport.
+    """
+    from shu.services.providers.adapters.responses_adapter import ResponsesAdapter
+    import httpx as _httpx
+
+    transport = _httpx.MockTransport(handler)
+    original_init = ResponsesAdapter.__init__
+
+    def patched_init(self, context):
+        original_init(self, context)
+        # Pre-install — cancel() short-circuits the lazy init when
+        # self._cancel_client is already set.
+        self._cancel_client = _httpx.AsyncClient(transport=transport, timeout=2.0)
+
+    with patch.object(ResponsesAdapter, "__init__", patched_init):
+        yield
+
+
+def openai_responses_response_completed_fixture(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    response_id: str = "resp_stub",
+    text_content: str = "Final answer.",
+    wire_cost: str | None = None,
+    delay_before_completed_s: float = 0.3,
+) -> StubStreamFixture:
+    """OpenAI Responses API shape: response.created (with response.id),
+    response.output_text.delta chunks, then response.completed with
+    usage in response.usage."""
+    completed_usage: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    if wire_cost is not None:
+        completed_usage["cost"] = wire_cost
+
+    return StubStreamFixture(
+        chunks=[
+            StubChunk(
+                {"type": "response.created", "response": {"id": response_id}},
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {"type": "response.output_text.delta", "delta": text_content[:5]},
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {"type": "response.output_text.delta", "delta": text_content[5:]},
+                delay_seconds=0.0,
+            ),
+            StubChunk(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": response_id,
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [{"type": "output_text", "text": text_content}],
+                            }
+                        ],
+                        "usage": completed_usage,
+                    },
+                },
+                delay_seconds=delay_before_completed_s,
+            ),
+        ]
+    )

--- a/backend/src/tests/integ/helpers/stub_provider_stream.py
+++ b/backend/src/tests/integ/helpers/stub_provider_stream.py
@@ -356,8 +356,8 @@ def openai_completions_end_usage_fixture(
 
 @contextmanager
 def stub_responses_cancel_transport(handler):
-    """Pre-install an ``httpx.MockTransport``-backed ``_cancel_client`` on
-    every ``ResponsesAdapter`` instance constructed inside the with-block.
+    """Inject an ``httpx.MockTransport`` into every ``ResponsesAdapter``
+    instance constructed inside the with-block via ``_cancel_transport``.
 
     Used by the AC10 ``test_terminate_responses_cancel_called_via_mock_transport``
     integration test to assert the cancel POST URL ends in
@@ -376,9 +376,9 @@ def stub_responses_cancel_transport(handler):
 
     def patched_init(self, context):
         original_init(self, context)
-        # Pre-install — cancel() short-circuits the lazy init when
-        # self._cancel_client is already set.
-        self._cancel_client = _httpx.AsyncClient(transport=transport, timeout=2.0)
+        # Injected on the adapter — cancel() reads this when constructing
+        # its short-lived httpx.AsyncClient inside an ``async with``.
+        self._cancel_transport = transport
 
     with patch.object(ResponsesAdapter, "__init__", patched_init):
         yield

--- a/backend/src/tests/integ/integration_test_runner.py
+++ b/backend/src/tests/integ/integration_test_runner.py
@@ -166,32 +166,42 @@ class IntegrationTestRunner:
         """Create an admin user for testing."""
         import uuid
 
+        from shu.core.tenant import tenant_context_for_tenant_id
+
         test_id = str(uuid.uuid4())[:8]
 
-        # Clean up any existing test admin users (and dependent rows)
-        await self.db.execute(
-            text(
-                "DELETE FROM plugin_subscriptions WHERE user_id IN (SELECT id FROM users WHERE email LIKE 'test-admin-%@example.com')"
+        # SHU-761: direct ORM inserts trip _stamp_tenant_id (before_flush event)
+        # which requires tenant_context to be set. The framework bypasses HTTP
+        # routes — which would set context via resolve_tenant — so we wrap the
+        # setup writes manually. Passing None defers to deployment-mode
+        # resolution: self-hosted → SELF_HOSTED_TENANT_UUID, silo → configured
+        # tenant. Multi-tenant test runs would need explicit tenant IDs but
+        # aren't the current target.
+        async with tenant_context_for_tenant_id(None):
+            # Clean up any existing test admin users (and dependent rows)
+            await self.db.execute(
+                text(
+                    "DELETE FROM plugin_subscriptions WHERE user_id IN (SELECT id FROM users WHERE email LIKE 'test-admin-%@example.com')"
+                )
             )
-        )
-        await self.db.execute(
-            text(
-                "DELETE FROM provider_credentials WHERE user_id IN (SELECT id FROM users WHERE email LIKE 'test-admin-%@example.com')"
+            await self.db.execute(
+                text(
+                    "DELETE FROM provider_credentials WHERE user_id IN (SELECT id FROM users WHERE email LIKE 'test-admin-%@example.com')"
+                )
             )
-        )
-        await self.db.execute(text("DELETE FROM users WHERE email LIKE 'test-admin-%@example.com'"))
-        await self.db.commit()
+            await self.db.execute(text("DELETE FROM users WHERE email LIKE 'test-admin-%@example.com'"))
+            await self.db.commit()
 
-        # Create new admin user
-        self.admin_user = User(
-            email=f"test-admin-{test_id}@example.com",
-            name=f"Test Admin {test_id}",
-            role=UserRole.ADMIN.value,
-            is_active=True,
-        )
-        self.db.add(self.admin_user)
-        await self.db.commit()
-        await self.db.refresh(self.admin_user)
+            # Create new admin user
+            self.admin_user = User(
+                email=f"test-admin-{test_id}@example.com",
+                name=f"Test Admin {test_id}",
+                role=UserRole.ADMIN.value,
+                is_active=True,
+            )
+            self.db.add(self.admin_user)
+            await self.db.commit()
+            await self.db.refresh(self.admin_user)
 
         # Invalidate policy cache so it picks up the new admin user
         from shu.services.policy_engine import POLICY_CACHE

--- a/backend/src/tests/integ/test_chat_early_persist_integration.py
+++ b/backend/src/tests/integ/test_chat_early_persist_integration.py
@@ -44,6 +44,7 @@ from integ.base_integration_test import BaseIntegrationTestSuite
 from integ.helpers.auth import cleanup_framework_test_admin, cleanup_test_user, create_active_user_with_id
 from integ.helpers.stub_provider_stream import (
     anthropic_message_start_then_delta_fixture,
+    anthropic_pre_delta_fixture,
     stub_provider_stream,
 )
 from integ.helpers.wait_for_message import wait_for_message_persisted
@@ -222,6 +223,7 @@ class ChatEarlyPersistIntegrationTest(BaseIntegrationTestSuite):
             self.test_terminate_then_followup_preserves_chronological_ordering,
             self.test_terminate_during_regenerate_assigns_correct_variant_index,
             self.test_natural_completion_does_not_take_early_persist_path,
+            self.test_terminate_during_silent_provider_gap_fires_early_persist_immediately,
             self.test_zz_teardown_test_admin,
         ]
 
@@ -539,6 +541,88 @@ class ChatEarlyPersistIntegrationTest(BaseIntegrationTestSuite):
             assert persisted is not None
             assert (persisted.message_metadata or {}).get("stream_state") == "complete"
             assert (persisted.message_metadata or {}).get("partial_usage_unavailable") is None
+        finally:
+            await cleanup_test_user(client, auth_headers, ctx["user_id"])
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=ctx["model_config_id"],
+                provider_id=ctx["provider_id"],
+            )
+
+    # ------------------------------------------------------------------
+    # 4. Silent-provider gap — Codex review follow-up
+    # ------------------------------------------------------------------
+    async def test_terminate_during_silent_provider_gap_fires_early_persist_immediately(
+        self, client, db, auth_headers
+    ):
+        """End-to-end coverage for ``_iter_with_signal_break``.
+
+        Codex code review (May 2026) flagged that the base SHU-803
+        early-persist callback was chunk-gated: the consumer loop's
+        terminate-detection check only ran between provider chunks,
+        so a silent provider after Stop delayed the partial-row commit
+        until the next chunk arrived. In that gap a refetch returned
+        no row and a follow-up message landed first — the same
+        races early-persist was supposed to close.
+
+        The fix wraps the provider stream in ``_iter_with_signal_break``,
+        which yields a sentinel the moment ``lifecycle.event`` fires
+        even if no chunk has arrived. This test exercises that path
+        live: the stub fixture sits silent for 2.5 seconds between
+        ``message_start`` and the first content delta, terminate fires
+        ~50ms into that gap, and we assert the early-persist log lands
+        well before the gap would have ended on its own.
+
+        Without the wrapper, the log lands at ~2.5s elapsed
+        (the next-chunk arrival). With the wrapper, it lands at
+        ~100ms elapsed (terminate POST latency + asyncio scheduling).
+        We pick a 1.0s threshold — well clear of both the
+        with-wrapper expected timing AND the without-wrapper failure
+        timing — so the assertion is decisive in either direction.
+        """
+        ctx = await self._setup(client, db, auth_headers)
+        try:
+            silent_gap_seconds = 2.5
+            fixture = anthropic_pre_delta_fixture(
+                input_tokens=11,
+                delay_before_first_content_s=silent_gap_seconds,
+            )
+
+            # Use the same wall clock that `logging.LogRecord.created`
+            # uses, so the elapsed-time math below is apples-to-apples.
+            import time
+
+            test_start_wall = time.time()
+            with _EarlyPersistLogCapture() as log_capture, stub_provider_stream(fixture):
+                stream_id, terminate_resp = await _capture_stream_id_and_terminate(
+                    client, conv_id=ctx["conv_id"], user_headers=ctx["user_headers"]
+                )
+            assert stream_id is not None
+            assert terminate_resp is not None
+            assert terminate_resp.status_code == 202
+
+            # Exactly one early-persist record (no double-fire).
+            assert len(log_capture.records) == 1, (
+                f"expected exactly one early_persist_terminated record, got {len(log_capture.records)}"
+            )
+            record = log_capture.records[0]
+
+            # Load-bearing: the record landed well before the silent
+            # gap would have ended naturally.
+            wall_elapsed_at_persist = record.created - test_start_wall
+            assert wall_elapsed_at_persist < (silent_gap_seconds * 0.5), (
+                f"early-persist landed {wall_elapsed_at_persist:.3f}s into the {silent_gap_seconds}s silent gap; "
+                f"expected sub-{silent_gap_seconds * 0.5:.1f}s. Without the wrapper, the chunk-gated check "
+                f"would have delayed this to ~{silent_gap_seconds:.1f}s — the regression Codex flagged."
+            )
+
+            # Sanity: the persisted row landed with the expected state.
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=ctx["conv_id"], role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+            assert (persisted.message_metadata or {}).get("stream_state") == "user_terminated"
         finally:
             await cleanup_test_user(client, auth_headers, ctx["user_id"])
             await _cleanup_provider_resources(

--- a/backend/src/tests/integ/test_chat_early_persist_integration.py
+++ b/backend/src/tests/integ/test_chat_early_persist_integration.py
@@ -127,6 +127,12 @@ async def _capture_regen_stream_id_and_terminate(  # noqa: C901  # mirrors the p
 
         deadline = asyncio.get_running_loop().time() + 5.0
         while True:
+            # Bail immediately if _consume_regen already resolved the
+            # future (e.g. set an exception on a non-200 response) so we
+            # don't keep the task alive until the 5s deadline — that
+            # delays the join in the finally block.
+            if stream_id_future.done():
+                return
             registry = getattr(_app.state, "in_flight_streams", {}) or {}
             matching = sorted(
                 stream_id

--- a/backend/src/tests/integ/test_chat_early_persist_integration.py
+++ b/backend/src/tests/integ/test_chat_early_persist_integration.py
@@ -1,0 +1,553 @@
+"""SHU-803 follow-up: terminate-time early-persist integration tests.
+
+The base SHU-803 suite ([test_chat_force_terminate_real_usage_integration](test_chat_force_terminate_real_usage_integration.py))
+proves drain captures usage correctly per provider. This suite proves
+the orthogonal guarantee that the **partial assistant Message row is
+committed at terminate-signal time, not drain-finish time** — the fix
+for two pre-fix bugs:
+
+(a) **Vanishing content during drain.** A navigation refetch landing
+    while the backend was still consuming upstream silently returned
+    zero assistant rows (the DB write only happened at drain-finish).
+    The user saw the partial answer disappear, then reappear after a
+    later refresh ~90s later on OpenRouter.
+
+(b) **Chronological ordering race.** If the user clicked Stop on a slow
+    stream and immediately sent a follow-up, the follow-up would
+    finalize first (created_at=now). The terminated stream's
+    drain-finish commit landed seconds-to-minutes later with
+    created_at=drain-finish, sorting AFTER the follow-up. A refetch
+    ordered by created_at showed messages out of conversational order.
+
+Coverage:
+
+- :meth:`test_terminate_then_followup_preserves_chronological_ordering`
+  — the headline race fix. Terminate stream A, send stream B in the
+  same conversation; assert ``user_A < assistant_A_terminated <
+  user_B < assistant_B_complete`` by created_at.
+
+- :meth:`test_terminate_during_regenerate_assigns_correct_variant_index`
+  — proves the early-persist callback's lifted regen-aware INSERT
+  block (sibling-max variant_index + regenerated metadata) works. The
+  whole point of the Plan agent's option (B refined) was to make
+  regen+terminate work; this is the test that proves it.
+
+- :meth:`test_natural_completion_does_not_take_early_persist_path` —
+  sanity / no-regression. Stream a chat to natural end, assert the
+  single Message has ``stream_state=complete``.
+"""
+
+import asyncio
+import logging
+
+from integ.base_integration_test import BaseIntegrationTestSuite
+from integ.helpers.auth import cleanup_framework_test_admin, cleanup_test_user, create_active_user_with_id
+from integ.helpers.stub_provider_stream import (
+    anthropic_message_start_then_delta_fixture,
+    stub_provider_stream,
+)
+from integ.helpers.wait_for_message import wait_for_message_persisted
+from integ.response_utils import extract_data
+from integ.test_chat_force_terminate_integration import _capture_stream_id_and_terminate
+from integ.test_chat_force_terminate_real_usage_integration import (
+    _cleanup_provider_resources,
+    _create_provider_model_conversation,
+    _ensure_local_provider_type,
+)
+from shu.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+async def _send_message_to_completion(
+    client,
+    *,
+    conv_id: str,
+    user_headers: dict,
+    message_text: str,
+) -> None:
+    """Send a chat message and drain the SSE stream to its natural end.
+
+    Counterpart to :func:`_capture_stream_id_and_terminate` for the
+    "no terminate" case. Used by the chronological-ordering test to
+    drive the second (post-terminate) stream to completion so its
+    Message row's ``stream_state`` is ``"complete"``.
+    """
+    async with client.stream(
+        "POST",
+        f"/api/v1/chat/conversations/{conv_id}/send",
+        json={"message": message_text, "rag_rewrite_mode": "no_rag"},
+        headers=user_headers,
+    ) as response:
+        assert response.status_code == 200, response.text
+        async for _line in response.aiter_lines():
+            pass
+
+
+async def _capture_regen_stream_id_and_terminate(  # noqa: C901  # mirrors the parent helper's structure
+    client,
+    *,
+    target_assistant_message_id: str,
+    conv_id: str,
+    user_headers: dict,
+) -> tuple[str | None, dict | None]:
+    """Counterpart to :func:`_capture_stream_id_and_terminate` for the
+    ``/api/v1/chat/messages/{id}/regenerate`` endpoint.
+
+    Drives the regenerate stream and POSTs terminate concurrently. The
+    polling strategy — peek ``app.state.in_flight_streams`` — is
+    identical to the /send-endpoint helper; only the request shape
+    changes. See the parent helper's docstring for the rationale.
+    """
+    stream_id_future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    async def _consume_regen() -> None:
+        try:
+            async with client.stream(
+                "POST",
+                f"/api/v1/chat/messages/{target_assistant_message_id}/regenerate",
+                json={},
+                headers=user_headers,
+            ) as response:
+                if response.status_code != 200:
+                    if not stream_id_future.done():
+                        stream_id_future.set_exception(
+                            AssertionError(f"regenerate failed: {response.status_code}")
+                        )
+                    return
+                async for _line in response.aiter_lines():
+                    pass
+        except Exception as exc:
+            if not stream_id_future.done():
+                stream_id_future.set_exception(exc)
+
+    async def _poll_registry(known_ids: set[str]) -> None:
+        from shu.main import app as _app
+
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while True:
+            registry = getattr(_app.state, "in_flight_streams", {}) or {}
+            matching = sorted(
+                stream_id
+                for stream_id, lifecycle in registry.items()
+                if stream_id not in known_ids
+                and getattr(lifecycle, "conversation_id", None) == conv_id
+            )
+            if matching:
+                stream_id_future.set_result(matching[0])
+                return
+            if asyncio.get_running_loop().time() >= deadline:
+                if not stream_id_future.done():
+                    stream_id_future.set_exception(
+                        AssertionError("no new regen stream_id appeared in app.state within 5s")
+                    )
+                return
+            await asyncio.sleep(0.005)
+
+    from shu.main import app as _app
+
+    pre_existing = set((getattr(_app.state, "in_flight_streams", {}) or {}).keys())
+    consumer = asyncio.create_task(_consume_regen())
+    poller = asyncio.create_task(_poll_registry(pre_existing))
+    try:
+        stream_id = await asyncio.wait_for(stream_id_future, timeout=5.0)
+        terminate_response = await client.post(
+            f"/api/v1/chat/streams/{stream_id}/terminate",
+            headers=user_headers,
+        )
+        return stream_id, terminate_response
+    finally:
+        for task in (poller, consumer):
+            if not task.done():
+                try:
+                    await asyncio.wait_for(task, timeout=10.0)
+                except TimeoutError:
+                    task.cancel()
+                except Exception:
+                    pass
+
+
+class _EarlyPersistLogCapture:
+    """Context manager that captures `phase=early_persist_terminated`
+    log records emitted by the chat-streaming module during the test
+    body. Used as the load-bearing evidence that the early-persist
+    callback fired (the Message-row state alone can't distinguish
+    early-persist from the legacy drain-finish INSERT path on
+    fast-drain stub providers, since both end up with the same
+    stream_state).
+    """
+
+    def __init__(self) -> None:
+        self.records: list[logging.LogRecord] = []
+        self._handler: logging.Handler | None = None
+
+    def __enter__(self) -> "_EarlyPersistLogCapture":
+        class _Capture(logging.Handler):
+            def __init__(self, sink: list[logging.LogRecord]) -> None:
+                super().__init__(level=logging.INFO)
+                self._sink = sink
+
+            def emit(self, record: logging.LogRecord) -> None:
+                phase = getattr(record, "phase", None)
+                if phase == "early_persist_terminated":
+                    self._sink.append(record)
+
+        self._handler = _Capture(self.records)
+        get_logger("services.chat_streaming").addHandler(self._handler)
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        if self._handler is not None:
+            get_logger("services.chat_streaming").removeHandler(self._handler)
+            self._handler = None
+
+
+class ChatEarlyPersistIntegrationTest(BaseIntegrationTestSuite):
+    """SHU-803 follow-up — terminate-time early-persist coverage."""
+
+    def get_suite_name(self) -> str:
+        return "Chat Early Persist Integration"
+
+    def get_suite_description(self) -> str:
+        return (
+            "SHU-803 follow-up: validates the partial assistant Message "
+            "row is committed at terminate-signal time, not drain-finish "
+            "time. Covers the chronological-ordering race fix, the "
+            "regen+terminate variant_index assignment, and the no-"
+            "regression sanity for natural completion."
+        )
+
+    def get_test_functions(self):
+        return [
+            self.test_terminate_then_followup_preserves_chronological_ordering,
+            self.test_terminate_during_regenerate_assigns_correct_variant_index,
+            self.test_natural_completion_does_not_take_early_persist_path,
+            self.test_zz_teardown_test_admin,
+        ]
+
+    async def test_zz_teardown_test_admin(self, client, db, auth_headers):
+        await cleanup_framework_test_admin(db)
+
+    async def _setup(self, client, db, auth_headers):
+        """Provision a user + provider + model_config + conversation
+        using the same anthropic stub shape the existing AC10 suite
+        uses. Returns the bundle the tests need plus the per-test
+        cleanup ids.
+        """
+        await _ensure_local_provider_type(db)
+        admin_headers = auth_headers
+        user_headers, user_id = await create_active_user_with_id(client, admin_headers)
+        provider_id, model_id, model_config_id, conv_id = await _create_provider_model_conversation(
+            client,
+            admin_headers,
+            user_headers,
+            provider_type="anthropic",
+            provider_name="shu803-early-persist",
+        )
+        return {
+            "user_headers": user_headers,
+            "user_id": user_id,
+            "provider_id": provider_id,
+            "model_id": model_id,
+            "model_config_id": model_config_id,
+            "conv_id": conv_id,
+        }
+
+    async def _list_messages_chronological(self, db, conv_id: str) -> list:
+        """Return the conversation's messages ordered by created_at
+        ASC. The DB ORM session is rolled back before the query so we
+        see committed rows from any in-flight transactions.
+        """
+        from sqlalchemy import select
+
+        from shu.models.llm_provider import Message
+
+        await db.rollback()
+        result = await db.execute(
+            select(Message).where(Message.conversation_id == conv_id).order_by(Message.created_at.asc())
+        )
+        return list(result.scalars().all())
+
+    # ------------------------------------------------------------------
+    # 1. Chronological ordering race fix
+    # ------------------------------------------------------------------
+    async def test_terminate_then_followup_preserves_chronological_ordering(self, client, db, auth_headers):
+        """The headline bug. Terminate stream A, send stream B; assert
+        ``user_A.created_at < assistant_A_terminated.created_at <
+        user_B.created_at < assistant_B_complete.created_at``.
+
+        Pre-fix, assistant_A's created_at reflected drain-finish time
+        — possibly minutes after Stop was clicked — so the timeline
+        would interleave: user_A, user_B, assistant_B, then much later
+        assistant_A. The early-persist contract guarantees
+        assistant_A's row commits at signal time, restoring
+        chronological order.
+        """
+        ctx = await self._setup(client, db, auth_headers)
+        try:
+            # Stream A — long-ish chunk delay so terminate POST lands
+            # AFTER the first content_delta but BEFORE message_delta.
+            fixture_a = anthropic_message_start_then_delta_fixture(
+                input_tokens=11,
+                output_tokens=22,
+                text_content="partial answer A",
+                delay_before_message_delta_s=0.3,
+            )
+            with _EarlyPersistLogCapture() as log_capture, stub_provider_stream(fixture_a):
+                stream_id_a, terminate_resp_a = await _capture_stream_id_and_terminate(
+                    client, conv_id=ctx["conv_id"], user_headers=ctx["user_headers"]
+                )
+            assert stream_id_a is not None
+            assert terminate_resp_a is not None
+            assert terminate_resp_a.status_code == 202
+
+            # Load-bearing: the early-persist callback fired. Without
+            # this, the test passes for the wrong reason — the
+            # message_state ordering assertion below could be
+            # satisfied by stub-driven drain completing within a
+            # millisecond of finalize, masking a regression in the
+            # callback wiring.
+            assert len(log_capture.records) == 1, (
+                f"expected exactly one early_persist_terminated log record, got {len(log_capture.records)}"
+            )
+            persist_record = log_capture.records[0]
+            assert getattr(persist_record, "regen", None) is False
+            assert getattr(persist_record, "variant_index", None) == 0
+
+            persisted_a = await wait_for_message_persisted(
+                db, conversation_id=ctx["conv_id"], role="assistant", timeout_seconds=5.0
+            )
+            assert persisted_a is not None
+            assert (persisted_a.message_metadata or {}).get("stream_state") == "user_terminated"
+
+            # Stream B — quick completion, no delay knob. Sends a
+            # separate user message and lets the assistant finalize
+            # naturally (stream_state=complete).
+            fixture_b = anthropic_message_start_then_delta_fixture(
+                input_tokens=3,
+                output_tokens=5,
+                text_content="Hi",
+                delay_before_message_delta_s=0.0,
+            )
+            with stub_provider_stream(fixture_b):
+                await _send_message_to_completion(
+                    client,
+                    conv_id=ctx["conv_id"],
+                    user_headers=ctx["user_headers"],
+                    message_text="Hello",
+                )
+
+            # Wait for B's assistant to land — `wait_for_message_persisted`
+            # with min_count=2 keeps polling until two assistant rows
+            # have committed (or the budget expires with a partial
+            # result that we'll catch in the length assertion below).
+            await wait_for_message_persisted(
+                db, conversation_id=ctx["conv_id"], role="assistant", min_count=2, timeout_seconds=5.0
+            )
+
+            messages = await self._list_messages_chronological(db, ctx["conv_id"])
+            # Expect exactly 4 rows: 2 user, 2 assistant, alternating.
+            assert len(messages) == 4, (
+                f"expected 4 messages (user_A, assistant_A, user_B, assistant_B), got {len(messages)}: "
+                + ", ".join(f"{m.role}@{m.created_at}" for m in messages)
+            )
+            assert messages[0].role == "user"
+            assert messages[1].role == "assistant"
+            assert messages[2].role == "user"
+            assert messages[3].role == "assistant"
+
+            # Stream-state ordering — A is terminated, B is complete.
+            assert (messages[1].message_metadata or {}).get("stream_state") == "user_terminated"
+            assert (messages[3].message_metadata or {}).get("stream_state") == "complete"
+
+            # The race fix — A's assistant was committed at signal time,
+            # NOT at drain finish, so it sorts BEFORE B's user message.
+            assert messages[1].created_at < messages[2].created_at, (
+                f"assistant_A.created_at ({messages[1].created_at}) should be < "
+                f"user_B.created_at ({messages[2].created_at}); the chronological-ordering race is back"
+            )
+        finally:
+            await cleanup_test_user(client, auth_headers, ctx["user_id"])
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=ctx["model_config_id"],
+                provider_id=ctx["provider_id"],
+            )
+
+    # ------------------------------------------------------------------
+    # 2. Regen + terminate — the Plan agent's option (B) load-bearing test
+    # ------------------------------------------------------------------
+    async def test_terminate_during_regenerate_assigns_correct_variant_index(self, client, db, auth_headers):
+        """The whole point of the Plan agent's option (B refined) was
+        to make regen+terminate work — the regen-aware INSERT block
+        (sibling-max variant_index, regenerated metadata stamp,
+        IntegrityError retry) was lifted into the early-persist
+        callback rather than duplicated as an extracted helper. This
+        test exercises that lift end-to-end:
+
+        1. Send an initial user message, let the assistant complete
+           naturally → variant_index=0, stream_state=complete.
+        2. POST regenerate on that assistant message, terminate
+           concurrently → the early-persist callback fires INSIDE the
+           regen branch, computes variant_index from sibling-max
+           (==1), stamps regenerated=True + regenerated_from_message_id.
+        3. Assert the new variant landed with the correct lineage.
+        """
+        ctx = await self._setup(client, db, auth_headers)
+        try:
+            # 1. Send initial message — natural completion.
+            with stub_provider_stream(
+                anthropic_message_start_then_delta_fixture(
+                    input_tokens=4,
+                    output_tokens=6,
+                    text_content="original answer",
+                    delay_before_message_delta_s=0.0,
+                )
+            ):
+                await _send_message_to_completion(
+                    client,
+                    conv_id=ctx["conv_id"],
+                    user_headers=ctx["user_headers"],
+                    message_text="What is 2+2?",
+                )
+
+            # Locate the original assistant message via the messages list.
+            list_resp = await client.get(
+                f"/api/v1/chat/conversations/{ctx['conv_id']}/messages",
+                headers=ctx["user_headers"],
+            )
+            assert list_resp.status_code == 200
+            messages_payload = extract_data(list_resp)
+            # The list endpoint may use different ordering conventions;
+            # find the assistant row by role + variant_index==0.
+            assistant_rows = [m for m in messages_payload if m["role"] == "assistant"]
+            assert len(assistant_rows) == 1, f"expected 1 assistant row after natural completion, got {len(assistant_rows)}"
+            original_assistant_id = assistant_rows[0]["id"]
+            original_parent = assistant_rows[0].get("parent_message_id") or assistant_rows[0]["id"]
+            assert assistant_rows[0].get("variant_index") in (0, None)
+
+            # 2. Regenerate + terminate.
+            fixture_regen = anthropic_message_start_then_delta_fixture(
+                input_tokens=4,
+                output_tokens=99,
+                text_content="regen partial answer",
+                delay_before_message_delta_s=0.3,
+            )
+            with _EarlyPersistLogCapture() as log_capture, stub_provider_stream(fixture_regen):
+                stream_id, terminate_resp = await _capture_regen_stream_id_and_terminate(
+                    client,
+                    target_assistant_message_id=original_assistant_id,
+                    conv_id=ctx["conv_id"],
+                    user_headers=ctx["user_headers"],
+                )
+            assert stream_id is not None
+            assert terminate_resp is not None
+            assert terminate_resp.status_code == 202
+
+            # Load-bearing: the early-persist callback fired in REGEN
+            # mode. Pre-fix, the callback didn't run at all for the
+            # regen path — the Plan agent's option (B) lift is what
+            # this assertion proves.
+            assert len(log_capture.records) == 1
+            persist_record = log_capture.records[0]
+            assert getattr(persist_record, "regen", None) is True
+            # Sibling-max → 1 (one existing sibling at index 0).
+            assert getattr(persist_record, "variant_index", None) == 1
+
+            # 3. Verify the new variant landed in DB with the correct
+            # lineage. Two assistant rows total, one terminated.
+            await wait_for_message_persisted(
+                db, conversation_id=ctx["conv_id"], role="assistant", min_count=2, timeout_seconds=5.0
+            )
+            assistants = [m for m in await self._list_messages_chronological(db, ctx["conv_id"]) if m.role == "assistant"]
+            assert len(assistants) == 2, (
+                f"expected 2 assistant rows (original + regen variant), got {len(assistants)}"
+            )
+
+            # Find the regen variant.
+            regen_variant = next(
+                (m for m in assistants if (m.message_metadata or {}).get("stream_state") == "user_terminated"),
+                None,
+            )
+            original_row = next(
+                (m for m in assistants if (m.message_metadata or {}).get("stream_state") == "complete"),
+                None,
+            )
+            assert regen_variant is not None, "regen variant not persisted with user_terminated state"
+            assert original_row is not None
+
+            # Lineage assertions — the regen-aware INSERT block from
+            # `_finalize_variant_phase` is what we lifted, so these
+            # are the same invariants the legacy regen path enforced:
+            assert regen_variant.parent_message_id == original_parent
+            assert regen_variant.variant_index == 1
+            regen_meta = regen_variant.message_metadata or {}
+            assert regen_meta.get("regenerated") is True
+            assert regen_meta.get("regenerated_from_message_id") == original_assistant_id
+        finally:
+            await cleanup_test_user(client, auth_headers, ctx["user_id"])
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=ctx["model_config_id"],
+                provider_id=ctx["provider_id"],
+            )
+
+    # ------------------------------------------------------------------
+    # 3. Natural completion — no early-persist path taken
+    # ------------------------------------------------------------------
+    async def test_natural_completion_does_not_take_early_persist_path(self, client, db, auth_headers):
+        """Sanity / no-regression. A chat that completes naturally
+        (no terminate signal) MUST NOT trigger the early-persist
+        callback. The Message row is committed once, via the legacy
+        INSERT path in `_finalize_variant_phase`, with
+        ``stream_state="complete"``.
+
+        Failure mode this guards against: a future refactor that
+        accidentally invokes the early-persist callback on every
+        terminate-detection check, including the no-signal case. The
+        log-record assertion catches that regression before any
+        user-visible symptom.
+        """
+        ctx = await self._setup(client, db, auth_headers)
+        try:
+            with _EarlyPersistLogCapture() as log_capture, stub_provider_stream(
+                anthropic_message_start_then_delta_fixture(
+                    input_tokens=2,
+                    output_tokens=3,
+                    text_content="ok",
+                    delay_before_message_delta_s=0.0,
+                )
+            ):
+                await _send_message_to_completion(
+                    client,
+                    conv_id=ctx["conv_id"],
+                    user_headers=ctx["user_headers"],
+                    message_text="Quick test",
+                )
+
+            # Load-bearing — no early-persist record fired.
+            assert len(log_capture.records) == 0, (
+                f"early-persist callback fired for a natural-completion stream; "
+                f"got {len(log_capture.records)} record(s)"
+            )
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=ctx["conv_id"], role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+            assert (persisted.message_metadata or {}).get("stream_state") == "complete"
+            assert (persisted.message_metadata or {}).get("partial_usage_unavailable") is None
+        finally:
+            await cleanup_test_user(client, auth_headers, ctx["user_id"])
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=ctx["model_config_id"],
+                provider_id=ctx["provider_id"],
+            )
+
+
+if __name__ == "__main__":
+    ChatEarlyPersistIntegrationTest().run()

--- a/backend/src/tests/integ/test_chat_force_terminate_integration.py
+++ b/backend/src/tests/integ/test_chat_force_terminate_integration.py
@@ -150,6 +150,12 @@ async def _capture_stream_id_and_terminate(
         # ~10ms so the terminate POST lands well before finalize.
         deadline = asyncio.get_running_loop().time() + 5.0
         while True:
+            # Bail immediately if _consume_stream already resolved the
+            # future (e.g. set an exception on a non-200 response) so we
+            # don't keep the task alive until the 5s deadline — that
+            # delays the join in the finally block.
+            if stream_id_future.done():
+                return
             registry = getattr(_app.state, "in_flight_streams", {}) or {}
             # Filter by conversation_id so the poller doesn't grab a stream
             # from elsewhere (a browser tab open during dev smoke testing, a

--- a/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
+++ b/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
@@ -32,7 +32,6 @@ OpenAI Responses ``response.completed``.
 """
 
 import asyncio
-import logging
 import uuid
 from decimal import Decimal
 
@@ -52,17 +51,15 @@ from integ.helpers.stub_provider_stream import (
 from integ.helpers.wait_for_message import wait_for_message_persisted
 from integ.response_utils import extract_data
 from integ.test_chat_force_terminate_integration import _capture_stream_id_and_terminate
-from shu.core.config import get_settings_instance
 from shu.core.logging import get_logger
 from shu.models.llm_provider import LLMModel, LLMUsage
-from shu.services.chat_streaming import StreamLifecycle
 
 logger = get_logger(__name__)
 
 # Per-chunk default delay used inside the stub generator. The terminate
 # POST in `_capture_stream_id_and_terminate` polls the registry every
 # 5ms and fires HTTP POST ~50ms after the variant registers. Most chunks
-# in the per-protocol fixtures pause 0–300ms; the test-specific delays
+# in the per-protocol fixtures pause 0-300ms; the test-specific delays
 # are tuned so the terminate-fire window lands between the chunks
 # documented in each test's docstring.
 
@@ -236,7 +233,8 @@ async def _ensure_local_provider_type(db) -> None:
     )
     if existing.first():
         return
-    from datetime import UTC, datetime as _dt
+    from datetime import UTC
+    from datetime import datetime as _dt
     now = _dt.now(UTC)
     await db.execute(
         text(
@@ -673,7 +671,7 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                     if not shutdown_task.done():
                         try:
                             await asyncio.wait_for(shutdown_task, timeout=2.0)
-                        except asyncio.TimeoutError:
+                        except TimeoutError:
                             shutdown_task.cancel()
 
             assert stream_id is not None
@@ -884,8 +882,8 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         contract.
 
         Asserts the LLMUsage row's
-        ``total_cost = input_tokens × cost_per_input_unit
-                     + output_tokens × cost_per_output_unit``
+        ``total_cost = input_tokens * cost_per_input_unit
+                     + output_tokens * cost_per_output_unit``
         and is non-zero. Pre-SHU-803 (or pre-fix MODEL_PRICING lookup),
         this row's ``total_cost`` was zero — the abuse vector.
         """

--- a/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
+++ b/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
@@ -88,10 +88,10 @@ async def _create_provider_model_conversation(
     model_name: str | None = None,
     cost_per_input_unit: Decimal | None = None,
     cost_per_output_unit: Decimal | None = None,
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, str]:
     """Provision the four DB rows each test needs: LLMProvider, LLMModel,
     ModelConfiguration, Conversation. Returns
-    ``(provider_id, model_id, conversation_id)``.
+    ``(provider_id, model_id, model_config_id, conversation_id)``.
 
     The ``cost_per_input_unit`` / ``cost_per_output_unit`` arguments are
     written directly onto the model row AFTER creation so the
@@ -159,7 +159,54 @@ async def _create_provider_model_conversation(
     assert conv_response.status_code == 200, conv_response.text
     conversation_id = extract_data(conv_response)["id"]
 
-    return provider_id, model_id, conversation_id
+    return provider_id, model_id, model_config_id, conversation_id
+
+
+async def _cleanup_provider_resources(
+    client,
+    admin_headers: dict,
+    *,
+    model_config_id: str | None = None,
+    provider_id: str | None = None,
+) -> None:
+    """SHU-803: tear down the provider + model_configuration rows a test
+    created so the suite leaves the DB clean and re-runs don't pile up
+    state.
+
+    Order matters: the conversation rows reference ``model_config_id``,
+    so this MUST run AFTER ``cleanup_test_user`` (which cascades-deletes
+    the user's conversations). The model rows are cascaded by the
+    provider delete, so we only delete config + provider explicitly.
+
+    Best-effort — a 404 means a prior test already tore the row down,
+    a 500 means something we can't recover from in test cleanup. Both
+    log at INFO so a failure here doesn't mask the actual test result.
+    """
+    if model_config_id:
+        try:
+            response = await client.delete(
+                f"/api/v1/model-configurations/{model_config_id}", headers=admin_headers
+            )
+            if response.status_code not in (200, 204, 404):
+                logger.warning(
+                    "Cleanup: model_configuration delete returned %d: %s",
+                    response.status_code,
+                    response.text,
+                )
+        except Exception as exc:
+            logger.warning("Cleanup: model_configuration delete raised: %s", exc)
+
+    if provider_id:
+        try:
+            response = await client.delete(f"/api/v1/llm/providers/{provider_id}", headers=admin_headers)
+            if response.status_code not in (200, 204, 404):
+                logger.warning(
+                    "Cleanup: provider delete returned %d: %s",
+                    response.status_code,
+                    response.text,
+                )
+        except Exception as exc:
+            logger.warning("Cleanup: provider delete raised: %s", exc)
 
 
 async def _seed_model_pricing(db, model_id: str, *, cost_per_input_unit: Decimal, cost_per_output_unit: Decimal) -> None:
@@ -264,12 +311,23 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         model_name: str | None = None,
         cost_per_input_unit: Decimal | None = None,
         cost_per_output_unit: Decimal | None = None,
-    ) -> tuple[dict, str, str, str, str]:
-        """Returns ``(user_headers, user_id, provider_id, model_id, conversation_id)``."""
+    ) -> tuple[dict, str, str, str, str, str]:
+        """Returns ``(user_headers, user_id, provider_id, model_id, model_config_id, conversation_id)``.
+
+        ``model_config_id`` is returned so the caller can pass it to
+        ``_cleanup_provider_resources`` in its ``finally`` block — that
+        cleanup is what keeps the suite re-runnable without name
+        collisions on the model_configurations.name UNIQUE constraint.
+        """
         await _ensure_local_provider_type(db)
         admin_headers = auth_headers
         user_headers, user_id = await create_active_user_with_id(client, admin_headers)
-        provider_id, model_id, conversation_id = await _create_provider_model_conversation(
+        (
+            provider_id,
+            model_id,
+            model_config_id,
+            conversation_id,
+        ) = await _create_provider_model_conversation(
             client,
             admin_headers,
             user_headers,
@@ -284,7 +342,7 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                 cost_per_input_unit=cost_per_input_unit or Decimal("0"),
                 cost_per_output_unit=cost_per_output_unit or Decimal("0"),
             )
-        return user_headers, user_id, provider_id, model_id, conversation_id
+        return user_headers, user_id, provider_id, model_id, model_config_id, conversation_id
 
     # ------------------------------------------------------------------
     # 1. Anthropic — happy path (message_start + delta both land)
@@ -298,7 +356,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         message_start nested-usage capture work — pre-fix only delta
         was caught.
         """
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client, db, auth_headers, provider_type="anthropic", provider_name="shu803-anthropic"
         )
         try:
@@ -335,7 +400,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                 f"output_tokens should be captured from message_delta; got {usage.output_tokens}"
             )
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 2. Anthropic — pre-delta (input_tokens ONLY)
@@ -349,7 +424,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         post-fix the LLMUsage row carries input_tokens > 0 with
         output_tokens = 0.
         """
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client, db, auth_headers, provider_type="anthropic", provider_name="shu803-anthropic-predelta"
         )
         try:
@@ -379,7 +461,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                 f"got {usage.output_tokens}"
             )
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 3. Gemini — cumulative usageMetadata
@@ -392,7 +484,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         protocol level (usage is incremental), but the drain path
         still runs and the audit fields are recorded.
         """
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client, db, auth_headers, provider_type="gemini", provider_name="shu803-gemini"
         )
         try:
@@ -421,7 +520,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
             assert usage.output_tokens > 0
 
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 4. OpenAI Chat Completions — drain catches end-of-stream usage
@@ -440,7 +549,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         at terminate (persisted ``Message.content`` shorter than the
         full fixture content).
         """
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client, db, auth_headers, provider_type="generic_completions", provider_name="shu803-completions"
         )
         try:
@@ -481,7 +597,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                 "drain spawns cancel_task concurrently — should be attempted even when adapter is no-op"
             )
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 5. Drain shutdown escape valve
@@ -497,7 +623,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         from shu.main import app as _app
         from shu.services.chat_streaming import signal_shutdown_to_in_flight_streams
 
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client, db, auth_headers, provider_type="generic_completions", provider_name="shu803-shutdown"
         )
         try:
@@ -566,7 +699,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                 f"{request_metadata.get('drain_outcome')!r}"
             )
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 6. OpenAI Responses — drain catches response.completed
@@ -579,7 +722,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         parallel via ``asyncio.gather`` and captures the eventual
         ``response.completed`` chunk's usage.
         """
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client, db, auth_headers, provider_type="openai", provider_name="shu803-responses"
         )
         try:
@@ -616,7 +766,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
             assert request_metadata.get("cancel_attempted") is True
             assert request_metadata.get("cancel_succeeded") is True
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 7. Responses cancel endpoint URL verification + negative
@@ -632,7 +792,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         end-of-stream usage so the row's token counts are non-zero
         (the value-add of running cancel+drain concurrently).
         """
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client, db, auth_headers, provider_type="openai", provider_name="shu803-cancel-url"
         )
         try:
@@ -690,7 +857,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                 "500 from cancel endpoint must surface as cancel_succeeded=False"
             )
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 8. OpenRouter Gemma-4 — DB-rate fallback cost (LOAD BEARING)
@@ -716,7 +893,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         rate_in = Decimal("0.00000018")  # 0.18 / 1e6
         rate_out = Decimal("0.00000050")  # 0.50 / 1e6
 
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client,
             db,
             auth_headers,
@@ -769,7 +953,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
                 "fallback resolves rates via AC9d normalization."
             )
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
     # ------------------------------------------------------------------
     # 9. OpenRouter — provider-authoritative wire cost
@@ -788,7 +982,14 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
         # computation so the test can prove which path was taken.
         wire_cost = Decimal("0.00012345")
 
-        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+        (
+            user_headers,
+            user_id,
+            provider_id,
+            model_id,
+            model_config_id,
+            conv_id,
+        ) = await self._setup_user_and_provider(
             client,
             db,
             auth_headers,
@@ -831,7 +1032,17 @@ class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
             assert usage.input_cost == Decimal("0")
             assert usage.output_cost == Decimal("0")
         finally:
+            # SHU-803: user cleanup MUST run before provider/config
+            # cleanup — conversations FK reference the model_config,
+            # and cleanup_test_user cascades-deletes the user's
+            # conversations.
             await cleanup_test_user(client, auth_headers, user_id)
+            await _cleanup_provider_resources(
+                client,
+                auth_headers,
+                model_config_id=model_config_id,
+                provider_id=provider_id,
+            )
 
 
 if __name__ == "__main__":

--- a/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
+++ b/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
@@ -1,0 +1,838 @@
+"""SHU-803 AC10: real-provider partial-usage capture under user-terminate.
+
+The existing :mod:`test_chat_force_terminate_integration` suite drives the
+local test provider, which never emits usage events — it only exercises
+the ``partial_usage_unavailable=True`` honest-flag branch from
+SHU-802. This suite covers the real-provider paths and the drain-after-
+terminate behavior AC9c introduces, plus the OpenRouter pricing
+normalization (AC9d) and the Responses cancel endpoint (AC9e).
+
+The load-bearing test is
+:meth:`test_terminate_openrouter_gemma4_cost_derived_from_model_pricing`
+— it proves the billing-evasion abuse vector close-out at the full
+HTTP → consumer-loop → drain → finalize → DB layer. The abuse vector:
+a user crafts a prompt to get a useful answer followed by tens of
+thousands of filler tokens, terminates mid-stream after the useful part,
+and pre-SHU-803 ends up with ``input_tokens=0, output_tokens=0,
+total_cost=0`` because OpenAI Chat Completions and OpenRouter emit usage
+only as the final chunk. AC9c (drain) catches the eventual usage chunk;
+AC9d (pricing normalization) ensures the DB-rate fallback resolves for
+OpenRouter slugs; the test asserts the LLMUsage row carries a non-zero
+``total_cost``.
+
+Implementation note: rather than registering test-only ``provider_type``
+values with stub adapters, this suite patches
+:meth:`UnifiedLLMClient._stream_response` to yield deterministic
+chunks (see :mod:`integ.helpers.stub_provider_stream`). Each chunk is
+fed to the REAL adapter's ``handle_provider_event`` so the capture
+logic is exercised against actual provider chunk shapes — anthropic
+``message_start`` / ``message_delta``, gemini cumulative
+``usageMetadata``, OpenAI Chat Completions end-only ``usage``,
+OpenAI Responses ``response.completed``.
+"""
+
+import asyncio
+import logging
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import select, text, update
+
+from integ.base_integration_test import BaseIntegrationTestSuite
+from integ.helpers.auth import cleanup_framework_test_admin, cleanup_test_user, create_active_user_with_id
+from integ.helpers.stub_provider_stream import (
+    anthropic_message_start_then_delta_fixture,
+    anthropic_pre_delta_fixture,
+    gemini_cumulative_usage_fixture,
+    openai_completions_end_usage_fixture,
+    openai_responses_response_completed_fixture,
+    stub_provider_stream,
+    stub_responses_cancel_transport,
+)
+from integ.helpers.wait_for_message import wait_for_message_persisted
+from integ.response_utils import extract_data
+from integ.test_chat_force_terminate_integration import _capture_stream_id_and_terminate
+from shu.core.config import get_settings_instance
+from shu.core.logging import get_logger
+from shu.models.llm_provider import LLMModel, LLMUsage
+from shu.services.chat_streaming import StreamLifecycle
+
+logger = get_logger(__name__)
+
+# Per-chunk default delay used inside the stub generator. The terminate
+# POST in `_capture_stream_id_and_terminate` polls the registry every
+# 5ms and fires HTTP POST ~50ms after the variant registers. Most chunks
+# in the per-protocol fixtures pause 0–300ms; the test-specific delays
+# are tuned so the terminate-fire window lands between the chunks
+# documented in each test's docstring.
+
+# Default model_name to use when the test doesn't care about pricing
+# resolution (most tests). For the OpenRouter cost tests we use the
+# real slug shape so AC9d normalization resolves to the bare-name
+# pricing entry.
+DEFAULT_MODEL_NAME_BY_PROVIDER = {
+    "anthropic": "claude-shu803-stub",
+    "gemini": "models/gemini-shu803-stub",
+    "generic_completions": "shu803-stub-completions",
+    "openai": "shu803-stub-responses",
+}
+
+
+async def _create_provider_model_conversation(
+    client,
+    admin_headers: dict,
+    user_headers: dict,
+    *,
+    provider_type: str,
+    provider_name: str,
+    model_name: str | None = None,
+    cost_per_input_unit: Decimal | None = None,
+    cost_per_output_unit: Decimal | None = None,
+) -> tuple[str, str, str]:
+    """Provision the four DB rows each test needs: LLMProvider, LLMModel,
+    ModelConfiguration, Conversation. Returns
+    ``(provider_id, model_id, conversation_id)``.
+
+    The ``cost_per_input_unit`` / ``cost_per_output_unit`` arguments are
+    written directly onto the model row AFTER creation so the
+    DB-rate fallback path in ``usage_recording.py`` resolves to a
+    non-zero cost. Skipped when None — the OpenRouter cost tests use
+    these; other tests don't care about the cost column.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    model_name = model_name or DEFAULT_MODEL_NAME_BY_PROVIDER[provider_type]
+
+    provider_payload = {
+        "name": f"{provider_name}-{suffix}",
+        "provider_type": provider_type,
+        "api_endpoint": "https://example-stub.invalid/v1",
+        "is_active": True,
+    }
+    provider_response = await client.post("/api/v1/llm/providers", json=provider_payload, headers=admin_headers)
+    assert provider_response.status_code == 201, provider_response.text
+    provider_id = extract_data(provider_response)["id"]
+
+    model_payload = {
+        "model_name": model_name,
+        "display_name": f"SHU-803 Stub Model ({provider_type}) {suffix}",
+        "description": "SHU-803 AC10 stub — synthetic chunks via _stream_response patch",
+        "context_window": 8192,
+        "max_tokens": 4096,
+        "supports_streaming": True,
+        "supports_functions": False,
+        "supports_vision": False,
+    }
+    model_response = await client.post(
+        f"/api/v1/llm/providers/{provider_id}/models", json=model_payload, headers=admin_headers
+    )
+    assert model_response.status_code == 200, model_response.text
+    model_id = extract_data(model_response)["id"]
+
+    config_payload = {
+        # SHU-803: suffix the config name with the same per-test UUID so
+        # tests run cleanly even when prior runs leaked rows. Without
+        # the suffix two same-provider_type tests (e.g. both
+        # generic_completions) collide on the name UNIQUE constraint.
+        "name": f"SHU-803 Stub Config ({provider_type}) {suffix}",
+        "description": "SHU-803 AC10",
+        "is_active": True,
+        "created_by": "test-user",
+        "knowledge_base_ids": [],
+        "llm_provider_id": provider_id,
+        "model_name": model_name,
+        # SHU-803: must be True so the chat streaming layer takes the
+        # streaming branch in chat_completion and goes through the
+        # patched _stream_response. Without this, allowed_to_stream
+        # evaluates False and chat_completion does a real HTTP POST
+        # against the stub api_endpoint → DNS failure.
+        "functionalities": {"supports_streaming": True},
+    }
+    config_response = await client.post("/api/v1/model-configurations", json=config_payload, headers=admin_headers)
+    assert config_response.status_code == 201, config_response.text
+    model_config_id = extract_data(config_response)["id"]
+
+    conv_response = await client.post(
+        "/api/v1/chat/conversations",
+        json={"title": f"SHU-803 Stub Test ({provider_type})", "model_configuration_id": model_config_id},
+        headers=user_headers,
+    )
+    assert conv_response.status_code == 200, conv_response.text
+    conversation_id = extract_data(conv_response)["id"]
+
+    return provider_id, model_id, conversation_id
+
+
+async def _seed_model_pricing(db, model_id: str, *, cost_per_input_unit: Decimal, cost_per_output_unit: Decimal) -> None:
+    """Write per-unit pricing onto an LLMModel row so the DB-rate fallback
+    path in ``usage_recording.py`` produces non-zero costs. The OpenRouter
+    cost tests use this to simulate ``sync_pricing_to_db`` having
+    populated rates via the AC9d normalized-fallback resolution.
+    """
+    await db.execute(
+        update(LLMModel)
+        .where(LLMModel.id == model_id)
+        .values(
+            cost_per_input_unit=cost_per_input_unit,
+            cost_per_output_unit=cost_per_output_unit,
+        )
+    )
+    await db.commit()
+
+
+async def _ensure_local_provider_type(db) -> None:
+    """SHU-803 tests don't use ``local`` directly, but they may run
+    before/alongside other suites that do. Mirror the
+    ``baseline/_setup.py`` bootstrap so a fresh DB has the row.
+    """
+    existing = await db.execute(
+        text("SELECT 1 FROM llm_provider_type_definitions WHERE key = :k"), {"k": "local"}
+    )
+    if existing.first():
+        return
+    from datetime import UTC, datetime as _dt
+    now = _dt.now(UTC)
+    await db.execute(
+        text(
+            "INSERT INTO llm_provider_type_definitions "
+            "(id, key, display_name, provider_adapter_name, is_active, created_at, updated_at) "
+            "VALUES (:id, :key, :display_name, :adapter, :is_active, :created_at, :updated_at)"
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "key": "local",
+            "display_name": "Local (test)",
+            "adapter": "local",
+            "is_active": True,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+    await db.commit()
+
+
+async def _latest_llm_usage_for_model(db, model_id: str) -> LLMUsage | None:
+    """Fetch the most-recent LLMUsage row for a given model_id. Used to
+    assert on the row finalize wrote after the terminate signal landed.
+    """
+    result = await db.execute(
+        select(LLMUsage).where(LLMUsage.model_id == model_id).order_by(LLMUsage.created_at.desc()).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):
+    """SHU-803 AC10 — per-protocol terminate integration coverage."""
+
+    def get_suite_name(self) -> str:
+        return "Chat Force Terminate Real Usage Integration"
+
+    def get_suite_description(self) -> str:
+        return (
+            "SHU-803 AC10: validates real-provider partial-usage capture "
+            "under user-terminate. Covers Anthropic message_start nested-"
+            "usage fix (AC9b), Gemini cumulative usageMetadata, OpenAI "
+            "Chat Completions / Responses drain (AC9c), Responses cancel "
+            "endpoint (AC9e), OpenRouter pricing normalization (AC9d), "
+            "and the shutdown escape valve."
+        )
+
+    def get_test_functions(self):
+        return [
+            self.test_terminate_anthropic_captures_message_start_and_delta_usage,
+            self.test_terminate_anthropic_pre_delta_captures_input_tokens_only,
+            self.test_terminate_gemini_captures_per_chunk_usage,
+            self.test_terminate_completions_drains_for_end_usage,
+            self.test_terminate_completions_drain_propagates_shutdown,
+            self.test_terminate_responses_drains_for_response_completed_usage,
+            self.test_terminate_responses_cancel_called_via_mock_transport,
+            self.test_terminate_openrouter_gemma4_cost_derived_from_model_pricing,
+            self.test_terminate_openrouter_authoritative_cost_via_wire,
+            self.test_zz_teardown_test_admin,
+        ]
+
+    async def test_zz_teardown_test_admin(self, client, db, auth_headers):
+        await cleanup_framework_test_admin(db)
+
+    async def _setup_user_and_provider(
+        self,
+        client,
+        db,
+        auth_headers,
+        *,
+        provider_type: str,
+        provider_name: str,
+        model_name: str | None = None,
+        cost_per_input_unit: Decimal | None = None,
+        cost_per_output_unit: Decimal | None = None,
+    ) -> tuple[dict, str, str, str, str]:
+        """Returns ``(user_headers, user_id, provider_id, model_id, conversation_id)``."""
+        await _ensure_local_provider_type(db)
+        admin_headers = auth_headers
+        user_headers, user_id = await create_active_user_with_id(client, admin_headers)
+        provider_id, model_id, conversation_id = await _create_provider_model_conversation(
+            client,
+            admin_headers,
+            user_headers,
+            provider_type=provider_type,
+            provider_name=provider_name,
+            model_name=model_name,
+        )
+        if cost_per_input_unit is not None or cost_per_output_unit is not None:
+            await _seed_model_pricing(
+                db,
+                model_id,
+                cost_per_input_unit=cost_per_input_unit or Decimal("0"),
+                cost_per_output_unit=cost_per_output_unit or Decimal("0"),
+            )
+        return user_headers, user_id, provider_id, model_id, conversation_id
+
+    # ------------------------------------------------------------------
+    # 1. Anthropic — happy path (message_start + delta both land)
+    # ------------------------------------------------------------------
+    async def test_terminate_anthropic_captures_message_start_and_delta_usage(self, client, db, auth_headers):
+        """Anthropic emits ``input_tokens`` on ``message_start`` (nested
+        under ``message.usage``) and ``output_tokens`` on each
+        ``message_delta`` (top-level ``usage``). When terminate fires
+        AFTER the first message_delta, both should land on the LLMUsage
+        row. The SHU-803 anthropic_adapter fix (AC9b) makes the
+        message_start nested-usage capture work — pre-fix only delta
+        was caught.
+        """
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client, db, auth_headers, provider_type="anthropic", provider_name="shu803-anthropic"
+        )
+        try:
+            fixture = anthropic_message_start_then_delta_fixture(
+                input_tokens=42,
+                output_tokens=17,
+                text_content="The answer is 42.",
+                delay_before_message_delta_s=0.05,
+            )
+            with stub_provider_stream(fixture):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+            assert (persisted.message_metadata or {}).get("stream_state") == "user_terminated"
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None, "LLMUsage row missing for Anthropic terminate test"
+            assert usage.success is False
+            assert usage.error_message == "Stream interrupted: user_terminated"
+            # Both axes captured — the load-bearing assertion for the
+            # SHU-803 Anthropic fix on the happy-path branch.
+            assert usage.input_tokens > 0, (
+                f"input_tokens should be captured from message_start; got {usage.input_tokens}"
+            )
+            assert usage.output_tokens > 0, (
+                f"output_tokens should be captured from message_delta; got {usage.output_tokens}"
+            )
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 2. Anthropic — pre-delta (input_tokens ONLY)
+    # ------------------------------------------------------------------
+    async def test_terminate_anthropic_pre_delta_captures_input_tokens_only(self, client, db, auth_headers):
+        """Load-bearing test for the SHU-803 anthropic_adapter fix
+        (AC9b). The fixture yields ``message_start`` (with nested
+        ``input_tokens``), then a 400ms pause where the terminate POST
+        lands, then content_block_delta. Terminate fires BEFORE any
+        ``message_delta`` — pre-fix this lost input_tokens entirely;
+        post-fix the LLMUsage row carries input_tokens > 0 with
+        output_tokens = 0.
+        """
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client, db, auth_headers, provider_type="anthropic", provider_name="shu803-anthropic-predelta"
+        )
+        try:
+            fixture = anthropic_pre_delta_fixture(input_tokens=250, delay_before_first_content_s=0.4)
+            with stub_provider_stream(fixture):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+            assert (persisted.message_metadata or {}).get("stream_state") == "user_terminated"
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            assert usage.success is False
+            assert usage.input_tokens > 0, (
+                "SHU-803 AC9b: input_tokens from message_start must survive "
+                "a terminate before any message_delta lands. Pre-fix this was 0."
+            )
+            assert usage.output_tokens == 0, (
+                f"No message_delta landed before terminate; output_tokens should be 0, "
+                f"got {usage.output_tokens}"
+            )
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 3. Gemini — cumulative usageMetadata
+    # ------------------------------------------------------------------
+    async def test_terminate_gemini_captures_per_chunk_usage(self, client, db, auth_headers):
+        """Gemini emits ``usageMetadata`` cumulative-to-date on every
+        streaming chunk. The drain-exit snapshot reflects the LAST-seen
+        cumulative counts — equivalent to "what the provider had billed
+        up to the moment terminate landed." No drain needed at the
+        protocol level (usage is incremental), but the drain path
+        still runs and the audit fields are recorded.
+        """
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client, db, auth_headers, provider_type="gemini", provider_name="shu803-gemini"
+        )
+        try:
+            fixture = gemini_cumulative_usage_fixture(
+                final_prompt_tokens=33,
+                final_candidates_tokens=8,
+                text_content="ok",
+                delay_before_final_chunk_s=0.3,
+            )
+            with stub_provider_stream(fixture):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            assert usage.success is False
+            assert usage.input_tokens > 0
+            assert usage.output_tokens > 0
+
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 4. OpenAI Chat Completions — drain catches end-of-stream usage
+    # ------------------------------------------------------------------
+    async def test_terminate_completions_drains_for_end_usage(self, client, db, auth_headers):
+        """OpenAI Chat Completions emits ``usage`` ONLY in the final
+        chunk before ``[DONE]`` when ``stream_options.include_usage=true``.
+        Pre-SHU-803 terminate broke the loop before that chunk and
+        the LLMUsage row recorded zero tokens (the billing-evasion
+        abuse vector). AC9c drain silently consumes the upstream until
+        the usage chunk lands, then finalize records it.
+
+        Asserts: input_tokens / output_tokens > 0 (drain captured the
+        end-of-stream usage), drain_audit reflects ``drain_outcome``
+        of ``done`` or ``final_event``, content_accumulator was frozen
+        at terminate (persisted ``Message.content`` shorter than the
+        full fixture content).
+        """
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client, db, auth_headers, provider_type="generic_completions", provider_name="shu803-completions"
+        )
+        try:
+            fixture = openai_completions_end_usage_fixture(
+                prompt_tokens=120,
+                completion_tokens=55,
+                text_content="Hello, this is a streamed response from the stub.",
+                delay_before_usage_chunk_s=0.3,
+            )
+            with stub_provider_stream(fixture):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+            assert (persisted.message_metadata or {}).get("stream_state") == "user_terminated"
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            assert usage.success is False
+            # The load-bearing assertions for AC9c drain:
+            assert usage.input_tokens > 0, (
+                "SHU-803 AC9c: drain must consume upstream until the end-of-stream "
+                "usage chunk lands. Pre-fix input_tokens was 0 on terminate."
+            )
+            assert usage.output_tokens > 0
+            # Drain audit recorded in request_metadata (AC9g).
+            request_metadata = usage.request_metadata or {}
+            assert request_metadata.get("drain_outcome") in {"done", "final_event"}, (
+                f"Expected clean drain exit; got drain_outcome={request_metadata.get('drain_outcome')!r}"
+            )
+            assert request_metadata.get("cancel_attempted") is True, (
+                "drain spawns cancel_task concurrently — should be attempted even when adapter is no-op"
+            )
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 5. Drain shutdown escape valve
+    # ------------------------------------------------------------------
+    async def test_terminate_completions_drain_propagates_shutdown(self, client, db, auth_headers):
+        """SHU-803 R7 / AC9c escape valve: drain in progress for a
+        user_terminated stream, then SIGTERM fires. The drain loop must
+        observe ``lifecycle.shutdown_signaled`` between events and exit
+        as ``drain_outcome=shutdown_aborted``. Without the escape valve,
+        drain would only stop via cancellation propagation at the
+        lifespan-drain timeout, bypassing the shielded finalize.
+        """
+        from shu.main import app as _app
+        from shu.services.chat_streaming import signal_shutdown_to_in_flight_streams
+
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client, db, auth_headers, provider_type="generic_completions", provider_name="shu803-shutdown"
+        )
+        try:
+            # Slow drain — the usage chunk lands far enough in the future
+            # that we can fire shutdown DURING drain.
+            fixture = openai_completions_end_usage_fixture(
+                prompt_tokens=88,
+                completion_tokens=44,
+                delay_before_usage_chunk_s=2.0,
+            )
+
+            async def _fire_shutdown_during_drain() -> None:
+                # Wait until the variant has registered AND terminate
+                # has fired (registry contains the lifecycle with
+                # reason="user_terminated"); then fire shutdown.
+                deadline = asyncio.get_running_loop().time() + 5.0
+                while True:
+                    registry = getattr(_app.state, "in_flight_streams", {}) or {}
+                    fired_lifecycles = [
+                        lc for lc in registry.values() if lc.reason == "user_terminated"
+                    ]
+                    if fired_lifecycles:
+                        # Allow drain to spin up briefly so the
+                        # between-events check is the one that observes
+                        # shutdown_signaled (not the entry check).
+                        await asyncio.sleep(0.1)
+                        signal_shutdown_to_in_flight_streams(registry)
+                        return
+                    if asyncio.get_running_loop().time() >= deadline:
+                        return
+                    await asyncio.sleep(0.01)
+
+            with stub_provider_stream(fixture):
+                shutdown_task = asyncio.create_task(_fire_shutdown_during_drain())
+                try:
+                    stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                        client, conv_id=conv_id, user_headers=user_headers
+                    )
+                finally:
+                    if not shutdown_task.done():
+                        try:
+                            await asyncio.wait_for(shutdown_task, timeout=2.0)
+                        except asyncio.TimeoutError:
+                            shutdown_task.cancel()
+
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=8.0
+            )
+            assert persisted is not None
+            # The stream was user-terminated; shutdown layered on top.
+            # ``reason`` stays user_terminated (first-writer-wins at
+            # tier 2) so the audit trail reflects user intent.
+            metadata = persisted.message_metadata or {}
+            assert metadata.get("stream_state") in {"user_terminated", "shutdown"}
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            assert usage.success is False
+            # The escape valve fired: drain exited as shutdown_aborted.
+            request_metadata = usage.request_metadata or {}
+            assert request_metadata.get("drain_outcome") == "shutdown_aborted", (
+                f"Expected drain_outcome=shutdown_aborted (escape valve); got "
+                f"{request_metadata.get('drain_outcome')!r}"
+            )
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 6. OpenAI Responses — drain catches response.completed
+    # ------------------------------------------------------------------
+    async def test_terminate_responses_drains_for_response_completed_usage(self, client, db, auth_headers):
+        """OpenAI Responses API emits usage ONLY on ``response.completed``
+        — same end-only pattern as Chat Completions but with a real
+        cancel endpoint to stop server-side billing (AC9e). Cancel is
+        mocked at the transport layer (200 OK); drain still runs in
+        parallel via ``asyncio.gather`` and captures the eventual
+        ``response.completed`` chunk's usage.
+        """
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client, db, auth_headers, provider_type="openai", provider_name="shu803-responses"
+        )
+        try:
+            fixture = openai_responses_response_completed_fixture(
+                input_tokens=200,
+                output_tokens=50,
+                text_content="Hi from Responses stub.",
+                delay_before_completed_s=0.3,
+            )
+
+            def cancel_handler(_request):
+                import httpx
+                return httpx.Response(200, json={"cancelled": True})
+
+            with stub_provider_stream(fixture), stub_responses_cancel_transport(cancel_handler):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+            assert (persisted.message_metadata or {}).get("stream_state") == "user_terminated"
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            assert usage.input_tokens > 0
+            assert usage.output_tokens > 0
+            request_metadata = usage.request_metadata or {}
+            # cancel was attempted; succeeded against the mock transport.
+            assert request_metadata.get("cancel_attempted") is True
+            assert request_metadata.get("cancel_succeeded") is True
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 7. Responses cancel endpoint URL verification + negative
+    # ------------------------------------------------------------------
+    async def test_terminate_responses_cancel_called_via_mock_transport(self, client, db, auth_headers):
+        """SHU-803 AC9e: the Responses cancel endpoint POST URL must end
+        in ``/responses/{response_id}/cancel`` and carry the adapter's
+        auth headers. This test intercepts the cancel POST via
+        httpx.MockTransport and asserts the URL.
+
+        Negative variant: with a 500 response, ``cancel_succeeded`` lands
+        as False on the LLMUsage row but drain still captures the
+        end-of-stream usage so the row's token counts are non-zero
+        (the value-add of running cancel+drain concurrently).
+        """
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client, db, auth_headers, provider_type="openai", provider_name="shu803-cancel-url"
+        )
+        try:
+            captured_requests = []
+
+            def cancel_handler(request):
+                import httpx
+                captured_requests.append(str(request.url))
+                # Return 500 — exercises the AC9j negative path: cancel
+                # fails but drain catches usage anyway.
+                return httpx.Response(500, json={"error": "simulated"})
+
+            fixture = openai_responses_response_completed_fixture(
+                input_tokens=75,
+                output_tokens=25,
+                response_id="resp_url_check",
+                delay_before_completed_s=0.3,
+            )
+
+            logger.info(
+                "=== EXPECTED TEST OUTPUT: ResponsesAdapter.cancel will log INFO/WARN "
+                "for the simulated 500 from the MockTransport ==="
+            )
+
+            with stub_provider_stream(fixture), stub_responses_cancel_transport(cancel_handler):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            # The cancel transport must have been hit at least once and
+            # the URL must end in /responses/{id}/cancel.
+            assert captured_requests, "cancel POST was never sent to the mock transport"
+            matching_urls = [url for url in captured_requests if url.endswith("/responses/resp_url_check/cancel")]
+            assert matching_urls, (
+                f"Expected cancel POST URL ending in /responses/resp_url_check/cancel; "
+                f"got {captured_requests!r}"
+            )
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            # Drain still captured usage despite the cancel 500 — that's
+            # the value-add of running cancel+drain concurrently.
+            assert usage.input_tokens > 0
+            assert usage.output_tokens > 0
+            request_metadata = usage.request_metadata or {}
+            assert request_metadata.get("cancel_attempted") is True
+            assert request_metadata.get("cancel_succeeded") is False, (
+                "500 from cancel endpoint must surface as cancel_succeeded=False"
+            )
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 8. OpenRouter Gemma-4 — DB-rate fallback cost (LOAD BEARING)
+    # ------------------------------------------------------------------
+    async def test_terminate_openrouter_gemma4_cost_derived_from_model_pricing(self, client, db, auth_headers):
+        """**The load-bearing AC10 test for the billing-evasion close-out.**
+
+        Stub OpenRouter-shaped provider with model_name
+        ``google/gemma-4-31b-it:nitro``. DB rates are seeded via the
+        AC9d normalized-fallback path (here simulated by direct DB
+        write; in production ``sync_pricing_to_db`` does it on startup).
+        The end-of-stream usage chunk does NOT carry ``usage.cost`` —
+        forcing the DB-rate fallback in ``usage_recording.py``'s cost
+        contract.
+
+        Asserts the LLMUsage row's
+        ``total_cost = input_tokens × cost_per_input_unit
+                     + output_tokens × cost_per_output_unit``
+        and is non-zero. Pre-SHU-803 (or pre-fix MODEL_PRICING lookup),
+        this row's ``total_cost`` was zero — the abuse vector.
+        """
+        # Per-token rates (Gemma-4-31B real rates: $0.18/Mtok in, $0.50/Mtok out).
+        rate_in = Decimal("0.00000018")  # 0.18 / 1e6
+        rate_out = Decimal("0.00000050")  # 0.50 / 1e6
+
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client,
+            db,
+            auth_headers,
+            provider_type="generic_completions",
+            provider_name="shu803-openrouter-gemma",
+            model_name="google/gemma-4-31b-it:nitro",
+            cost_per_input_unit=rate_in,
+            cost_per_output_unit=rate_out,
+        )
+        try:
+            # Realistic token counts for a partial Gemma-4 stream.
+            input_tokens = 500
+            output_tokens = 250
+            fixture = openai_completions_end_usage_fixture(
+                prompt_tokens=input_tokens,
+                completion_tokens=output_tokens,
+                text_content="Useful answer; then 50k words of filler the user never read.",
+                wire_cost=None,  # CRITICAL: no wire cost → DB-rate fallback path.
+                delay_before_usage_chunk_s=0.3,
+            )
+            with stub_provider_stream(fixture):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            assert usage.success is False
+            assert usage.input_tokens == input_tokens, (
+                f"Drain must have captured the full end-of-stream usage chunk; "
+                f"expected input_tokens={input_tokens}, got {usage.input_tokens}"
+            )
+            assert usage.output_tokens == output_tokens
+            # **The billing-evasion close-out assertion.** total_cost must
+            # be the DB-rate fallback computation, non-zero.
+            expected_total = (Decimal(input_tokens) * rate_in) + (Decimal(output_tokens) * rate_out)
+            assert usage.total_cost == expected_total, (
+                f"SHU-803 abuse-vector close-out: total_cost must equal the DB-rate "
+                f"fallback computation. Expected {expected_total}, got {usage.total_cost}"
+            )
+            assert usage.total_cost > Decimal("0"), (
+                "Pre-fix this was 0 (the abuse vector). Post-fix the DB-rate "
+                "fallback resolves rates via AC9d normalization."
+            )
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+    # ------------------------------------------------------------------
+    # 9. OpenRouter — provider-authoritative wire cost
+    # ------------------------------------------------------------------
+    async def test_terminate_openrouter_authoritative_cost_via_wire(self, client, db, auth_headers):
+        """When the OpenRouter stream emits ``usage.cost`` on the wire,
+        the cost contract in ``usage_recording.py`` records it verbatim
+        (provider-authoritative path) and skips the DB-rate fallback.
+        Drain still captures the token counts (so the row's
+        input_tokens / output_tokens are accurate); cost comes from the
+        wire.
+        """
+        rate_in = Decimal("0.00000018")
+        rate_out = Decimal("0.00000050")
+        # Wire cost reported by OpenRouter — intentionally NOT the DB-rate
+        # computation so the test can prove which path was taken.
+        wire_cost = Decimal("0.00012345")
+
+        user_headers, user_id, _, model_id, conv_id = await self._setup_user_and_provider(
+            client,
+            db,
+            auth_headers,
+            provider_type="generic_completions",
+            provider_name="shu803-openrouter-wire",
+            model_name="google/gemma-4-31b-it:nitro",
+            cost_per_input_unit=rate_in,
+            cost_per_output_unit=rate_out,
+        )
+        try:
+            fixture = openai_completions_end_usage_fixture(
+                prompt_tokens=400,
+                completion_tokens=200,
+                wire_cost=str(wire_cost),
+                delay_before_usage_chunk_s=0.3,
+            )
+            with stub_provider_stream(fixture):
+                stream_id, terminate_response = await _capture_stream_id_and_terminate(
+                    client, conv_id=conv_id, user_headers=user_headers
+                )
+            assert stream_id is not None
+            assert terminate_response.status_code == 202
+
+            persisted = await wait_for_message_persisted(
+                db, conversation_id=conv_id, role="assistant", timeout_seconds=5.0
+            )
+            assert persisted is not None
+
+            usage = await _latest_llm_usage_for_model(db, model_id)
+            assert usage is not None
+            assert usage.input_tokens == 400
+            assert usage.output_tokens == 200
+            # Wire cost recorded verbatim — provider-authoritative path.
+            assert usage.total_cost == wire_cost, (
+                f"Provider-authoritative path: total_cost must match wire usage.cost. "
+                f"Expected {wire_cost}, got {usage.total_cost}"
+            )
+            # And the contract invariant — when wire cost > 0, the split
+            # stays at 0/0 (per the cost contract in usage_recording.py).
+            assert usage.input_cost == Decimal("0")
+            assert usage.output_cost == Decimal("0")
+        finally:
+            await cleanup_test_user(client, auth_headers, user_id)
+
+
+if __name__ == "__main__":
+    ChatForceTerminateRealUsageIntegrationTest().run()

--- a/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
+++ b/backend/src/tests/integ/test_chat_force_terminate_real_usage_integration.py
@@ -255,14 +255,44 @@ async def _ensure_local_provider_type(db) -> None:
     await db.commit()
 
 
-async def _latest_llm_usage_for_model(db, model_id: str) -> LLMUsage | None:
-    """Fetch the most-recent LLMUsage row for a given model_id. Used to
-    assert on the row finalize wrote after the terminate signal landed.
+async def _latest_llm_usage_for_model(
+    db,
+    model_id: str,
+    *,
+    timeout_seconds: float = 5.0,
+    interval_seconds: float = 0.05,
+) -> LLMUsage | None:
+    """Poll for the most-recent LLMUsage row for a given model_id.
+
+    Synchronization rationale: the early-persist Message row lands at
+    terminate-signal time, but the LLMUsage row is written later when
+    finalize runs after drain captures provider usage. Callers that
+    sequence ``wait_for_message_persisted`` → ``_latest_llm_usage_for_model``
+    would otherwise race that gap (50ms+ on the slow-drain fixtures) and
+    flake. The poll-and-rollback pattern mirrors ``wait_for_message_persisted``:
+    each iteration drops the session's read view so a row committed on
+    the finalize task's connection becomes visible.
+
+    Returns the row when it lands, or ``None`` if no row appears within
+    ``timeout_seconds``. All callers in this file assert ``usage is not None``
+    immediately after the call, so the default budget is generous enough
+    to absorb fixture drain delays.
     """
-    result = await db.execute(
-        select(LLMUsage).where(LLMUsage.model_id == model_id).order_by(LLMUsage.created_at.desc()).limit(1)
-    )
-    return result.scalar_one_or_none()
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while True:
+        # Drop the implicit transaction's read view so a row committed on
+        # the finalize task's connection becomes visible to the next SELECT.
+        # Same rationale as wait_for_message_persisted.
+        await db.rollback()
+        result = await db.execute(
+            select(LLMUsage).where(LLMUsage.model_id == model_id).order_by(LLMUsage.created_at.desc()).limit(1)
+        )
+        row = result.scalar_one_or_none()
+        if row is not None:
+            return row
+        if asyncio.get_running_loop().time() >= deadline:
+            return None
+        await asyncio.sleep(interval_seconds)
 
 
 class ChatForceTerminateRealUsageIntegrationTest(BaseIntegrationTestSuite):

--- a/backend/src/tests/unit/core/test_model_pricing_normalization.py
+++ b/backend/src/tests/unit/core/test_model_pricing_normalization.py
@@ -1,0 +1,265 @@
+"""Unit tests for SHU-803 AC9d/9i pricing-lookup normalization.
+
+The lookup must resolve OpenRouter-style slugs (``vendor/model:tier``) to
+the corresponding bare-name ``MODEL_PRICING`` entries so the DB-rate
+fallback in ``usage_recording.py`` produces non-zero costs for chat rows
+that don't carry provider-authoritative wire cost (the billing-evasion
+abuse vector AC9d closes).
+
+These tests pin both the pure lookup (``get_pricing``) and the
+DB-side sync (``sync_pricing_to_db``) — the latter including the
+collision-warning behavior from AC9i.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shu.core.model_pricing import (
+    MODEL_PRICING,
+    _normalize_model_key,
+    get_pricing,
+    sync_pricing_to_db,
+)
+
+
+class TestNormalizeModelKey:
+    """Pure-string normalization. No DB, no MODEL_PRICING lookups."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            # OpenRouter happy path — vendor prefix + tier suffix.
+            ("google/gemma-4-31b-it:nitro", "gemma-4-31b-it"),
+            ("google/gemma-4-31b-it:free", "gemma-4-31b-it"),
+            # Vendor prefix only.
+            ("google/gemma-4-31b-it", "gemma-4-31b-it"),
+            # Tier suffix only.
+            ("gemma-4-31b-it:nitro", "gemma-4-31b-it"),
+            # Bare name (no prefix, no suffix). Lowercased.
+            ("gemma-4-31B-it", "gemma-4-31b-it"),
+            # Qwen slug variant.
+            ("qwen/qwen3.5-397b-a17b:free", "qwen3.5-397b-a17b"),
+            # Already-normalized OCR model (no prefix or suffix).
+            ("mistral-ocr-latest", "mistral-ocr-latest"),
+            # Edge: empty string falls through untouched.
+            ("", ""),
+        ],
+    )
+    def test_normalization_strips_prefix_suffix_and_lowercases(self, raw, expected):
+        assert _normalize_model_key(raw) == expected
+
+    def test_only_first_slash_is_treated_as_provider_prefix(self):
+        """Path-like names should keep nested segments after the first slash.
+
+        Some Gemini model identifiers carry ``models/gemini-3-pro-preview``
+        as the canonical name. The first slash is a provider-like prefix
+        and gets stripped; everything after is preserved.
+        """
+        assert _normalize_model_key("models/gemini-3-pro-preview") == "gemini-3-pro-preview"
+
+    def test_tier_suffix_must_be_at_the_end(self):
+        """Colons inside the model name (e.g. an embedded version) are not
+        treated as tier suffixes. Only a trailing ``:tier`` is stripped.
+        """
+        # A colon in the middle: nothing to strip.
+        assert _normalize_model_key("custom:v1/model-x") == "model-x"
+
+
+class TestGetPricingResolution:
+    """``get_pricing`` resolution: exact match first, normalized fallback second."""
+
+    def test_exact_bare_name_match_wins(self):
+        """Pre-existing keys in MODEL_PRICING must continue to resolve
+        without going through the normalized fallback path. Regression
+        guard for the existing call sites in ``usage_recording.py``.
+        """
+        # Bare-name keys present in MODEL_PRICING (verified at module load).
+        rates = get_pricing("gemma-4-31B-it")
+        assert rates is not None
+        assert rates["input"] > Decimal("0")
+        assert rates["output"] > Decimal("0")
+
+    def test_openrouter_slug_resolves_via_normalized_fallback(self):
+        """The AC9d load-bearing assertion: an OpenRouter slug for Gemma-4
+        resolves to the bare-name rates. Pre-fix this returned None and the
+        DB-rate fallback in ``usage_recording.py`` produced cost=0.
+        """
+        slug_rates = get_pricing("google/gemma-4-31b-it:nitro")
+        bare_rates = get_pricing("gemma-4-31B-it")
+        assert slug_rates is not None
+        assert bare_rates is not None
+        # Same underlying dict (we store references, not copies, in
+        # _NORMALIZED_PRICING — see model_pricing.py).
+        assert slug_rates is bare_rates
+
+    def test_qwen_openrouter_slug_resolves(self):
+        """Same pattern for the Qwen open-weight model — the other half of
+        the SHU-803 abuse-vector close-out."""
+        rates = get_pricing("qwen/qwen3.5-397b-a17b:free")
+        assert rates is not None
+        assert rates["input"] > Decimal("0")
+
+    def test_unknown_model_returns_none(self):
+        """Both lookup paths exhausted → None, signaling 'no DB-rate
+        fallback available' to the cost contract in usage_recording.py."""
+        assert get_pricing("anthropic/nonexistent-model:foo") is None
+        assert get_pricing("totally-made-up-model") is None
+
+    def test_case_insensitive_match_via_normalization(self):
+        """Mixed-case slugs (operator typo or vendor inconsistency) still
+        resolve via the lowercase normalization step."""
+        rates = get_pricing("GOOGLE/Gemma-4-31B-IT:NITRO")
+        assert rates is not None
+        assert rates is get_pricing("gemma-4-31B-it")
+
+
+class TestSyncPricingToDb:
+    """``sync_pricing_to_db`` over a mocked AsyncSession.
+
+    We mock the session to avoid Postgres dependency in unit tests. The
+    assertion targets the resolved rates + the WARN-on-collision behavior
+    rather than SQL emission shape.
+    """
+
+    @pytest.mark.asyncio
+    async def test_openrouter_slug_picks_up_rates_via_normalized_fallback(self):
+        """The load-bearing AC9d scenario at the DB layer: an LLMModel row
+        whose ``model_name`` is the OpenRouter slug gets its rates populated
+        via the normalized fallback. Pre-fix it would be skipped (no
+        exact match in MODEL_PRICING) and its rate columns would stay NULL.
+        """
+        session = MagicMock()
+        # Return one row that needs the normalized fallback.
+        result_mock = MagicMock()
+        result_mock.all.return_value = [("google/gemma-4-31b-it:nitro",)]
+        session.execute = AsyncMock(return_value=result_mock)
+        session.commit = AsyncMock()
+
+        counts = await sync_pricing_to_db(session)
+
+        assert counts["updated"] == 1
+        assert counts["skipped"] == 0
+        # The update call shape isn't asserted in detail — what matters is
+        # that we issued at least one update for the OpenRouter-slug name.
+        # The first execute() is the SELECT; subsequent execute() calls are
+        # the UPDATEs.
+        assert session.execute.await_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_collision_logs_warning_with_both_names(self, caplog):
+        """AC9i: two distinct DB model_name values resolving to the same
+        MODEL_PRICING entry via the normalized fallback emit a WARN naming
+        both. This is informational for tier-variant resolution
+        (``...:nitro`` and ``...:free`` sharing rates by design) but
+        operators want the breadcrumb so they can confirm the resolution
+        matches intent.
+        """
+        session = MagicMock()
+        # Two OpenRouter slugs both normalize to "gemma-4-31b-it".
+        result_mock = MagicMock()
+        result_mock.all.return_value = [
+            ("google/gemma-4-31b-it:nitro",),
+            ("google/gemma-4-31b-it:free",),
+        ]
+        session.execute = AsyncMock(return_value=result_mock)
+        session.commit = AsyncMock()
+
+        with caplog.at_level(logging.WARNING, logger="shu.core.model_pricing"):
+            await sync_pricing_to_db(session)
+
+        collision_records = [
+            r for r in caplog.records if "normalization collision" in r.getMessage()
+        ]
+        assert len(collision_records) == 1, (
+            f"Expected one collision WARN; got {[r.getMessage() for r in caplog.records]}"
+        )
+        msg = collision_records[0].getMessage()
+        assert "google/gemma-4-31b-it:nitro" in msg
+        assert "google/gemma-4-31b-it:free" in msg
+
+    @pytest.mark.asyncio
+    async def test_exact_match_does_not_count_as_collision(self, caplog):
+        """A DB row whose ``model_name`` matches MODEL_PRICING exactly
+        resolves via the exact-match path and never touches the normalized
+        fallback. It must NOT participate in collision detection — only
+        normalized-fallback resolutions count.
+        """
+        session = MagicMock()
+        result_mock = MagicMock()
+        # One exact-match name + one normalized-fallback name. Even if
+        # both normalize to the same key, the exact match doesn't go
+        # through the fallback path so no collision is recorded.
+        result_mock.all.return_value = [
+            ("gemma-4-31B-it",),  # exact match in MODEL_PRICING
+            ("google/gemma-4-31b-it:nitro",),  # normalized fallback only
+        ]
+        session.execute = AsyncMock(return_value=result_mock)
+        session.commit = AsyncMock()
+
+        with caplog.at_level(logging.WARNING, logger="shu.core.model_pricing"):
+            await sync_pricing_to_db(session)
+
+        collision_records = [
+            r for r in caplog.records if "normalization collision" in r.getMessage()
+        ]
+        assert collision_records == [], (
+            "Exact matches must not participate in collision detection — only "
+            "multiple normalized-fallback resolutions to the same key warn."
+        )
+
+    @pytest.mark.asyncio
+    async def test_skipped_count_reflects_unknown_models(self):
+        """DB models with no MODEL_PRICING resolution (exact or normalized)
+        are left untouched and counted under ``skipped``."""
+        session = MagicMock()
+        result_mock = MagicMock()
+        result_mock.all.return_value = [("totally-fake-model-name",)]
+        session.execute = AsyncMock(return_value=result_mock)
+        session.commit = AsyncMock()
+
+        counts = await sync_pricing_to_db(session)
+        assert counts["updated"] == 0
+        assert counts["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_no_collision_warning_for_single_normalized_resolution(self, caplog):
+        """One DB name resolving via normalization is not a collision; no WARN."""
+        session = MagicMock()
+        result_mock = MagicMock()
+        result_mock.all.return_value = [("google/gemma-4-31b-it:nitro",)]
+        session.execute = AsyncMock(return_value=result_mock)
+        session.commit = AsyncMock()
+
+        with caplog.at_level(logging.WARNING, logger="shu.core.model_pricing"):
+            await sync_pricing_to_db(session)
+
+        collision_records = [
+            r for r in caplog.records if "normalization collision" in r.getMessage()
+        ]
+        assert collision_records == []
+
+
+class TestModelPricingInvariants:
+    """Module-load invariants worth pinning."""
+
+    def test_normalized_table_has_one_entry_per_model_pricing_key(self):
+        """A regression guard: if two MODEL_PRICING keys normalize to the
+        same value (e.g., somebody adds both ``gemma-4-31B-it`` and
+        ``gemma-4-31b-it`` with different rates), the second one silently
+        overwrites the first in _NORMALIZED_PRICING. This test would catch
+        that — currently all keys normalize uniquely.
+        """
+        normalized_seen: dict[str, str] = {}
+        for key in MODEL_PRICING:
+            normalized = _normalize_model_key(key)
+            assert normalized not in normalized_seen, (
+                f"MODEL_PRICING keys {normalized_seen[normalized]!r} and {key!r} "
+                f"both normalize to {normalized!r}. Pick one canonical key "
+                f"or change the normalization rules."
+            )
+            normalized_seen[normalized] = key

--- a/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
+++ b/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
@@ -368,3 +368,276 @@ async def test_response_completed_with_only_reasoning_emits_error(responses_adap
     result = await responses_adapter.handle_provider_event(chunk)
     assert isinstance(result, ProviderErrorEventResult)
     assert "no text content" in result.content
+
+
+# SHU-803 AC9e: ResponsesAdapter.cancel() POSTs to /responses/{id}/cancel
+# because OpenAI Responses keeps generating server-side after stream
+# close (and billing continues) unless the cancel endpoint is hit. These
+# tests pin the URL shape, return semantics, and AC9j logging behavior.
+
+
+import logging  # noqa: E402
+
+import httpx  # noqa: E402
+
+from shu.services.providers.adapters.responses_adapter import (  # noqa: E402
+    _reset_cancel_failure_tracking,
+)
+
+
+@pytest.fixture(scope="function")
+def _reset_cancel_logging():
+    """Ensure each cancel-failure-logging test starts from a clean slate.
+
+    The module-level ``_CANCEL_FAILURE_LOGGED_PROVIDERS`` set tracks
+    which provider IDs have already emitted an INFO log; without
+    resetting between tests, the INFO-then-WARN escalation can't be
+    asserted in isolation.
+    """
+    _reset_cancel_failure_tracking()
+    yield
+    _reset_cancel_failure_tracking()
+
+
+@pytest.fixture(scope="function")
+def mock_provider_with_id():
+    """A mock provider with an ``id`` set (used by AC9j logging) and a
+    ``config`` carrying the API base URL so the adapter's
+    ``get_field_with_override("get_api_base_url")`` resolves without
+    needing a concrete subclass."""
+    return types.SimpleNamespace(
+        id="test-provider-id",
+        name="test-responses",
+        api_key_encrypted=None,
+        config={"get_api_base_url": "https://api.example.com/v1"},
+    )
+
+
+@pytest.fixture(scope="function")
+def cancellable_adapter(mock_db_session, mock_provider_with_id):
+    return ResponsesAdapter(
+        ProviderAdapterContext(
+            db_session=mock_db_session,
+            provider=mock_provider_with_id,
+            conversation_owner_id="unit-test-user",
+        )
+    )
+
+
+def _make_mock_transport(handler):
+    """Build an httpx.MockTransport that delegates each request to the
+    test-supplied handler."""
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_false_when_response_id_not_yet_seen(cancellable_adapter):
+    """If terminate fires before `response.created` lands (extremely tight
+    race), cancel() no-ops with False. Drain still runs and captures any
+    eventual `response.completed` usage.
+    """
+    assert cancellable_adapter._response_id is None
+    result = await cancellable_adapter.cancel()
+    assert result is False
+    # No httpx client should be instantiated for the no-op path.
+    assert cancellable_adapter._cancel_client is None
+
+
+@pytest.mark.asyncio
+async def test_response_created_event_captures_response_id(cancellable_adapter):
+    """`response.created` is the first event in a Responses-API stream.
+    The adapter must stash `response.id` so a subsequent `cancel()` can
+    address the right in-flight run.
+    """
+    await cancellable_adapter.handle_provider_event(
+        {"type": "response.created", "response": {"id": "resp_abc123"}}
+    )
+    assert cancellable_adapter._response_id == "resp_abc123"
+
+
+@pytest.mark.asyncio
+async def test_response_created_second_event_does_not_overwrite_id(cancellable_adapter):
+    """A second `response.created` (shouldn't normally happen but worth
+    pinning) must NOT replace the id we already have — once captured,
+    the id we'd cancel is locked.
+    """
+    await cancellable_adapter.handle_provider_event(
+        {"type": "response.created", "response": {"id": "resp_first"}}
+    )
+    await cancellable_adapter.handle_provider_event(
+        {"type": "response.created", "response": {"id": "resp_second"}}
+    )
+    assert cancellable_adapter._response_id == "resp_first"
+
+
+@pytest.mark.asyncio
+async def test_cancel_posts_to_responses_cancel_endpoint_on_2xx(
+    cancellable_adapter, _reset_cancel_logging
+):
+    """The load-bearing AC9e assertion: cancel POSTs to
+    `{base_url}/responses/{response_id}/cancel` with the adapter's auth
+    headers, and returns True when the upstream responds 2xx.
+    """
+    captured_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, json={"cancelled": True})
+
+    # Seed response_id and pre-install the mock transport so the lazy
+    # init in cancel() doesn't replace it.
+    cancellable_adapter._response_id = "resp_xyz"
+    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+
+    result = await cancellable_adapter.cancel()
+
+    assert result is True
+    assert len(captured_requests) == 1
+    request = captured_requests[0]
+    assert request.method == "POST"
+    # The path must end in /responses/{id}/cancel.
+    assert str(request.url).endswith("/responses/resp_xyz/cancel")
+    # Built atop the provider's configured base URL.
+    assert str(request.url).startswith("https://api.example.com/v1/")
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_false_on_4xx_response(cancellable_adapter, _reset_cancel_logging):
+    """Non-2xx responses are best-effort failures: the cancel was attempted
+    but the provider didn't honor it (or doesn't support the endpoint).
+    Returns False so the consumer loop falls through to drain.
+    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    cancellable_adapter._response_id = "resp_xyz"
+    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+
+    result = await cancellable_adapter.cancel()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_false_on_5xx_response(cancellable_adapter, _reset_cancel_logging):
+    """Same shape as 4xx — upstream failure means drain takes over."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    cancellable_adapter._response_id = "resp_xyz"
+    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+
+    result = await cancellable_adapter.cancel()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_swallows_network_exceptions_and_returns_false(
+    cancellable_adapter, _reset_cancel_logging
+):
+    """The cancel contract says implementations MUST NOT raise. A network
+    failure (DNS, TLS, connection refused, timeout) is folded into a
+    False return so `asyncio.gather(cancel_task, drain_task)` does not
+    surface the cancel-side exception.
+    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated network failure")
+
+    cancellable_adapter._response_id = "resp_xyz"
+    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+
+    result = await cancellable_adapter.cancel()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_false_when_base_url_missing(cancellable_adapter, _reset_cancel_logging):
+    """A mis-configured adapter (no base URL resolvable from
+    get_field_with_override) returns False — we can't construct the
+    cancel URL without the base, and we shouldn't crash the gather.
+    """
+    cancellable_adapter.provider.config = {"get_api_base_url": ""}
+    cancellable_adapter._response_id = "resp_xyz"
+
+    result = await cancellable_adapter.cancel()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ac9j_first_cancel_failure_logs_info_then_warn(
+    cancellable_adapter, _reset_cancel_logging, caplog
+):
+    """AC9j: the first non-2xx from a given provider logs INFO; subsequent
+    failures from the same provider escalate to WARN with a hint to
+    configure as completions-shape.
+    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    cancellable_adapter._response_id = "resp_xyz"
+    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+
+    with caplog.at_level(logging.INFO, logger="shu.services.providers.adapters.responses_adapter"):
+        await cancellable_adapter.cancel()  # First failure → INFO
+        await cancellable_adapter.cancel()  # Second failure → WARN
+
+    failure_records = [
+        r for r in caplog.records if "ResponsesAdapter.cancel" in r.getMessage()
+    ]
+    assert len(failure_records) == 2
+    assert failure_records[0].levelno == logging.INFO, (
+        f"First failure should log INFO, got level {failure_records[0].levelname}"
+    )
+    assert failure_records[1].levelno == logging.WARNING, (
+        f"Second failure should escalate to WARN, got level {failure_records[1].levelname}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ac9j_two_different_providers_each_get_one_info(_reset_cancel_logging, caplog):
+    """The INFO-then-WARN escalation is per-provider — two different
+    providers each get their own first-time INFO without polluting each
+    other's escalation state.
+    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    transport = _make_mock_transport(handler)
+
+    adapter_a = ResponsesAdapter(
+        ProviderAdapterContext(
+            provider=types.SimpleNamespace(
+                id="provider-A",
+                name="A",
+                api_key_encrypted=None,
+                config={"get_api_base_url": "https://a.example.com"},
+            )
+        )
+    )
+    adapter_a._response_id = "resp_a"
+    adapter_a._cancel_client = httpx.AsyncClient(transport=transport)
+
+    adapter_b = ResponsesAdapter(
+        ProviderAdapterContext(
+            provider=types.SimpleNamespace(
+                id="provider-B",
+                name="B",
+                api_key_encrypted=None,
+                config={"get_api_base_url": "https://b.example.com"},
+            )
+        )
+    )
+    adapter_b._response_id = "resp_b"
+    adapter_b._cancel_client = httpx.AsyncClient(transport=transport)
+
+    with caplog.at_level(logging.INFO, logger="shu.services.providers.adapters.responses_adapter"):
+        await adapter_a.cancel()
+        await adapter_b.cancel()
+
+    failure_records = [
+        r for r in caplog.records if "ResponsesAdapter.cancel" in r.getMessage()
+    ]
+    assert len(failure_records) == 2
+    assert all(r.levelno == logging.INFO for r in failure_records), (
+        f"Both providers should INFO on first failure, got: "
+        f"{[(r.name, r.levelname) for r in failure_records]}"
+    )

--- a/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
+++ b/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
@@ -439,8 +439,8 @@ async def test_cancel_returns_false_when_response_id_not_yet_seen(cancellable_ad
     assert cancellable_adapter._response_id is None
     result = await cancellable_adapter.cancel()
     assert result is False
-    # No httpx client should be instantiated for the no-op path.
-    assert cancellable_adapter._cancel_client is None
+    # No transport should be installed for the no-op path.
+    assert cancellable_adapter._cancel_transport is None
 
 
 @pytest.mark.asyncio
@@ -484,10 +484,11 @@ async def test_cancel_posts_to_responses_cancel_endpoint_on_2xx(
         captured_requests.append(request)
         return httpx.Response(200, json={"cancelled": True})
 
-    # Seed response_id and pre-install the mock transport so the lazy
-    # init in cancel() doesn't replace it.
+    # Seed response_id and inject the mock transport — cancel() builds
+    # its own ``httpx.AsyncClient`` inside an ``async with``, passing
+    # ``self._cancel_transport`` as the client's transport.
     cancellable_adapter._response_id = "resp_xyz"
-    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+    cancellable_adapter._cancel_transport = _make_mock_transport(handler)
 
     result = await cancellable_adapter.cancel()
 
@@ -511,7 +512,7 @@ async def test_cancel_returns_false_on_4xx_response(cancellable_adapter, _reset_
         return httpx.Response(404)
 
     cancellable_adapter._response_id = "resp_xyz"
-    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+    cancellable_adapter._cancel_transport = _make_mock_transport(handler)
 
     result = await cancellable_adapter.cancel()
     assert result is False
@@ -524,7 +525,7 @@ async def test_cancel_returns_false_on_5xx_response(cancellable_adapter, _reset_
         return httpx.Response(500)
 
     cancellable_adapter._response_id = "resp_xyz"
-    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+    cancellable_adapter._cancel_transport = _make_mock_transport(handler)
 
     result = await cancellable_adapter.cancel()
     assert result is False
@@ -543,7 +544,7 @@ async def test_cancel_swallows_network_exceptions_and_returns_false(
         raise httpx.ConnectError("simulated network failure")
 
     cancellable_adapter._response_id = "resp_xyz"
-    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+    cancellable_adapter._cancel_transport = _make_mock_transport(handler)
 
     result = await cancellable_adapter.cancel()
     assert result is False
@@ -574,7 +575,7 @@ async def test_ac9j_first_cancel_failure_logs_info_then_warn(
         return httpx.Response(404)
 
     cancellable_adapter._response_id = "resp_xyz"
-    cancellable_adapter._cancel_client = httpx.AsyncClient(transport=_make_mock_transport(handler))
+    cancellable_adapter._cancel_transport = _make_mock_transport(handler)
 
     with caplog.at_level(logging.INFO, logger="shu.services.providers.adapters.responses_adapter"):
         await cancellable_adapter.cancel()  # First failure → INFO
@@ -614,7 +615,7 @@ async def test_ac9j_two_different_providers_each_get_one_info(_reset_cancel_logg
         )
     )
     adapter_a._response_id = "resp_a"
-    adapter_a._cancel_client = httpx.AsyncClient(transport=transport)
+    adapter_a._cancel_transport = transport
 
     adapter_b = ResponsesAdapter(
         ProviderAdapterContext(
@@ -627,7 +628,7 @@ async def test_ac9j_two_different_providers_each_get_one_info(_reset_cancel_logg
         )
     )
     adapter_b._response_id = "resp_b"
-    adapter_b._cancel_client = httpx.AsyncClient(transport=transport)
+    adapter_b._cancel_transport = transport
 
     with caplog.at_level(logging.INFO, logger="shu.services.providers.adapters.responses_adapter"):
         await adapter_a.cancel()

--- a/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
+++ b/backend/src/tests/unit/services/providers/adapters/test_responses_adapter.py
@@ -456,10 +456,14 @@ async def test_response_created_event_captures_response_id(cancellable_adapter):
 
 
 @pytest.mark.asyncio
-async def test_response_created_second_event_does_not_overwrite_id(cancellable_adapter):
-    """A second `response.created` (shouldn't normally happen but worth
-    pinning) must NOT replace the id we already have — once captured,
-    the id we'd cancel is locked.
+async def test_response_created_second_event_overwrites_id(cancellable_adapter):
+    """A second ``response.created`` MUST refresh ``_response_id`` to the
+    new id. The adapter instance is reused across tool-call follow-up
+    turns in ``_stream_variant_phase`` — each turn opens a fresh stream
+    and emits a new ``response.created``. If we kept the first id,
+    ``cancel()`` on Stop during the second turn would POST to a stale
+    /responses/{id}/cancel endpoint and the live stream would keep
+    billing.
     """
     await cancellable_adapter.handle_provider_event(
         {"type": "response.created", "response": {"id": "resp_first"}}
@@ -467,7 +471,7 @@ async def test_response_created_second_event_does_not_overwrite_id(cancellable_a
     await cancellable_adapter.handle_provider_event(
         {"type": "response.created", "response": {"id": "resp_second"}}
     )
-    assert cancellable_adapter._response_id == "resp_first"
+    assert cancellable_adapter._response_id == "resp_second"
 
 
 @pytest.mark.asyncio

--- a/backend/src/tests/unit/services/providers/test_adapter_base_usage.py
+++ b/backend/src/tests/unit/services/providers/test_adapter_base_usage.py
@@ -435,3 +435,187 @@ class TestAnthropicAdapterPartialUsageSnapshot:
         }
         snapshot = adapter.get_partial_usage_snapshot()
         assert snapshot == adapter.usage
+
+
+# SHU-803 AC9b: Anthropic's `message_start` event carries initial input_tokens
+# nested under `message.usage` rather than top-level. The pre-fix capture
+# clause (`if "usage" in chunk: self._latest_usage_event = chunk`) misses
+# that shape entirely, so a terminate fired before any `message_delta`
+# lands with `input_tokens=0` even though the provider had emitted them.
+# These tests pin both shapes through the actual `handle_provider_event`
+# code path (not just the snapshot) so a regression in the additive
+# branch can't be masked by the existing top-level test.
+
+
+def _make_anthropic_adapter_for_event_handling() -> AnthropicAdapter:
+    """Like ``_make_anthropic_adapter`` but also seeds the streaming-state
+    attributes (`_stream_content`, `_stream_tool_calls`) that
+    ``handle_provider_event`` reaches into.
+    """
+    adapter = AnthropicAdapter.__new__(AnthropicAdapter)
+    adapter.usage = {}
+    adapter._latest_usage_event = None
+    adapter._stream_content = []
+    adapter._stream_tool_calls = {}
+    return adapter
+
+
+class TestAnthropicHandleProviderEventUsageCapture:
+    """SHU-803 AC9b: `handle_provider_event` must stash both Anthropic
+    usage shapes (`message_start` nested + `message_delta` top-level) onto
+    `_latest_usage_event` so `get_partial_usage_snapshot()` can flush them
+    on terminate."""
+
+    @pytest.mark.asyncio
+    async def test_message_start_chunk_captures_nested_usage(self):
+        """The fix path: `message_start` carries `message.usage` (input_tokens
+        on the initial event). Pre-fix this was lost; post-fix it lands on
+        `_latest_usage_event` and the snapshot flushes it into `self.usage`.
+        """
+        adapter = _make_anthropic_adapter_for_event_handling()
+        await adapter.handle_provider_event(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-haiku-4-5",
+                    "usage": {"input_tokens": 42, "output_tokens": 1},
+                },
+            }
+        )
+        # The normalized stash exposes the usage at the same top-level
+        # `usage` key that `_extract_usage` jmespath-searches for.
+        assert adapter._latest_usage_event == {
+            "usage": {"input_tokens": 42, "output_tokens": 1}
+        }
+        snapshot = adapter.get_partial_usage_snapshot()
+        assert snapshot["input_tokens"] == 42
+        assert snapshot["output_tokens"] == 1
+
+    @pytest.mark.asyncio
+    async def test_message_delta_chunk_still_captures_top_level_usage(self):
+        """Regression guard for the existing path: `message_delta` carries
+        `usage` at top-level. The additive `elif` branch must not break this.
+        """
+        adapter = _make_anthropic_adapter_for_event_handling()
+        await adapter.handle_provider_event(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": None, "stop_sequence": None},
+                "usage": {"output_tokens": 17},
+            }
+        )
+        # Existing behavior: the whole chunk is stashed.
+        assert adapter._latest_usage_event is not None
+        assert adapter._latest_usage_event["usage"] == {"output_tokens": 17}
+        snapshot = adapter.get_partial_usage_snapshot()
+        assert snapshot["output_tokens"] == 17
+
+    @pytest.mark.asyncio
+    async def test_message_start_then_message_delta_accumulates(self):
+        """End-to-end stream shape: ``message_start`` lands input_tokens,
+        then ``message_delta`` carries output_tokens. The capture branch
+        MERGES the message_delta's top-level usage with the prior
+        ``_latest_usage_event`` from ``message_start`` so BOTH axes
+        survive to the snapshot. Without the merge, message_delta would
+        overwrite ``_latest_usage_event`` with output-only and
+        input_tokens would land as 0 on the LLMUsage row — the bug that
+        SHU-803 AC9b closes.
+        """
+        adapter = _make_anthropic_adapter_for_event_handling()
+        await adapter.handle_provider_event(
+            {
+                "type": "message_start",
+                "message": {"usage": {"input_tokens": 100, "output_tokens": 1}},
+            }
+        )
+        await adapter.handle_provider_event(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": None, "stop_sequence": None},
+                "usage": {"output_tokens": 45},
+            }
+        )
+        snapshot = adapter.get_partial_usage_snapshot()
+        # BOTH axes — input_tokens from message_start, output_tokens
+        # from message_delta — survive the merge.
+        assert snapshot["input_tokens"] == 100, (
+            "SHU-803 AC9b: message_start input_tokens must survive a later "
+            "message_delta. Pre-fix the delta overwrote _latest_usage_event."
+        )
+        assert snapshot["output_tokens"] == 45
+
+    @pytest.mark.asyncio
+    async def test_terminate_after_message_start_only_captures_input_tokens(self):
+        """The load-bearing scenario for the fix: terminate fires AFTER
+        `message_start` but BEFORE any `message_delta`. Pre-fix, input_tokens
+        were lost (`_latest_usage_event` stayed None). Post-fix, input_tokens
+        land on the snapshot.
+        """
+        adapter = _make_anthropic_adapter_for_event_handling()
+        await adapter.handle_provider_event(
+            {
+                "type": "message_start",
+                "message": {"usage": {"input_tokens": 250, "output_tokens": 0}},
+            }
+        )
+        # No message_delta arrives — terminate fires here.
+        snapshot = adapter.get_partial_usage_snapshot()
+        assert snapshot["input_tokens"] == 250, (
+            "SHU-803 AC9b: input_tokens from message_start must survive "
+            "a terminate before any message_delta lands. Pre-fix this was 0."
+        )
+
+    @pytest.mark.asyncio
+    async def test_content_block_delta_chunk_does_not_overwrite_usage(self):
+        """Content deltas are the bulk of the stream; they have no `usage`
+        field. The new branch must not fire and stomp on a previously
+        captured usage event.
+        """
+        adapter = _make_anthropic_adapter_for_event_handling()
+        # Seed via a message_start.
+        await adapter.handle_provider_event(
+            {"type": "message_start", "message": {"usage": {"input_tokens": 99}}}
+        )
+        # Now a content_block_delta — has no usage anywhere.
+        await adapter.handle_provider_event(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            }
+        )
+        # The stash from message_start must survive.
+        assert adapter._latest_usage_event == {"usage": {"input_tokens": 99}}
+
+
+# SHU-803 AC9e: the base ``cancel()`` is a no-op default — adapters whose
+# providers don't expose a real cancel API inherit it and return False
+# immediately so the consumer loop falls through to drain.
+
+
+class TestBaseProviderAdapterCancel:
+    """The base ``cancel()`` returns False without doing any work.
+
+    Adapters that DO support cancel (currently only ResponsesAdapter)
+    override; the rest inherit this no-op so the consumer loop's
+    ``asyncio.gather(adapter.cancel(), _drain(...))`` call site stays
+    uniform across providers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_returns_false(self):
+        adapter = _make_adapter()
+        result = await adapter.cancel()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise(self):
+        """The cancel contract says implementations MUST NOT raise. The
+        default trivially upholds this, but the test pins the invariant
+        so a future regression that adds a side-effect can't slip in."""
+        adapter = _make_adapter()
+        # If cancel raised, this would surface as a test failure.
+        await adapter.cancel()

--- a/backend/src/tests/unit/services/test_drain_handler.py
+++ b/backend/src/tests/unit/services/test_drain_handler.py
@@ -313,3 +313,83 @@ class TestSignalShutdownToInFlightStreams:
         # Count reflects the snapshot length (2), not the post-mutation
         # registry length (1).
         assert count == 2
+
+
+# SHU-803: both shutdown-signal helpers must set
+# ``lifecycle.shutdown_signaled = True`` IN ADDITION to calling
+# ``lc.signal("shutdown")``. The separate flag is the SIGTERM escape
+# valve for the per-stream drain loop in ``_call_provider``, which
+# can't rely on ``reason`` alone (priority semantics block
+# ``shutdown`` from overriding an existing ``user_terminated``).
+# Without this flag, an in-flight drain following user-terminate
+# would have no way to detect SIGTERM and would only exit via
+# cancellation propagation — bypassing the shielded finalize.
+
+
+class TestShutdownSignaledFlag:
+    """SHU-803: shutdown_signaled is the drain-escape-valve flag."""
+
+    def test_signal_shutdown_helper_sets_flag_on_every_lifecycle(self):
+        """``signal_shutdown_to_in_flight_streams`` is what the asyncio
+        SIGTERM signal handler calls (sync path). Every lifecycle in the
+        registry gets BOTH ``shutdown_signaled = True`` AND a
+        ``signal("shutdown")`` call. The flag is what the drain loop
+        observes between events.
+        """
+        first = _build_lifecycle("stream-1")
+        second = _build_lifecycle("stream-2")
+        registry = {first.stream_id: first, second.stream_id: second}
+
+        assert first.shutdown_signaled is False
+        assert second.shutdown_signaled is False
+
+        signal_shutdown_to_in_flight_streams(registry)
+
+        assert first.shutdown_signaled is True
+        assert second.shutdown_signaled is True
+        # And the reason update still happened.
+        assert first.reason == "shutdown"
+        assert second.reason == "shutdown"
+
+    @pytest.mark.asyncio
+    async def test_drain_helper_sets_flag_on_every_lifecycle(self):
+        """``drain_in_flight_streams`` (the lifespan backstop) also sets
+        the flag so a lifespan-only path — running without the SIGTERM
+        signal handler having fired first, e.g. on Windows dev without
+        ``add_signal_handler`` — still trips the drain escape valve.
+        """
+        first = _build_lifecycle("stream-1")
+        second = _build_lifecycle("stream-2")
+        # Give them no-op supervisor tasks so drain has something to
+        # await on.
+        first.supervise_task = asyncio.create_task(asyncio.sleep(0))
+        second.supervise_task = asyncio.create_task(asyncio.sleep(0))
+        registry = {first.stream_id: first, second.stream_id: second}
+
+        assert first.shutdown_signaled is False
+        assert second.shutdown_signaled is False
+
+        await drain_in_flight_streams(registry, timeout_seconds=1.0)
+
+        assert first.shutdown_signaled is True
+        assert second.shutdown_signaled is True
+
+    def test_flag_survives_user_terminated_first_writer_wins(self):
+        """The case the flag exists for: ``user_terminated`` won the
+        ``reason`` slot at priority 2, then SIGTERM fires shutdown. The
+        priority rule keeps ``reason="user_terminated"`` (audit trail
+        intact), but ``shutdown_signaled`` flips to True so the drain
+        knows to exit.
+        """
+        lc = _build_lifecycle("stream-1")
+        lc.signal("user_terminated")
+        assert lc.reason == "user_terminated"
+        assert lc.shutdown_signaled is False
+
+        registry = {lc.stream_id: lc}
+        signal_shutdown_to_in_flight_streams(registry)
+
+        # ``reason`` stays user_terminated (first-writer-wins at tier 2).
+        assert lc.reason == "user_terminated"
+        # But the flag is set — drain detects it and exits gracefully.
+        assert lc.shutdown_signaled is True

--- a/backend/src/tests/unit/services/test_iter_with_signal_break.py
+++ b/backend/src/tests/unit/services/test_iter_with_signal_break.py
@@ -1,0 +1,360 @@
+"""Unit tests for ``_iter_with_signal_break`` (SHU-803 follow-up).
+
+The wrapper races each provider next-chunk read against
+``lifecycle.event.wait()`` so the consumer-loop's terminate-detection
+fires at signal time, not at next-chunk time. Without this guarantee,
+a provider going silent after the user clicks Stop delays the
+early-persist callback — and a refetch or follow-up message in the
+gap reintroduces the vanishing-content + temporal-ordering races
+SHU-803's early-persist guarantee is meant to prevent.
+
+The integration-level coverage exists in the SHU-803 force-terminate
+real-usage suite, but those tests run against stub providers that
+stream chunks rapidly — they don't exercise the silent-provider gap
+this wrapper closes. This file does, by feeding the wrapper an
+explicit async generator that pauses on demand and asserting on the
+sentinel-yield timing.
+
+Three concrete scenarios are pinned here:
+
+1. **Hot path** — chunks arrive faster than the signal fires. Wrapper
+   yields each chunk normally; the sentinel never appears.
+2. **Silent provider gap** — wrapper yields the sentinel within the
+   asyncio scheduling latency of when the signal fires, NOT when the
+   provider next yields. After the sentinel, the wrapper resumes
+   yielding chunks (so drain can consume them).
+3. **Cleanup on early exit** — consumer abandons the generator
+   mid-iteration; pending next-chunk and signal-wait tasks are
+   cancelled and their exceptions absorbed (no "Task exception was
+   never retrieved" warnings).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from shu.services.chat_streaming import _SIGNAL_SENTINEL, _iter_with_signal_break
+
+
+class _ControllableStream:
+    """Async-iterable wrapper around an ``asyncio.Queue`` so tests can
+    push chunks and a sentinel end-marker on demand. Mirrors the shape
+    of the provider stream the real consumer loop iterates.
+    """
+
+    _END = object()  # in-band end-of-stream marker
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue = asyncio.Queue()
+
+    def push(self, item: object) -> None:
+        self._queue.put_nowait(item)
+
+    def end(self) -> None:
+        self._queue.put_nowait(self._END)
+
+    def __aiter__(self) -> AsyncGenerator[object, None]:
+        async def _gen() -> AsyncGenerator[object, None]:
+            while True:
+                item = await self._queue.get()
+                if item is self._END:
+                    return
+                yield item
+
+        return _gen()
+
+
+@pytest.mark.asyncio
+class TestIterWithSignalBreak:
+    """Behavior of the signal-aware iterator wrapper in isolation."""
+
+    async def test_hot_path_yields_chunks_without_sentinel(self):
+        """When chunks arrive before any signal fires, the wrapper is
+        transparent — yields each chunk and nothing else. Catches a
+        regression where the sentinel-yield branch fires when it
+        shouldn't.
+        """
+        stream = _ControllableStream()
+        signal_event = asyncio.Event()
+
+        stream.push("chunk-1")
+        stream.push("chunk-2")
+        stream.push("chunk-3")
+        stream.end()
+
+        collected = [item async for item in _iter_with_signal_break(stream, signal_event)]
+        assert collected == ["chunk-1", "chunk-2", "chunk-3"]
+        assert _SIGNAL_SENTINEL not in collected
+
+    async def test_sentinel_fires_when_signal_set_before_first_chunk(self):
+        """Signal fires while the wrapper is awaiting the first chunk
+        from a silent provider. The wrapper must yield the sentinel
+        without waiting for a chunk that may never arrive — that's
+        the load-bearing property this wrapper exists for.
+        """
+        stream = _ControllableStream()
+        signal_event = asyncio.Event()
+
+        # Spawn the iteration; consumer collects via a queue so we can
+        # observe yields in real time.
+        collected: list[object] = []
+
+        async def _consume() -> None:
+            async for item in _iter_with_signal_break(stream, signal_event):
+                collected.append(item)
+                if item is _SIGNAL_SENTINEL:
+                    # Stop consuming after the sentinel so the test
+                    # doesn't hang on the never-arriving next chunk.
+                    break
+
+        task = asyncio.create_task(_consume())
+
+        # Let the wrapper enter its wait state.
+        await asyncio.sleep(0.01)
+        # Provider is silent; fire the signal.
+        signal_event.set()
+
+        await asyncio.wait_for(task, timeout=1.0)
+        assert collected == [_SIGNAL_SENTINEL]
+
+    async def test_sentinel_then_chunks_resume_for_drain(self):
+        """After the sentinel, the wrapper continues yielding chunks
+        from the underlying stream — that's how the consumer's drain
+        path captures end-of-stream usage post-terminate.
+
+        Sequence: provider yields chunk-A; signal fires (sentinel);
+        provider yields chunk-B + chunk-C + end. Wrapper output:
+        chunk-A, _SIGNAL_SENTINEL, chunk-B, chunk-C.
+        """
+        stream = _ControllableStream()
+        signal_event = asyncio.Event()
+
+        collected: list[object] = []
+
+        async def _consume() -> None:
+            async for item in _iter_with_signal_break(stream, signal_event):
+                collected.append(item)
+
+        task = asyncio.create_task(_consume())
+
+        # Push first chunk + let it be observed.
+        stream.push("chunk-A")
+        await asyncio.sleep(0.01)
+
+        # Fire signal while wrapper is awaiting next chunk.
+        signal_event.set()
+        await asyncio.sleep(0.01)
+
+        # Resume the stream with more chunks (drain phase).
+        stream.push("chunk-B")
+        stream.push("chunk-C")
+        stream.end()
+
+        await asyncio.wait_for(task, timeout=1.0)
+        assert collected == ["chunk-A", _SIGNAL_SENTINEL, "chunk-B", "chunk-C"]
+        # Exactly one sentinel — never two.
+        assert collected.count(_SIGNAL_SENTINEL) == 1
+
+    async def test_signal_already_set_at_iteration_start_yields_sentinel_first(self):
+        """Signal is already set when the wrapper's first iteration
+        starts (terminate POST landed in the brief window between
+        handleStreamingResponse starting and the wrapper entering its
+        loop — e.g., user clicked Stop immediately after stream_start
+        but before the provider's first content chunk).
+
+        Pre-fix the wrapper assumed the caller's
+        ``lifecycle.event.is_set()`` check would handle this — but the
+        caller's check only runs AFTER the wrapper yields, and the
+        wrapper was blocking on ``await pending_chunk``. That left the
+        early-persist callback gated on the provider's next chunk
+        arrival, which is exactly the silent-provider gap the wrapper
+        exists to close.
+
+        Post-fix: the wrapper yields the sentinel immediately when
+        signal_event is set at iteration start, then transitions into
+        normal chunk-yielding so drain captures whatever the provider
+        eventually emits.
+        """
+        stream = _ControllableStream()
+        signal_event = asyncio.Event()
+        signal_event.set()  # already set BEFORE iteration begins
+
+        stream.push("chunk-1")
+        stream.push("chunk-2")
+        stream.end()
+
+        collected = [item async for item in _iter_with_signal_break(stream, signal_event)]
+        # Sentinel must be the FIRST yield — proves the wrapper didn't
+        # wait for the provider's first chunk before observing the
+        # signal.
+        assert collected[0] is _SIGNAL_SENTINEL
+        # Chunks resume after the sentinel for drain to consume.
+        assert collected[1:] == ["chunk-1", "chunk-2"]
+        # Sentinel yielded exactly once across the whole iteration.
+        assert collected.count(_SIGNAL_SENTINEL) == 1
+
+    async def test_signal_set_before_iteration_with_silent_provider_yields_sentinel(self):
+        """The load-bearing variant of the test above: signal is
+        already set AND the provider stays silent (never emits a
+        chunk). Pre-fix the wrapper would block on ``await
+        pending_chunk`` forever — early-persist never fires.
+
+        Post-fix: the wrapper yields the sentinel immediately, the
+        caller's terminate path runs (early-persist fires), and the
+        consumer can break out of iteration cleanly once it observes
+        the sentinel without waiting for a chunk that may never come.
+        """
+        stream = _ControllableStream()  # never pushed; never ended
+        signal_event = asyncio.Event()
+        signal_event.set()
+
+        collected: list[object] = []
+
+        async def _consume() -> None:
+            async for item in _iter_with_signal_break(stream, signal_event):
+                collected.append(item)
+                if item is _SIGNAL_SENTINEL:
+                    break
+
+        # Tight deadline — if this exceeds the timeout, the wrapper
+        # is blocked on a chunk read it should never have entered.
+        await asyncio.wait_for(_consume(), timeout=1.0)
+        assert collected == [_SIGNAL_SENTINEL]
+
+    async def test_consumer_early_break_cancels_pending_tasks(self):
+        """Consumer abandons the iterator mid-stream (e.g., drain
+        catches ``ProviderFinalEventResult`` and breaks). The wrapper's
+        ``finally`` block must cancel and absorb the dangling
+        ``next-chunk`` and ``signal-wait`` tasks — otherwise asyncio
+        emits ``Task exception was never retrieved`` warnings and the
+        underlying HTTP read leaks.
+
+        We can't directly observe task cancellation from the outside,
+        but we CAN observe that no unhandled warnings emit and the
+        generator's ``aclose()`` returns cleanly within a short
+        deadline.
+        """
+        stream = _ControllableStream()
+        signal_event = asyncio.Event()
+
+        gen = _iter_with_signal_break(stream, signal_event)
+
+        # Consume one chunk, then break out and close the generator.
+        stream.push("chunk-1")
+        first = await gen.__anext__()
+        assert first == "chunk-1"
+
+        # Close the generator — this triggers the finally cleanup.
+        # The next-chunk task is pending against an empty queue; the
+        # signal-wait task is pending against an unset event. Both
+        # must be cancelled and absorbed.
+        await asyncio.wait_for(gen.aclose(), timeout=1.0)
+
+    async def test_only_one_sentinel_emitted_across_long_drain(self):
+        """A drain that runs over many chunks must not re-yield the
+        sentinel for each chunk. The wrapper sets ``signal_yielded``
+        on the first sentinel and skips the race thereafter, so even
+        a long drain with hundreds of chunks observes exactly one
+        sentinel.
+        """
+        stream = _ControllableStream()
+        signal_event = asyncio.Event()
+
+        collected: list[object] = []
+
+        async def _consume() -> None:
+            async for item in _iter_with_signal_break(stream, signal_event):
+                collected.append(item)
+
+        task = asyncio.create_task(_consume())
+
+        # Let the wrapper enter its race-wait state BEFORE firing the
+        # signal. Without this, the very first iteration sees
+        # ``signal_event.is_set()`` and takes the "no sentinel" branch
+        # — which is correct behavior in production (terminate landed
+        # before iteration started) but defeats this test's premise.
+        await asyncio.sleep(0.01)
+        signal_event.set()
+        await asyncio.sleep(0.01)  # let the wrapper yield the sentinel
+
+        for i in range(50):
+            stream.push(f"drain-chunk-{i}")
+        stream.end()
+
+        await asyncio.wait_for(task, timeout=2.0)
+        assert collected.count(_SIGNAL_SENTINEL) == 1
+        # Sentinel came before the drain chunks, not interleaved.
+        sentinel_idx = collected.index(_SIGNAL_SENTINEL)
+        assert all(c == f"drain-chunk-{i}" for i, c in enumerate(collected[sentinel_idx + 1 :]))
+
+    async def test_disconnect_then_intentional_stop_wakes_silent_provider(self):
+        """SHU-803 follow-up (Codex re-review). The Codex-flagged
+        regression: ``_iter_with_signal_break`` used to race against
+        ``lifecycle.event`` (the omnibus event), which fires on
+        ANY signal including ``client_disconnected``. A disconnect
+        would consume the wrapper's one-shot sentinel; the
+        ``_call_provider`` consumer-loop check then ignored it (the
+        reason wasn't an intentional stop), and the wrapper switched
+        to plain chunk-await mode. A LATER ``user_terminated`` /
+        ``shutdown`` upgrade had no way to wake the wrapper because
+        the omnibus event was already set and the wrapper wasn't
+        racing it anymore.
+
+        Fix: the wrapper races ``lifecycle.intentional_stop_event``
+        instead. ``client_disconnected`` does not set this event;
+        the eventual intentional-stop signal sets it for the first
+        time, waking the silent provider's race.
+
+        This integration-style test wires the wrapper to a real
+        ``StreamLifecycle`` (rather than a bare ``asyncio.Event``)
+        so we exercise the actual production event source and catch
+        a regression in either the lifecycle's signal() semantics
+        OR the wrapper's wiring.
+        """
+        from shu.services.chat_streaming import StreamLifecycle
+
+        lifecycle = StreamLifecycle(
+            stream_id="test-stream", user_id="test-user", conversation_id="test-conv"
+        )
+        stream = _ControllableStream()  # silent provider — never pushed
+        collected: list[object] = []
+
+        async def _consume() -> None:
+            async for item in _iter_with_signal_break(stream, lifecycle.intentional_stop_event):
+                collected.append(item)
+                if item is _SIGNAL_SENTINEL:
+                    break
+
+        task = asyncio.create_task(_consume())
+
+        # Let the wrapper enter its race state.
+        await asyncio.sleep(0.01)
+
+        # Phase 1: client_disconnected fires. The omnibus event sets
+        # but the intentional-stop event does NOT — the wrapper must
+        # NOT yield the sentinel here.
+        lifecycle.signal("client_disconnected")
+        assert lifecycle.event.is_set() is True
+        assert lifecycle.intentional_stop_event.is_set() is False
+
+        # Give the wrapper a chance to (incorrectly, if buggy) wake up.
+        await asyncio.sleep(0.05)
+        assert collected == [], (
+            "wrapper consumed its sentinel on client_disconnected; the "
+            "later intentional-stop wake-up below would be missed. This "
+            "is the exact Codex-flagged regression."
+        )
+
+        # Phase 2: a LATER user_terminated upgrades the lifecycle and
+        # fires the intentional-stop event for the first time. The
+        # wrapper, which was correctly NOT racing the omnibus event,
+        # must now wake up and yield the sentinel — proving that the
+        # disconnect didn't permanently disable future wake-ups.
+        lifecycle.signal("user_terminated")
+        assert lifecycle.intentional_stop_event.is_set() is True
+
+        await asyncio.wait_for(task, timeout=1.0)
+        assert collected == [_SIGNAL_SENTINEL]

--- a/backend/src/tests/unit/services/test_stream_lifecycle.py
+++ b/backend/src/tests/unit/services/test_stream_lifecycle.py
@@ -308,3 +308,83 @@ class TestStreamLifecycleEventWaitInterop:
         # event.wait() on an already-set event returns immediately.
         await asyncio.wait_for(lc.event.wait(), timeout=0.1)
         assert lc.resolved_reason() == "shutdown"
+
+
+# SHU-803: ``shutdown_signaled`` is a separate flag — independent of
+# ``reason`` — that the drain loop reads as the SIGTERM escape valve.
+# Because priority-based signal() treats ``user_terminated`` and
+# ``shutdown`` as the SAME priority tier (both intentional stops at
+# priority 2), a shutdown arriving after user_terminated does NOT
+# update ``reason``. Without a separate flag, an in-flight drain
+# (entered via user_terminated) would have no way to detect shutdown
+# and would only exit when the lifespan-drain cancellation propagated
+# — bypassing the shielded finalize since ``_call_provider`` itself
+# is not shielded.
+
+
+class TestStreamLifecycleShutdownSignaled:
+    """The ``shutdown_signaled`` flag is the SIGTERM escape valve for
+    the drain loop. The flag is INDEPENDENT of ``reason``: signal()
+    alone does not set it; the two helpers in chat_streaming.py
+    (``signal_shutdown_to_in_flight_streams``,
+    ``drain_in_flight_streams``) set it before calling signal()."""
+
+    def test_default_is_false(self):
+        """A freshly constructed lifecycle has shutdown_signaled=False —
+        the drain loop's between-events check must observe this as
+        "no shutdown yet" and continue draining normally.
+        """
+        lc = _build_lifecycle()
+        assert lc.shutdown_signaled is False
+
+    def test_signal_alone_does_not_set_shutdown_flag(self):
+        """``lifecycle.signal("shutdown")`` updates ``reason`` (when
+        priority allows) and fires the event but does NOT touch
+        ``shutdown_signaled``. The two helpers in chat_streaming.py
+        set the flag explicitly before signaling — so any code calling
+        ``signal()`` directly (e.g. unit tests, future callers) won't
+        accidentally trip the drain escape valve.
+        """
+        lc = _build_lifecycle()
+        lc.signal("shutdown")
+        assert lc.reason == "shutdown"
+        assert lc.shutdown_signaled is False, (
+            "signal() alone must not set shutdown_signaled — only the two "
+            "chat_streaming helpers do, so a unit-test call to signal('shutdown') "
+            "doesn't accidentally trip the drain escape valve."
+        )
+
+    def test_shutdown_after_user_terminated_preserves_user_terminated_reason(self):
+        """The load-bearing SHU-803 priority assertion: when
+        ``user_terminated`` was signaled first and ``shutdown`` arrives
+        later (the SIGTERM-during-drain case), ``reason`` stays
+        ``user_terminated`` because both signals are at priority tier 2.
+        This is by design — the user requested terminate; shutdown
+        shouldn't rewrite the audit trail. But the drain still needs
+        to detect the shutdown; that's what ``shutdown_signaled`` is
+        for, set separately by the two chat_streaming helpers (this
+        test only exercises the priority semantics, not the flag).
+        """
+        lc = _build_lifecycle()
+        first_accepted = lc.signal("user_terminated")
+        second_accepted = lc.signal("shutdown")
+        assert first_accepted is True
+        assert second_accepted is False, (
+            "shutdown after user_terminated must be rejected at the priority "
+            "level — both are tier 2, first-writer-wins. SHU-803 introduces "
+            "the separate ``shutdown_signaled`` flag exactly because of this "
+            "first-writer-wins semantics."
+        )
+        assert lc.reason == "user_terminated"
+
+    def test_flag_can_be_set_directly_without_signal(self):
+        """The two chat_streaming helpers set the flag directly via
+        ``lc.shutdown_signaled = True`` (then call ``lc.signal``).
+        Verifying the flag is writable as a plain attribute — no
+        property, no descriptor, no surprises.
+        """
+        lc = _build_lifecycle()
+        lc.shutdown_signaled = True
+        assert lc.shutdown_signaled is True
+        # Reason untouched by the flag.
+        assert lc.reason is None

--- a/backend/src/tests/unit/services/test_stream_lifecycle.py
+++ b/backend/src/tests/unit/services/test_stream_lifecycle.py
@@ -388,3 +388,103 @@ class TestStreamLifecycleShutdownSignaled:
         assert lc.shutdown_signaled is True
         # Reason untouched by the flag.
         assert lc.reason is None
+
+
+class TestStreamLifecycleIntentionalStopEvent:
+    """SHU-803 follow-up: the dedicated ``intentional_stop_event``
+    drives ``_iter_with_signal_break``'s race so a ``client_disconnected``
+    does not consume the wrapper's one-shot sentinel and leave a later
+    ``user_terminated`` / ``shutdown`` unable to wake a silent provider.
+
+    The invariant the wrapper relies on:
+    - ``client_disconnected`` alone NEVER sets this event.
+    - Any signal that resolves ``self.reason`` to an intentional stop
+      (``user_terminated`` or ``shutdown``) sets it.
+    - Set is idempotent — subsequent intentional signals are no-ops on
+      the already-set event (matches asyncio.Event semantics).
+    """
+
+    def test_default_is_unset(self):
+        lc = _build_lifecycle()
+        assert lc.intentional_stop_event.is_set() is False
+
+    def test_client_disconnected_does_not_set_intentional_stop_event(self):
+        """The load-bearing assertion. If ``client_disconnected`` set
+        this event, the wrapper would consume its sentinel and a later
+        upgrade to ``user_terminated`` / ``shutdown`` could not wake a
+        silent provider — exactly the Codex-flagged regression.
+        """
+        lc = _build_lifecycle()
+        lc.signal("client_disconnected")
+        assert lc.reason == "client_disconnected"
+        assert lc.event.is_set() is True
+        assert lc.intentional_stop_event.is_set() is False
+
+    def test_user_terminated_sets_intentional_stop_event(self):
+        lc = _build_lifecycle()
+        lc.signal("user_terminated")
+        assert lc.reason == "user_terminated"
+        assert lc.intentional_stop_event.is_set() is True
+
+    def test_shutdown_sets_intentional_stop_event(self):
+        lc = _build_lifecycle()
+        lc.signal("shutdown")
+        assert lc.reason == "shutdown"
+        assert lc.intentional_stop_event.is_set() is True
+
+    def test_disconnect_then_user_terminated_sets_intentional_stop_event(self):
+        """The Codex-flagged disconnect-then-stop sequence. The omnibus
+        ``event`` is already set from the disconnect; the dedicated
+        ``intentional_stop_event`` must fire on the LATER
+        ``user_terminated`` so the wrapper's race wakes up.
+        """
+        lc = _build_lifecycle()
+        lc.signal("client_disconnected")
+        assert lc.event.is_set() is True
+        assert lc.intentional_stop_event.is_set() is False
+        # Later intentional stop upgrades reason AND sets the event,
+        # even though the omnibus event was already set from the
+        # disconnect.
+        lc.signal("user_terminated")
+        assert lc.reason == "user_terminated"
+        assert lc.intentional_stop_event.is_set() is True
+
+    def test_disconnect_then_shutdown_sets_intentional_stop_event(self):
+        """Variant of the above — same property, but the intentional
+        stop is the shutdown one (deploy-during-disconnect). The
+        wrapper must wake so the shielded finalize commits before
+        lifespan-drain cancellation propagates.
+        """
+        lc = _build_lifecycle()
+        lc.signal("client_disconnected")
+        assert lc.intentional_stop_event.is_set() is False
+        lc.signal("shutdown")
+        assert lc.reason == "shutdown"
+        assert lc.intentional_stop_event.is_set() is True
+
+    def test_user_terminated_then_shutdown_keeps_event_set(self):
+        """Same-priority signals are first-writer-wins on ``reason``,
+        but the event must remain set regardless. The wrapper's race
+        already consumed its sentinel on the first signal; a later
+        signal of the same priority is informational at this layer.
+        """
+        lc = _build_lifecycle()
+        lc.signal("user_terminated")
+        assert lc.intentional_stop_event.is_set() is True
+        lc.signal("shutdown")
+        # First-writer-wins: reason stays user_terminated.
+        assert lc.reason == "user_terminated"
+        # Event stays set; idempotent set is fine.
+        assert lc.intentional_stop_event.is_set() is True
+
+    def test_signal_returns_accepted_status_unchanged(self):
+        """Adding the intentional_stop_event mechanism MUST NOT change
+        the existing ``signal()`` return contract: True if the reason
+        was accepted (priority higher than current), False otherwise.
+        Existing callers rely on this for log filtering and metrics.
+        """
+        lc = _build_lifecycle()
+        assert lc.signal("client_disconnected") is True  # was None
+        assert lc.signal("user_terminated") is True  # priority upgrade
+        assert lc.signal("shutdown") is False  # same priority, first-wins
+        assert lc.signal("client_disconnected") is False  # priority downgrade

--- a/frontend/src/components/ModernChat.js
+++ b/frontend/src/components/ModernChat.js
@@ -664,7 +664,7 @@ const ModernChat = () => {
     });
   }, []);
 
-  const { handleStreamingResponse, handleRegenerate } = useChatStreaming({
+  const { handleStreamingResponse, handleRegenerate, handleStopStream } = useChatStreaming({
     queryClient,
     setError,
     setStreamingConversationId,
@@ -1277,6 +1277,7 @@ const ModernChat = () => {
     variantSelection,
     onVariantChange: handleVariantChange,
     onRegenerate: handleRegenerate,
+    onStop: handleStopStream,
     onCopy: handleCopyMessage,
     isVariantGroupStreaming,
     parseDocumentHref,

--- a/frontend/src/components/ModernChat.js
+++ b/frontend/src/components/ModernChat.js
@@ -725,6 +725,25 @@ const ModernChat = () => {
 
   const isSendDisabled = isStreamingForSelectedConversation;
 
+  // SHU-803: the Send button morphs into a Stop button while streaming.
+  // `activeStreamingMessage` is any in-flight placeholder with a
+  // captured streamId — handleStopStream broadcasts the user_terminated
+  // stamp to every placeholder sharing that streamId, so for ensemble
+  // mode any one variant suffices as the message argument.
+  const activeStreamingMessage = useMemo(() => {
+    if (!isStreamingForSelectedConversation || !Array.isArray(flattenedMessages)) {
+      return null;
+    }
+    return flattenedMessages.find((m) => m?.isStreaming && m?.streamId) || null;
+  }, [isStreamingForSelectedConversation, flattenedMessages]);
+
+  const handleInputBarStop = useCallback(() => {
+    if (!activeStreamingMessage) {
+      return undefined;
+    }
+    return handleStopStream(activeStreamingMessage);
+  }, [activeStreamingMessage, handleStopStream]);
+
   const {
     visibleMessages: windowMessages,
     expandWindow,
@@ -1277,7 +1296,6 @@ const ModernChat = () => {
     variantSelection,
     onVariantChange: handleVariantChange,
     onRegenerate: handleRegenerate,
-    onStop: handleStopStream,
     onCopy: handleCopyMessage,
     isVariantGroupStreaming,
     parseDocumentHref,
@@ -1346,6 +1364,9 @@ const ModernChat = () => {
     onUploadToPersonalKB: uploadToPersonalKB,
     onRetryPersonalKBFile: retryPersonalKBFile,
     onDismissPersonalKBError: dismissPersonalKBError,
+    isStreaming: isStreamingForSelectedConversation,
+    canStop: Boolean(activeStreamingMessage),
+    onStop: handleInputBarStop,
   };
 
   const pluginPickerDialogProps = {

--- a/frontend/src/components/chat/ModernChat/InputBar.jsx
+++ b/frontend/src/components/chat/ModernChat/InputBar.jsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Chip,
+  CircularProgress,
   IconButton,
   ListItemIcon,
   Menu,
@@ -18,6 +19,7 @@ import {
   AttachFile as AttachmentIcon,
   SmartToy as BotIcon,
   Send as SendIcon,
+  Stop as StopIcon,
   Hub as EnsembleIcon,
   LibraryBooks as LibraryBooksIcon,
 } from '@mui/icons-material';
@@ -59,11 +61,37 @@ const InputBar = React.memo(function InputBar({
   onUploadToPersonalKB,
   onRetryPersonalKBFile,
   onDismissPersonalKBError,
+  // SHU-803: Send button morphs into Stop while the current conversation
+  // has an in-flight stream. `canStop` is false during the ~10-50ms
+  // window after Send before stream_start arrives — disabled state with
+  // "Initializing…" tooltip is more discoverable than no button at all.
+  isStreaming = false,
+  canStop = false,
+  onStop,
   isMobile = false,
 }) {
   const [brainAnchorEl, setBrainAnchorEl] = useState(null);
   const [dragActive, setDragActive] = useState(false);
   const [toast, setToast] = useState(null);
+  const [stopping, setStopping] = useState(false);
+
+  const handleStopClick = useCallback(async () => {
+    if (!onStop || stopping) {
+      return;
+    }
+    setStopping(true);
+    try {
+      await onStop();
+    } finally {
+      setStopping(false);
+    }
+  }, [onStop, stopping]);
+
+  useEffect(() => {
+    if (!isStreaming) {
+      setStopping(false);
+    }
+  }, [isStreaming]);
 
   const dragCounterRef = useRef(0);
   const wasUploadingRef = useRef(false);
@@ -378,8 +406,62 @@ const InputBar = React.memo(function InputBar({
             },
           }}
         />
-        {/* On mobile: icon-only send button. On desktop: full button with text */}
-        {isMobile ? (
+        {/* SHU-803: while streaming, the Send button becomes a Stop
+            button anchored in the same spot. This keeps the control
+            within thumb reach on mobile and at a predictable location
+            on desktop (Send and Stop never coexist — streaming blocks
+            input). We use color="inherit" / a neutral grey background
+            so Stop reads as a secondary action — we don't want users
+            terminating streams as a reflex. */}
+        {isStreaming ? (
+          isMobile ? (
+            <Tooltip title={canStop ? 'Stop generating' : 'Initializing…'}>
+              <span>
+                <IconButton
+                  onClick={handleStopClick}
+                  disabled={!canStop || stopping || !onStop}
+                  sx={{
+                    bgcolor: 'action.selected',
+                    color: 'text.primary',
+                    width: 44,
+                    height: 44,
+                    flexShrink: 0,
+                    '&:hover': {
+                      bgcolor: 'action.hover',
+                    },
+                  }}
+                  aria-label="Stop generating"
+                >
+                  {stopping ? <CircularProgress size={20} color="inherit" /> : <StopIcon />}
+                </IconButton>
+              </span>
+            </Tooltip>
+          ) : (
+            <Tooltip title={canStop ? 'Stop generating' : 'Initializing…'}>
+              <span>
+                <Button
+                  variant="contained"
+                  disableElevation
+                  startIcon={stopping ? <CircularProgress size={16} color="inherit" /> : <StopIcon />}
+                  onClick={handleStopClick}
+                  disabled={!canStop || stopping || !onStop}
+                  aria-label="Stop generating"
+                  sx={{
+                    minWidth: 100,
+                    flexShrink: 0,
+                    bgcolor: 'action.selected',
+                    color: 'text.primary',
+                    '&:hover': {
+                      bgcolor: 'action.hover',
+                    },
+                  }}
+                >
+                  Stop
+                </Button>
+              </span>
+            </Tooltip>
+          )
+        ) : isMobile ? (
           <Tooltip title="Send">
             <span>
               <IconButton

--- a/frontend/src/components/chat/ModernChat/MessageItem.jsx
+++ b/frontend/src/components/chat/ModernChat/MessageItem.jsx
@@ -426,16 +426,21 @@ const MessageItem = React.memo(function MessageItem({
                       <CircularProgress size={12} sx={{ color: theme.palette.secondary.main }} />
                     </Box>
                   )}
-                  {/* SHU-803 AC6/AC7: italic "Stopped by user" caption on
-                      persisted messages whose backend stream_state is
-                      user_terminated or shutdown (server-initiated stop
-                      looks identical from the user's perspective —
-                      partial content, here's what we got). Hidden while
-                      still streaming so the live spinner / Stop button
-                      own the "active" UI; surfaces once the placeholder
-                      flips out of isStreaming (either via SSE
-                      final_message landing or the AC5 optimistic flip
-                      on the terminate POST 202 response). */}
+                  {/* SHU-803 AC6/AC7/AC8: italic stopped-state caption on
+                      persisted messages. Hidden while still streaming so
+                      the live spinner / Stop button own the "active" UI;
+                      surfaces once the placeholder flips out of
+                      isStreaming (either via SSE final_message landing
+                      or the AC5 optimistic flip on the terminate POST
+                      202 response).
+
+                      Caption text branches on attribution: a
+                      user_terminated state reads "Stopped by user"
+                      (true cause), while a shutdown state reads
+                      "Response stopped" — server-initiated stops look
+                      like the same "partial content, here's what we
+                      got" outcome (AC8), but the user didn't trigger
+                      it and "by user" attribution would mislead. */}
                   {!variant.isStreaming &&
                     (variant.message_metadata?.stream_state === 'user_terminated' ||
                       variant.message_metadata?.stream_state === 'shutdown') && (
@@ -449,7 +454,7 @@ const MessageItem = React.memo(function MessageItem({
                           color: timestampColor,
                         }}
                       >
-                        Stopped by user
+                        {variant.message_metadata?.stream_state === 'shutdown' ? 'Response stopped' : 'Stopped by user'}
                       </Typography>
                     )}
                   <Typography

--- a/frontend/src/components/chat/ModernChat/MessageItem.jsx
+++ b/frontend/src/components/chat/ModernChat/MessageItem.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Avatar,
   Box,
@@ -18,6 +18,7 @@ import {
   NavigateBefore as NavigateBeforeIcon,
   NavigateNext as NavigateNextIcon,
   ViewColumn as SideBySideIcon,
+  Stop as StopIcon,
 } from '@mui/icons-material';
 import MessageContent from './MessageContent';
 import UserAvatar from '../../shared/UserAvatar.jsx';
@@ -40,6 +41,7 @@ const MessageItem = React.memo(function MessageItem({
   variantSelection,
   onVariantChange,
   onRegenerate,
+  onStop,
   onCopy,
   isVariantGroupStreaming,
   parseDocumentHref,
@@ -92,6 +94,28 @@ const MessageItem = React.memo(function MessageItem({
   }, [regenerationRequests, parentId]);
 
   const disableRegenerate = message.isStreaming || isVariantGroupStreaming(parentId) || pendingRegenerationForGroup;
+
+  // SHU-803 AC3/AC5: local in-flight state for the Stop POST. While the
+  // POST is open the button shows a spinner + stays disabled so a
+  // double-click can't fire a second terminate request. On
+  // 202 / 410 success the placeholder's ``isStreaming`` flag flips to
+  // false and the Stop button unmounts naturally; on 403 / 5xx the
+  // placeholder stays streaming and the button re-enables for retry.
+  const [stopping, setStopping] = useState(false);
+  const handleStopClick = useCallback(
+    async (variant) => {
+      if (!onStop || stopping || !variant?.streamId) {
+        return;
+      }
+      setStopping(true);
+      try {
+        await onStop(variant);
+      } finally {
+        setStopping(false);
+      }
+    },
+    [onStop, stopping]
+  );
 
   const isUser = message.role === 'user';
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -426,6 +450,32 @@ const MessageItem = React.memo(function MessageItem({
                       <CircularProgress size={12} sx={{ color: theme.palette.secondary.main }} />
                     </Box>
                   )}
+                  {/* SHU-803 AC6/AC7: italic "Stopped by user" caption on
+                      persisted messages whose backend stream_state is
+                      user_terminated or shutdown (server-initiated stop
+                      looks identical from the user's perspective —
+                      partial content, here's what we got). Hidden while
+                      still streaming so the live spinner / Stop button
+                      own the "active" UI; surfaces once the placeholder
+                      flips out of isStreaming (either via SSE
+                      final_message landing or the AC5 optimistic flip
+                      on the terminate POST 202 response). */}
+                  {!variant.isStreaming &&
+                    (variant.message_metadata?.stream_state === 'user_terminated' ||
+                      variant.message_metadata?.stream_state === 'shutdown') && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          mt: 0.5,
+                          display: 'block',
+                          fontStyle: 'italic',
+                          opacity: 0.7,
+                          color: timestampColor,
+                        }}
+                      >
+                        Stopped by user
+                      </Typography>
+                    )}
                   <Typography
                     variant="caption"
                     sx={{
@@ -468,6 +518,44 @@ const MessageItem = React.memo(function MessageItem({
                       </span>
                     </Box>
                   </Typography>
+                  {/* SHU-803 AC2/AC3/AC4/AC5/AC8: Stop button toolbar.
+                      Discrete action below the bubble's content for an
+                      in-flight stream. Disabled (rather than hidden)
+                      while ``stream_start`` hasn't yet landed and
+                      ``variant.streamId`` is still missing — that
+                      window is ~10–50ms and the disabled state with
+                      tooltip is more discoverable than an invisible
+                      button. Once SHU-802's terminate endpoint returns
+                      202 (or 410 STREAM_NOT_ACTIVE — treated as
+                      success per AC5), the placeholder flips
+                      ``isStreaming=false`` and this whole block
+                      unmounts. */}
+                  {variant.isStreaming && (
+                    <Box sx={{ mt: 1, display: 'flex', justifyContent: 'flex-start' }}>
+                      <Tooltip title={variant.streamId ? 'Stop generating' : 'Initializing…'} arrow>
+                        <span>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="inherit"
+                            startIcon={
+                              stopping ? (
+                                <CircularProgress size={12} sx={{ color: 'inherit' }} />
+                              ) : (
+                                <StopIcon fontSize="small" />
+                              )
+                            }
+                            onClick={() => handleStopClick(variant)}
+                            disabled={stopping || !variant.streamId || !onStop}
+                            aria-label="Stop generating"
+                            sx={{ textTransform: 'none', minWidth: 0, py: 0.25, px: 1 }}
+                          >
+                            Stop
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    </Box>
+                  )}
                 </Paper>
               );
             })}

--- a/frontend/src/components/chat/ModernChat/MessageItem.jsx
+++ b/frontend/src/components/chat/ModernChat/MessageItem.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import {
   Avatar,
   Box,
@@ -18,7 +18,6 @@ import {
   NavigateBefore as NavigateBeforeIcon,
   NavigateNext as NavigateNextIcon,
   ViewColumn as SideBySideIcon,
-  Stop as StopIcon,
 } from '@mui/icons-material';
 import MessageContent from './MessageContent';
 import UserAvatar from '../../shared/UserAvatar.jsx';
@@ -41,7 +40,6 @@ const MessageItem = React.memo(function MessageItem({
   variantSelection,
   onVariantChange,
   onRegenerate,
-  onStop,
   onCopy,
   isVariantGroupStreaming,
   parseDocumentHref,
@@ -94,28 +92,6 @@ const MessageItem = React.memo(function MessageItem({
   }, [regenerationRequests, parentId]);
 
   const disableRegenerate = message.isStreaming || isVariantGroupStreaming(parentId) || pendingRegenerationForGroup;
-
-  // SHU-803 AC3/AC5: local in-flight state for the Stop POST. While the
-  // POST is open the button shows a spinner + stays disabled so a
-  // double-click can't fire a second terminate request. On
-  // 202 / 410 success the placeholder's ``isStreaming`` flag flips to
-  // false and the Stop button unmounts naturally; on 403 / 5xx the
-  // placeholder stays streaming and the button re-enables for retry.
-  const [stopping, setStopping] = useState(false);
-  const handleStopClick = useCallback(
-    async (variant) => {
-      if (!onStop || stopping || !variant?.streamId) {
-        return;
-      }
-      setStopping(true);
-      try {
-        await onStop(variant);
-      } finally {
-        setStopping(false);
-      }
-    },
-    [onStop, stopping]
-  );
 
   const isUser = message.role === 'user';
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -518,44 +494,6 @@ const MessageItem = React.memo(function MessageItem({
                       </span>
                     </Box>
                   </Typography>
-                  {/* SHU-803 AC2/AC3/AC4/AC5/AC8: Stop button toolbar.
-                      Discrete action below the bubble's content for an
-                      in-flight stream. Disabled (rather than hidden)
-                      while ``stream_start`` hasn't yet landed and
-                      ``variant.streamId`` is still missing — that
-                      window is ~10–50ms and the disabled state with
-                      tooltip is more discoverable than an invisible
-                      button. Once SHU-802's terminate endpoint returns
-                      202 (or 410 STREAM_NOT_ACTIVE — treated as
-                      success per AC5), the placeholder flips
-                      ``isStreaming=false`` and this whole block
-                      unmounts. */}
-                  {variant.isStreaming && (
-                    <Box sx={{ mt: 1, display: 'flex', justifyContent: 'flex-start' }}>
-                      <Tooltip title={variant.streamId ? 'Stop generating' : 'Initializing…'} arrow>
-                        <span>
-                          <Button
-                            size="small"
-                            variant="outlined"
-                            color="inherit"
-                            startIcon={
-                              stopping ? (
-                                <CircularProgress size={12} sx={{ color: 'inherit' }} />
-                              ) : (
-                                <StopIcon fontSize="small" />
-                              )
-                            }
-                            onClick={() => handleStopClick(variant)}
-                            disabled={stopping || !variant.streamId || !onStop}
-                            aria-label="Stop generating"
-                            sx={{ textTransform: 'none', minWidth: 0, py: 0.25, px: 1 }}
-                          >
-                            Stop
-                          </Button>
-                        </span>
-                      </Tooltip>
-                    </Box>
-                  )}
                 </Paper>
               );
             })}

--- a/frontend/src/components/chat/ModernChat/MessageList.jsx
+++ b/frontend/src/components/chat/ModernChat/MessageList.jsx
@@ -18,6 +18,7 @@ const MessageList = React.memo(
       onToggleSideBySide,
       onVariantChange,
       onRegenerate,
+      onStop,
       onCopy,
       isVariantGroupStreaming,
       parseDocumentHref,
@@ -200,6 +201,7 @@ const MessageList = React.memo(
                   variantSelection={variantSelection}
                   onVariantChange={onVariantChange}
                   onRegenerate={onRegenerate}
+                  onStop={onStop}
                   onCopy={onCopy}
                   isVariantGroupStreaming={isVariantGroupStreaming}
                   parseDocumentHref={parseDocumentHref}

--- a/frontend/src/components/chat/ModernChat/MessageList.jsx
+++ b/frontend/src/components/chat/ModernChat/MessageList.jsx
@@ -18,7 +18,6 @@ const MessageList = React.memo(
       onToggleSideBySide,
       onVariantChange,
       onRegenerate,
-      onStop,
       onCopy,
       isVariantGroupStreaming,
       parseDocumentHref,
@@ -201,7 +200,6 @@ const MessageList = React.memo(
                   variantSelection={variantSelection}
                   onVariantChange={onVariantChange}
                   onRegenerate={onRegenerate}
-                  onStop={onStop}
                   onCopy={onCopy}
                   isVariantGroupStreaming={isVariantGroupStreaming}
                   parseDocumentHref={parseDocumentHref}

--- a/frontend/src/components/chat/ModernChat/__tests__/InputBar.test.jsx
+++ b/frontend/src/components/chat/ModernChat/__tests__/InputBar.test.jsx
@@ -1,0 +1,160 @@
+/**
+ * SHU-803 Vitest coverage for InputBar — Send <-> Stop swap during
+ * streaming. The Stop button replaces the Send button (same screen
+ * position) while a stream is in flight; this keeps the action within
+ * thumb reach on mobile and at a predictable location on desktop
+ * regardless of how far the streaming bubble has scrolled.
+ */
+
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { vi } from 'vitest';
+import InputBar from '../InputBar';
+
+// BrainIcon/BrainPopover render heavy theme-driven decoration that
+// isn't part of the swap under test; mock them out to keep the test
+// fast and focused.
+vi.mock('../BrainIcon', () => ({
+  default: () => <div data-testid="brain-icon" />,
+}));
+vi.mock('../BrainPopover', () => ({
+  default: () => null,
+}));
+
+const TestWrapper = ({ children }) => {
+  const theme = createTheme();
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};
+TestWrapper.displayName = 'InputBarTestThemeWrapper';
+
+const baseProps = (overrides = {}) => ({
+  pendingAttachments: [],
+  onRemoveAttachment: vi.fn(),
+  attachmentChipStyles: {},
+  inputMessage: '',
+  onInputChange: vi.fn(),
+  onKeyDown: vi.fn(),
+  onSend: vi.fn(),
+  sendDisabled: false,
+  inputRef: { current: null },
+  fileInputRef: { current: null },
+  onFileSelected: vi.fn(),
+  plusAnchorEl: null,
+  onPlusOpen: vi.fn(),
+  onPlusClose: vi.fn(),
+  isUploadingAttachment: false,
+  onOpenPluginPicker: vi.fn(),
+  pluginsEnabled: false,
+  onUploadClick: vi.fn(),
+  onOpenKBPicker: vi.fn(),
+  selectedKBs: [],
+  onRemoveKB: vi.fn(),
+  onSelectEnsembleMode: undefined,
+  isEnsembleModeActive: false,
+  ensembleModeLabel: null,
+  onClearEnsembleMode: undefined,
+  ensembleMenuDisabled: false,
+  personalKB: null,
+  personalKBLoading: false,
+  personalKBUploading: false,
+  personalKBErrors: [],
+  onUploadToPersonalKB: vi.fn(),
+  onRetryPersonalKBFile: vi.fn(),
+  onDismissPersonalKBError: vi.fn(),
+  isStreaming: false,
+  canStop: false,
+  onStop: undefined,
+  isMobile: false,
+  ...overrides,
+});
+
+describe('InputBar — SHU-803 Send/Stop swap', () => {
+  it('shows the Send button (and no Stop button) when not streaming', () => {
+    render(
+      <TestWrapper>
+        <InputBar {...baseProps({ inputMessage: 'hi' })} />
+      </TestWrapper>
+    );
+    expect(screen.getByRole('button', { name: /^send/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /stop generating/i })).toBeNull();
+  });
+
+  it('replaces Send with Stop while streaming', () => {
+    render(
+      <TestWrapper>
+        <InputBar {...baseProps({ isStreaming: true, canStop: true, onStop: vi.fn() })} />
+      </TestWrapper>
+    );
+    expect(screen.queryByRole('button', { name: /^send/i })).toBeNull();
+    const stopButton = screen.getByRole('button', { name: /stop generating/i });
+    expect(stopButton).toBeInTheDocument();
+    expect(stopButton).not.toBeDisabled();
+  });
+
+  it('disables Stop while streaming but stream_id has not yet arrived', () => {
+    // canStop=false maps to the ~10-50ms window between Send and
+    // stream_start. We keep the button visible (with "Initializing…"
+    // tooltip) rather than hiding it so the user has consistent feedback.
+    render(
+      <TestWrapper>
+        <InputBar {...baseProps({ isStreaming: true, canStop: false, onStop: vi.fn() })} />
+      </TestWrapper>
+    );
+    const stopButton = screen.getByRole('button', { name: /stop generating/i });
+    expect(stopButton).toBeDisabled();
+  });
+
+  it('clicking Stop invokes onStop', async () => {
+    const onStop = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TestWrapper>
+        <InputBar {...baseProps({ isStreaming: true, canStop: true, onStop })} />
+      </TestWrapper>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /stop generating/i }));
+    await waitFor(() => expect(onStop).toHaveBeenCalledTimes(1));
+  });
+
+  it('double-click is debounced via the local stopping state', async () => {
+    let resolveStop;
+    const onStop = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveStop = resolve;
+        })
+    );
+    render(
+      <TestWrapper>
+        <InputBar {...baseProps({ isStreaming: true, canStop: true, onStop })} />
+      </TestWrapper>
+    );
+    const stopButton = screen.getByRole('button', { name: /stop generating/i });
+    fireEvent.click(stopButton);
+    fireEvent.click(stopButton);
+    await waitFor(() => expect(stopButton).toBeDisabled());
+    expect(onStop).toHaveBeenCalledTimes(1);
+    resolveStop?.();
+  });
+
+  it('mobile variant: Stop renders as an icon-only IconButton', () => {
+    render(
+      <TestWrapper>
+        <InputBar {...baseProps({ isStreaming: true, canStop: true, onStop: vi.fn(), isMobile: true })} />
+      </TestWrapper>
+    );
+    const stopButton = screen.getByRole('button', { name: /stop generating/i });
+    expect(stopButton).toBeInTheDocument();
+    // The mobile variant has no visible "Stop" label text — just the icon.
+    expect(within(stopButton).queryByText('Stop')).toBeNull();
+  });
+
+  it('Stop is disabled when no onStop handler is wired', () => {
+    render(
+      <TestWrapper>
+        <InputBar {...baseProps({ isStreaming: true, canStop: true, onStop: undefined })} />
+      </TestWrapper>
+    );
+    expect(screen.getByRole('button', { name: /stop generating/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/chat/ModernChat/__tests__/MessageItem.test.jsx
+++ b/frontend/src/components/chat/ModernChat/__tests__/MessageItem.test.jsx
@@ -1,21 +1,19 @@
 /**
- * SHU-803 Vitest coverage for MessageItem — Stop-button toolbar and
- * "Stopped by user" caption behavior.
+ * SHU-803 Vitest coverage for MessageItem — "Stopped by user" caption.
  *
- * The interesting cases:
- * - Stop button renders only while ``variant.isStreaming``.
- * - Stop button is disabled (not hidden) when ``variant.streamId`` is
- *   missing — that's the ~10-50ms window after the placeholder lands
- *   but before ``stream_start`` arrives (AC8).
- * - Click fires ``onStop(variant)`` and shows in-flight state (AC3).
- * - Double-click is debounced via the local ``stopping`` state.
- * - The "Stopped by user" caption renders for non-streaming messages
- *   whose ``message_metadata.stream_state`` is ``user_terminated`` or
+ * The Stop button itself lives in the input bar (see InputBar.test.jsx)
+ * so it stays visible regardless of scroll position. MessageItem only
+ * owns the persisted "Stopped by user" caption that surfaces once the
+ * placeholder flips out of isStreaming.
+ *
+ * The interesting cases here:
+ * - The caption renders for non-streaming messages whose
+ *   ``message_metadata.stream_state`` is ``user_terminated`` or
  *   ``shutdown`` (AC6), and is ABSENT for ``complete`` /
  *   ``client_disconnected`` (AC7).
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { vi } from 'vitest';
@@ -74,100 +72,6 @@ const makeAssistantMessage = (overrides = {}) => ({
   ...overrides,
 });
 
-describe('MessageItem — SHU-803 Stop button (AC2/3/4/5/8)', () => {
-  it('does not render the Stop button for a non-streaming message', () => {
-    const message = makeAssistantMessage({ isStreaming: false });
-    render(
-      <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
-      </TestWrapper>
-    );
-    expect(screen.queryByRole('button', { name: /stop generating/i })).toBeNull();
-  });
-
-  it('renders the Stop button while streaming with a captured stream_id', () => {
-    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
-    render(
-      <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
-      </TestWrapper>
-    );
-    const button = screen.getByRole('button', { name: /stop generating/i });
-    expect(button).toBeInTheDocument();
-    expect(button).not.toBeDisabled();
-  });
-
-  it('AC8: Stop button is disabled (not hidden) while streaming without a stream_id', () => {
-    // The ~10-50ms window between placeholder creation and `stream_start`.
-    // Disabled state with the "Initializing…" tooltip is more
-    // discoverable than an invisible button per the SHU-803 plan
-    // Decisions Log.
-    const message = makeAssistantMessage({ isStreaming: true, streamId: undefined });
-    render(
-      <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
-      </TestWrapper>
-    );
-    const button = screen.getByRole('button', { name: /stop generating/i });
-    expect(button).toBeInTheDocument();
-    expect(button).toBeDisabled();
-  });
-
-  it('AC4: clicking Stop calls onStop with the variant', async () => {
-    const onStop = vi.fn().mockResolvedValue(undefined);
-    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
-    render(
-      <TestWrapper>
-        <MessageItem message={message} onStop={onStop} {...baseProps()} />
-      </TestWrapper>
-    );
-    const button = screen.getByRole('button', { name: /stop generating/i });
-    fireEvent.click(button);
-    await waitFor(() => expect(onStop).toHaveBeenCalledTimes(1));
-    // The variant object (a clone of the message) was passed.
-    expect(onStop).toHaveBeenCalledWith(expect.objectContaining({ id: 'msg-1', streamId: 'stream-xyz' }));
-  });
-
-  it('AC3: double-click is debounced via the local stopping state', async () => {
-    // Hold the promise open so the button stays in `stopping=true`
-    // for the duration of the test. Two rapid clicks should fire only
-    // one onStop call.
-    let resolveStop;
-    const onStop = vi.fn(
-      () =>
-        new Promise((resolve) => {
-          resolveStop = resolve;
-        })
-    );
-    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
-    render(
-      <TestWrapper>
-        <MessageItem message={message} onStop={onStop} {...baseProps()} />
-      </TestWrapper>
-    );
-    const button = screen.getByRole('button', { name: /stop generating/i });
-    fireEvent.click(button);
-    fireEvent.click(button);
-    // Wait for the first click's state update to settle.
-    await waitFor(() => expect(button).toBeDisabled());
-    expect(onStop).toHaveBeenCalledTimes(1);
-    // Release the promise so the component doesn't leak.
-    resolveStop?.();
-  });
-
-  it('does not call onStop when onStop is not provided', () => {
-    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
-    render(
-      <TestWrapper>
-        <MessageItem message={message} onStop={undefined} {...baseProps()} />
-      </TestWrapper>
-    );
-    const button = screen.getByRole('button', { name: /stop generating/i });
-    // Disabled when no onStop handler — defensive against integration regressions.
-    expect(button).toBeDisabled();
-  });
-});
-
 describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
   it('AC6: renders the caption for stream_state="user_terminated"', () => {
     const message = makeAssistantMessage({
@@ -177,7 +81,7 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
     });
     render(
       <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+        <MessageItem message={message} {...baseProps()} />
       </TestWrapper>
     );
     expect(screen.getByText('Stopped by user')).toBeInTheDocument();
@@ -193,7 +97,7 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
     });
     render(
       <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+        <MessageItem message={message} {...baseProps()} />
       </TestWrapper>
     );
     expect(screen.getByText('Stopped by user')).toBeInTheDocument();
@@ -206,7 +110,7 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
     });
     render(
       <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+        <MessageItem message={message} {...baseProps()} />
       </TestWrapper>
     );
     expect(screen.queryByText('Stopped by user')).toBeNull();
@@ -219,17 +123,17 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
     });
     render(
       <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+        <MessageItem message={message} {...baseProps()} />
       </TestWrapper>
     );
     expect(screen.queryByText('Stopped by user')).toBeNull();
   });
 
   it('no caption while the message is still streaming (live spinner owns the UI)', () => {
-    // While streaming, the caption is suppressed — the Stop button and
-    // spinner are the active UI. The caption only surfaces once the
-    // placeholder flips isStreaming=false (either via final_message or
-    // the AC5 optimistic flip).
+    // While streaming, the caption is suppressed — the live spinner is
+    // the active UI. The caption only surfaces once the placeholder
+    // flips isStreaming=false (either via final_message or the AC5
+    // optimistic flip).
     const message = makeAssistantMessage({
       isStreaming: true,
       streamId: 'stream-xyz',
@@ -237,7 +141,7 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
     });
     render(
       <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+        <MessageItem message={message} {...baseProps()} />
       </TestWrapper>
     );
     expect(screen.queryByText('Stopped by user')).toBeNull();
@@ -250,7 +154,7 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
     });
     render(
       <TestWrapper>
-        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+        <MessageItem message={message} {...baseProps()} />
       </TestWrapper>
     );
     expect(screen.queryByText('Stopped by user')).toBeNull();

--- a/frontend/src/components/chat/ModernChat/__tests__/MessageItem.test.jsx
+++ b/frontend/src/components/chat/ModernChat/__tests__/MessageItem.test.jsx
@@ -1,0 +1,258 @@
+/**
+ * SHU-803 Vitest coverage for MessageItem — Stop-button toolbar and
+ * "Stopped by user" caption behavior.
+ *
+ * The interesting cases:
+ * - Stop button renders only while ``variant.isStreaming``.
+ * - Stop button is disabled (not hidden) when ``variant.streamId`` is
+ *   missing — that's the ~10-50ms window after the placeholder lands
+ *   but before ``stream_start`` arrives (AC8).
+ * - Click fires ``onStop(variant)`` and shows in-flight state (AC3).
+ * - Double-click is debounced via the local ``stopping`` state.
+ * - The "Stopped by user" caption renders for non-streaming messages
+ *   whose ``message_metadata.stream_state`` is ``user_terminated`` or
+ *   ``shutdown`` (AC6), and is ABSENT for ``complete`` /
+ *   ``client_disconnected`` (AC7).
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { vi } from 'vitest';
+import MessageItem from '../MessageItem';
+
+// MessageContent makes its own renderer calls; stub it out so we focus
+// on the surrounding chrome under test here.
+vi.mock('../MessageContent', () => ({
+  default: ({ message }) => <div data-testid="message-content">{message?.content ?? ''}</div>,
+}));
+
+vi.mock('../../shared/UserAvatar.jsx', () => ({
+  default: () => <div data-testid="user-avatar" />,
+}));
+
+const TestWrapper = ({ children }) => {
+  const theme = createTheme();
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};
+
+const baseProps = (overrides = {}) => ({
+  user: { id: 'test-user', email: 'test@example.com' },
+  theme: createTheme(),
+  chatStyles: {
+    userBubbleBg: '#fff',
+    userBubbleText: '#000',
+    assistantBubbleBg: '#eee',
+    assistantBubbleBorder: '1px solid #ccc',
+    assistantLinkColor: '#1976d2',
+    isDarkMode: false,
+  },
+  attachmentChipStyles: {},
+  variantGroups: {},
+  variantSelection: {},
+  onVariantChange: vi.fn(),
+  onRegenerate: vi.fn(),
+  onCopy: vi.fn(),
+  isVariantGroupStreaming: () => false,
+  parseDocumentHref: () => null,
+  onOpenDocument: vi.fn(),
+  fallbackModelConfig: null,
+  regenerationRequests: new Map(),
+  onToggleReasoning: vi.fn(),
+  ...overrides,
+});
+
+const makeAssistantMessage = (overrides = {}) => ({
+  id: 'msg-1',
+  conversation_id: 'conv-1',
+  role: 'assistant',
+  content: 'hello world',
+  created_at: '2026-05-20T17:00:00Z',
+  parent_message_id: null,
+  variant_index: 0,
+  message_metadata: {},
+  ...overrides,
+});
+
+describe('MessageItem — SHU-803 Stop button (AC2/3/4/5/8)', () => {
+  it('does not render the Stop button for a non-streaming message', () => {
+    const message = makeAssistantMessage({ isStreaming: false });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    expect(screen.queryByRole('button', { name: /stop generating/i })).toBeNull();
+  });
+
+  it('renders the Stop button while streaming with a captured stream_id', () => {
+    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    const button = screen.getByRole('button', { name: /stop generating/i });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
+
+  it('AC8: Stop button is disabled (not hidden) while streaming without a stream_id', () => {
+    // The ~10-50ms window between placeholder creation and `stream_start`.
+    // Disabled state with the "Initializing…" tooltip is more
+    // discoverable than an invisible button per the SHU-803 plan
+    // Decisions Log.
+    const message = makeAssistantMessage({ isStreaming: true, streamId: undefined });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    const button = screen.getByRole('button', { name: /stop generating/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it('AC4: clicking Stop calls onStop with the variant', async () => {
+    const onStop = vi.fn().mockResolvedValue(undefined);
+    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={onStop} {...baseProps()} />
+      </TestWrapper>
+    );
+    const button = screen.getByRole('button', { name: /stop generating/i });
+    fireEvent.click(button);
+    await waitFor(() => expect(onStop).toHaveBeenCalledTimes(1));
+    // The variant object (a clone of the message) was passed.
+    expect(onStop).toHaveBeenCalledWith(expect.objectContaining({ id: 'msg-1', streamId: 'stream-xyz' }));
+  });
+
+  it('AC3: double-click is debounced via the local stopping state', async () => {
+    // Hold the promise open so the button stays in `stopping=true`
+    // for the duration of the test. Two rapid clicks should fire only
+    // one onStop call.
+    let resolveStop;
+    const onStop = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveStop = resolve;
+        })
+    );
+    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={onStop} {...baseProps()} />
+      </TestWrapper>
+    );
+    const button = screen.getByRole('button', { name: /stop generating/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    // Wait for the first click's state update to settle.
+    await waitFor(() => expect(button).toBeDisabled());
+    expect(onStop).toHaveBeenCalledTimes(1);
+    // Release the promise so the component doesn't leak.
+    resolveStop?.();
+  });
+
+  it('does not call onStop when onStop is not provided', () => {
+    const message = makeAssistantMessage({ isStreaming: true, streamId: 'stream-xyz' });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={undefined} {...baseProps()} />
+      </TestWrapper>
+    );
+    const button = screen.getByRole('button', { name: /stop generating/i });
+    // Disabled when no onStop handler — defensive against integration regressions.
+    expect(button).toBeDisabled();
+  });
+});
+
+describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
+  it('AC6: renders the caption for stream_state="user_terminated"', () => {
+    const message = makeAssistantMessage({
+      isStreaming: false,
+      content: 'partial answer',
+      message_metadata: { stream_state: 'user_terminated' },
+    });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    expect(screen.getByText('Stopped by user')).toBeInTheDocument();
+  });
+
+  it('AC6: renders the caption for stream_state="shutdown" (server-initiated)', () => {
+    // Per AC6: server-initiated stop looks identical to user-initiated
+    // from the reader's perspective — partial content, here's what we got.
+    const message = makeAssistantMessage({
+      isStreaming: false,
+      content: 'partial answer cut by shutdown',
+      message_metadata: { stream_state: 'shutdown' },
+    });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    expect(screen.getByText('Stopped by user')).toBeInTheDocument();
+  });
+
+  it('AC7: no caption for stream_state="complete"', () => {
+    const message = makeAssistantMessage({
+      isStreaming: false,
+      message_metadata: { stream_state: 'complete' },
+    });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    expect(screen.queryByText('Stopped by user')).toBeNull();
+  });
+
+  it('AC7: no caption for stream_state="client_disconnected" (whole point of disconnect-survival)', () => {
+    const message = makeAssistantMessage({
+      isStreaming: false,
+      message_metadata: { stream_state: 'client_disconnected' },
+    });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    expect(screen.queryByText('Stopped by user')).toBeNull();
+  });
+
+  it('no caption while the message is still streaming (live spinner owns the UI)', () => {
+    // While streaming, the caption is suppressed — the Stop button and
+    // spinner are the active UI. The caption only surfaces once the
+    // placeholder flips isStreaming=false (either via final_message or
+    // the AC5 optimistic flip).
+    const message = makeAssistantMessage({
+      isStreaming: true,
+      streamId: 'stream-xyz',
+      message_metadata: { stream_state: 'user_terminated' },
+    });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    expect(screen.queryByText('Stopped by user')).toBeNull();
+  });
+
+  it('no caption when message_metadata is null / undefined (e.g. legacy or user messages)', () => {
+    const message = makeAssistantMessage({
+      isStreaming: false,
+      message_metadata: null,
+    });
+    render(
+      <TestWrapper>
+        <MessageItem message={message} onStop={vi.fn()} {...baseProps()} />
+      </TestWrapper>
+    );
+    expect(screen.queryByText('Stopped by user')).toBeNull();
+  });
+});

--- a/frontend/src/components/chat/ModernChat/__tests__/MessageItem.test.jsx
+++ b/frontend/src/components/chat/ModernChat/__tests__/MessageItem.test.jsx
@@ -1,16 +1,20 @@
 /**
- * SHU-803 Vitest coverage for MessageItem — "Stopped by user" caption.
+ * SHU-803 Vitest coverage for MessageItem — stopped-state caption.
  *
  * The Stop button itself lives in the input bar (see InputBar.test.jsx)
- * so it stays visible regardless of scroll position. MessageItem only
- * owns the persisted "Stopped by user" caption that surfaces once the
- * placeholder flips out of isStreaming.
+ * so it stays visible regardless of scroll position. MessageItem owns
+ * the persisted stopped-state caption that surfaces once the placeholder
+ * flips out of isStreaming.
  *
  * The interesting cases here:
  * - The caption renders for non-streaming messages whose
  *   ``message_metadata.stream_state`` is ``user_terminated`` or
- *   ``shutdown`` (AC6), and is ABSENT for ``complete`` /
+ *   ``shutdown`` (AC6/AC8), and is ABSENT for ``complete`` /
  *   ``client_disconnected`` (AC7).
+ * - Caption text branches by attribution: ``user_terminated`` reads
+ *   "Stopped by user" (true cause); ``shutdown`` reads "Response
+ *   stopped" since the user didn't trigger it and "by user" would
+ *   mislead (AC8).
  */
 
 import { render, screen } from '@testing-library/react';
@@ -72,7 +76,7 @@ const makeAssistantMessage = (overrides = {}) => ({
   ...overrides,
 });
 
-describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
+describe('MessageItem — SHU-803 stopped-state caption (AC6/AC7/AC8)', () => {
   it('AC6: renders the caption for stream_state="user_terminated"', () => {
     const message = makeAssistantMessage({
       isStreaming: false,
@@ -87,9 +91,11 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
     expect(screen.getByText('Stopped by user')).toBeInTheDocument();
   });
 
-  it('AC6: renders the caption for stream_state="shutdown" (server-initiated)', () => {
-    // Per AC6: server-initiated stop looks identical to user-initiated
-    // from the reader's perspective — partial content, here's what we got.
+  it('AC8: renders "Response stopped" (NOT "Stopped by user") for stream_state="shutdown"', () => {
+    // Per AC8 — server-initiated stop has the same partial-content
+    // outcome from the reader's perspective, but the user didn't
+    // trigger it. Attributing "by user" would mislead. Caption reads
+    // "Response stopped" so attribution stays accurate.
     const message = makeAssistantMessage({
       isStreaming: false,
       content: 'partial answer cut by shutdown',
@@ -100,7 +106,10 @@ describe('MessageItem — SHU-803 "Stopped by user" caption (AC6/AC7)', () => {
         <MessageItem message={message} {...baseProps()} />
       </TestWrapper>
     );
-    expect(screen.getByText('Stopped by user')).toBeInTheDocument();
+    expect(screen.getByText('Response stopped')).toBeInTheDocument();
+    // Critical attribution guard: must NOT show the user-attributed copy
+    // for a server-initiated stop.
+    expect(screen.queryByText('Stopped by user')).toBeNull();
   });
 
   it('AC7: no caption for stream_state="complete"', () => {

--- a/frontend/src/components/chat/ModernChat/hooks/__tests__/useChatStreaming.test.js
+++ b/frontend/src/components/chat/ModernChat/hooks/__tests__/useChatStreaming.test.js
@@ -3,12 +3,22 @@
  * adds (stream_start parsing + stream_id stamping + handleStopStream).
  *
  * The hook depends on a query client, an axios chat API, a slew of
- * sub-hooks, and an SSE reader. Rather than mock every dependency end-to-
- * end (which would test the mocks instead of the code), this suite
- * targets the handleStopStream callback in isolation against a real
- * QueryClient. The stream_start parsing inside the SSE iteration is
- * covered by the SHU-803 backend integration suite end-to-end; here we
- * pin the Stop-button callback semantics that AC4/AC5 specify.
+ * sub-hooks, and an SSE reader. Two surfaces are exercised here:
+ *
+ *   - **handleStopStream callback semantics (AC4/AC5)**: pinned in
+ *     isolation against a real QueryClient with chatAPI.terminateStream
+ *     mocked.
+ *   - **stream_start SSE parsing (AC1)**: exercised end-to-end through
+ *     `handleStreamingResponse` with a controllable mock SSE reader.
+ *     Pre-seeds the cache with a placeholder, feeds a stream_start
+ *     event, asserts the streamId gets stamped on the placeholder so
+ *     the InputBar's Stop-button lookup
+ *     (``flattenedMessages.find(m => m.isStreaming && m.streamId)``)
+ *     picks it up.
+ *
+ * The backend integration suite proves the server-side SSE event
+ * shape; this file proves the React client consumes it correctly —
+ * the bar AC11 specifically calls out.
  */
 
 import { renderHook, act } from '@testing-library/react';
@@ -20,6 +30,7 @@ import { chatAPI } from '../../../../../services/api';
 vi.mock('../../../../../services/api', () => ({
   chatAPI: {
     terminateStream: vi.fn(),
+    streamMessage: vi.fn(),
   },
   // chatCache.js imports this — without it, getMessagesFromCache
   // throws and every setQueryData inside the hook explodes.
@@ -281,6 +292,118 @@ describe('useChatStreaming.handleStopStream (SHU-803 AC4/AC5)', () => {
     expect(chatAPI.terminateStream).not.toHaveBeenCalled();
   });
 
+  it('does not clear global streaming state when this hook never owned it', async () => {
+    // SHU-803 follow-up (Codex review): handleStopStream's optimistic
+    // global-state clear (setStreamingConversationId(null) +
+    // setStreamingStarted(false)) is ownership-guarded via the
+    // hook-internal streamingOwnerRef. In this test, we never call
+    // handleStreamingResponse first — so the ref stays null and a
+    // direct handleStopStream call must NOT touch the global setters,
+    // even though the terminate POST itself succeeded and the cache
+    // optimistic update fires.
+    //
+    // Real-world failure this guards against: user stops stream A,
+    // immediately starts stream B (which takes ownership and sets
+    // streamingConversationId=B). A straggling stale handleStopStream
+    // for A (or A's [DONE] / abort / error event) would unconditionally
+    // null out B's state and the InputBar would briefly flip to Send
+    // while B is still streaming.
+    chatAPI.terminateStream.mockResolvedValueOnce({ status: 202 });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient);
+
+    const setStreamingConversationId = vi.fn();
+    const setStreamingStarted = vi.fn();
+    const { result } = renderUseChatStreaming(queryClient, {
+      setStreamingConversationId,
+      setStreamingStarted,
+    });
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    // Terminate fired AND the cache optimistic update applied —
+    // the guard only protects the global state setters, not the
+    // user-visible "Stopped by user" stamp on the placeholder.
+    expect(chatAPI.terminateStream).toHaveBeenCalledWith(STREAM_ID);
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache[0].message_metadata.stream_state).toBe('user_terminated');
+
+    // Critical assertion: the global setters were NEVER called with
+    // the clear values. Since the hook never claimed ownership of the
+    // global state in this test (no handleStreamingResponse), the
+    // guard correctly skipped the clear path.
+    expect(setStreamingConversationId).not.toHaveBeenCalledWith(null);
+    expect(setStreamingStarted).not.toHaveBeenCalledWith(false);
+  });
+
+  it('clears "Thinking…" content when Stop fires before any content_delta arrived', async () => {
+    // SHU-803 follow-up: pre-fix, a Stop click before the first
+    // content_delta left the bubble showing "Thinking…" alongside the
+    // "Stopped by user" caption for the entire backend drain window
+    // (up to ~90s on OpenRouter). The two messages contradict each
+    // other — the model isn't thinking, it was stopped. Fix wipes the
+    // PLACEHOLDER_THINKING content in the optimistic update so the
+    // bubble shows just the caption + timestamp, then the backend's
+    // final_message replaces it with whatever partial content was
+    // captured (often empty for a pre-delta stop).
+    chatAPI.terminateStream.mockResolvedValueOnce({ status: 202 });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient);
+    // Confirm the seeded placeholder uses the load-bearing content
+    // value — guards against a future refactor that changes the
+    // placeholder copy and silently invalidates the test.
+    expect(getMessagesFromQueryCache(queryClient, CONVERSATION_ID)[0].content).toBe('Thinking…');
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache[0].content).toBe('');
+    expect(cache[0].message_metadata.stream_state).toBe('user_terminated');
+  });
+
+  it('preserves real partial content when Stop fires after content_delta arrived', async () => {
+    // Symmetric guard: the "clear PLACEHOLDER_THINKING" fix MUST NOT
+    // wipe real partial content. If the user clicked Stop after a
+    // chunk of "Once upon a time…" streamed in, that content is the
+    // most useful artifact of the interrupted exchange and must
+    // survive the optimistic flip.
+    chatAPI.terminateStream.mockResolvedValueOnce({ status: 202 });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient, { content: 'Once upon a time…' });
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache[0].content).toBe('Once upon a time…');
+    expect(cache[0].message_metadata.stream_state).toBe('user_terminated');
+  });
+
   it('M2: ensemble — every placeholder sharing the streamId is marked stopped', async () => {
     // Single terminate POST cascades the user_terminated stamp across
     // every placeholder with the same streamId. Matches the backend
@@ -330,5 +453,310 @@ describe('useChatStreaming.handleStopStream (SHU-803 AC4/AC5)', () => {
       expect(variant.isPlaceholder).toBe(false);
       expect(variant.message_metadata.stream_state).toBe('user_terminated');
     }
+  });
+});
+
+/**
+ * Build a ReadableStream-like reader that yields one chunk containing
+ * all provided SSE events, then EOF. Matches the chunk shape
+ * ``iterateSSE`` expects: ``{ done, value: Uint8Array }``.
+ *
+ * Pass either:
+ *   - a string ``"[DONE]"`` → emits ``data: [DONE]\n\n``
+ *   - an object → JSON-stringified, emitted as ``data: <json>\n\n``
+ */
+function makeMockSseReader(events) {
+  const encoder = new TextEncoder();
+  const sseText = events.map((e) => `data: ${typeof e === 'string' ? e : JSON.stringify(e)}\n\n`).join('');
+  const value = encoder.encode(sseText);
+  let consumed = false;
+  return {
+    read: async () => {
+      if (consumed) {
+        return { done: true, value: undefined };
+      }
+      consumed = true;
+      return { done: false, value };
+    },
+  };
+}
+
+function makeMockSseResponse(events) {
+  return {
+    ok: true,
+    body: { getReader: () => makeMockSseReader(events) },
+  };
+}
+
+/**
+ * Controllable async reader that lets the test push SSE events on
+ * demand and end the stream manually. Mirrors the WHATWG ReadableStream
+ * reader interface (`.read() -> Promise<{ done, value }>`) so it plugs
+ * into the production ``iterateSSE(reader)`` without changes.
+ *
+ * Use case: the SHU-803 same-conversation race test needs stream A to
+ * sit mid-flight while stream B starts and completes. With a one-shot
+ * "yields all events then EOF" mock that's impossible. This reader
+ * exposes ``push(event)`` / ``end()`` so the test orchestrates the
+ * two streams' interleaving deterministically.
+ */
+class ControlledSseReader {
+  constructor() {
+    this._chunks = [];
+    this._waiters = [];
+    this._encoder = new TextEncoder();
+  }
+
+  push(event) {
+    const text = `data: ${typeof event === 'string' ? event : JSON.stringify(event)}\n\n`;
+    this._chunks.push({ done: false, value: this._encoder.encode(text) });
+    this._drain();
+  }
+
+  end() {
+    this._chunks.push({ done: true, value: undefined });
+    this._drain();
+  }
+
+  _drain() {
+    while (this._chunks.length > 0 && this._waiters.length > 0) {
+      const chunk = this._chunks.shift();
+      const resolve = this._waiters.shift();
+      resolve(chunk);
+    }
+  }
+
+  read() {
+    if (this._chunks.length > 0) {
+      return Promise.resolve(this._chunks.shift());
+    }
+    return new Promise((resolve) => {
+      this._waiters.push(resolve);
+    });
+  }
+}
+
+describe('useChatStreaming.handleStreamingResponse (SHU-803 AC1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('AC1: parses stream_start SSE event and stamps streamId on the placeholder', async () => {
+    // Production code path under test: useChatStreaming.js line ~302 —
+    // ``if (eventType === 'stream_start') { ... streamIdByConversationRef
+    // .set(...) ... setQueryData stamps streamId on placeholderIdSet
+    // members ... }``. The backend integration suite proves the server
+    // emits the event; this test proves the React client captures it
+    // and writes the streamId where the InputBar can find it.
+    //
+    // Without this stamp, ``activeStreamingMessage`` in ModernChat.js
+    // never matches and the Stop button stays disabled / unclickable.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    // Pre-seed the cache with a placeholder. We pass options.tempMessageId
+    // matching this id so the hook's placeholderLookup / placeholderIdSet
+    // includes it — that's the set the stream_start branch stamps over.
+    const TEMP_PLACEHOLDER_ID = 'temp-streaming-msg-1';
+    queryClient.setQueryData(
+      ['conversation-messages', CONVERSATION_ID],
+      [
+        {
+          id: TEMP_PLACEHOLDER_ID,
+          role: 'assistant',
+          content: 'Thinking…',
+          conversation_id: CONVERSATION_ID,
+          isStreaming: true,
+          isPlaceholder: true,
+          message_metadata: {},
+        },
+      ]
+    );
+
+    // Mock the SSE response: stream_start with the id we want stamped,
+    // then [DONE] so the hook exits cleanly. Skipping content_delta /
+    // final_message here because they'd require the mocked sub-hooks
+    // to behave realistically and we're testing the stream_start
+    // branch in isolation.
+    chatAPI.streamMessage.mockResolvedValueOnce(
+      makeMockSseResponse([{ event: 'stream_start', content: { stream_id: STREAM_ID } }, '[DONE]'])
+    );
+
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStreamingResponse(
+        CONVERSATION_ID,
+        { message: 'hi' },
+        { tempMessageId: TEMP_PLACEHOLDER_ID }
+      );
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    const placeholder = cache.find((m) => m.id === TEMP_PLACEHOLDER_ID);
+    expect(placeholder).toBeDefined();
+    expect(placeholder.streamId).toBe(STREAM_ID);
+  });
+
+  it('AC1: stream_start with no stream_id leaves placeholder un-stamped', async () => {
+    // Defensive: if the event payload is malformed (missing
+    // content.stream_id), the parser must not write anything — a row
+    // with ``streamId: undefined`` would NOT match the InputBar's
+    // ``m.streamId`` truthiness check anyway, but writing the field
+    // pollutes the cache shape unnecessarily.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const TEMP_PLACEHOLDER_ID = 'temp-streaming-msg-2';
+    queryClient.setQueryData(
+      ['conversation-messages', CONVERSATION_ID],
+      [
+        {
+          id: TEMP_PLACEHOLDER_ID,
+          role: 'assistant',
+          content: 'Thinking…',
+          conversation_id: CONVERSATION_ID,
+          isStreaming: true,
+          isPlaceholder: true,
+          message_metadata: {},
+        },
+      ]
+    );
+
+    chatAPI.streamMessage.mockResolvedValueOnce(
+      makeMockSseResponse([{ event: 'stream_start', content: {} }, '[DONE]'])
+    );
+
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStreamingResponse(
+        CONVERSATION_ID,
+        { message: 'hi' },
+        { tempMessageId: TEMP_PLACEHOLDER_ID }
+      );
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    const placeholder = cache.find((m) => m.id === TEMP_PLACEHOLDER_ID);
+    expect(placeholder).toBeDefined();
+    expect(placeholder.streamId).toBeUndefined();
+  });
+
+  it("same-conv race: old stream A's [DONE] does NOT clear newer stream B's state while B is still streaming", async () => {
+    // Codex-flagged scenario (SHU-803 follow-up). Pre-fix the ownership
+    // guard was keyed by conversationId — fine for cross-conversation
+    // races, but unable to distinguish two streams in the SAME
+    // conversation. The bug:
+    //
+    //   1. User starts stream A in conversation X → ref = X.
+    //   2. User clicks Stop on A → handleStopStream clears ref.
+    //   3. User sends a new message (stream B) in conversation X → ref = X.
+    //   4. A's drain finishes; backend emits A's [DONE] on the old SSE.
+    //   5. A's [DONE] checks ``ref === A.conversationId`` → TRUE
+    //      (because B claims the SAME conv) → blindly clears state.
+    //   6. B's InputBar momentarily flashes Send mid-stream.
+    //
+    // Post-fix the ref holds a per-stream `streamToken` generated at
+    // handleStreamingResponse entry. A's closure captures token_A; B
+    // overwrites ref to token_B. A's [DONE] checks ``ref === token_A``
+    // → FALSE → no-op. B's state survives.
+    //
+    // **Test interleaving (the load-bearing part):** A's stale [DONE]
+    // MUST fire WHILE B is still mid-stream. If B finishes first, its
+    // own [DONE] clears the ref to null, and A's later [DONE] sees
+    // ``null === A.conversationId`` → FALSE anyway. That ordering
+    // would pass even with the pre-fix conv-keyed guard, making the
+    // test prove nothing. So this test holds B open across A's [DONE]
+    // and only releases B's [DONE] after asserting no spurious clear
+    // fired.
+    const readerA = new ControlledSseReader();
+    const readerB = new ControlledSseReader();
+
+    chatAPI.streamMessage
+      .mockResolvedValueOnce({ ok: true, body: { getReader: () => readerA } })
+      .mockResolvedValueOnce({ ok: true, body: { getReader: () => readerB } });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(
+      ['conversation-messages', CONVERSATION_ID],
+      [
+        {
+          id: 'temp-a',
+          role: 'assistant',
+          content: 'Thinking…',
+          conversation_id: CONVERSATION_ID,
+          isStreaming: true,
+          isPlaceholder: true,
+          message_metadata: {},
+        },
+        {
+          id: 'temp-b',
+          role: 'assistant',
+          content: 'Thinking…',
+          conversation_id: CONVERSATION_ID,
+          isStreaming: true,
+          isPlaceholder: true,
+          message_metadata: {},
+        },
+      ]
+    );
+
+    const setStreamingConversationId = vi.fn();
+    const setStreamingStarted = vi.fn();
+    const { result } = renderUseChatStreaming(queryClient, {
+      setStreamingConversationId,
+      setStreamingStarted,
+    });
+
+    // Start A.
+    const taskA = act(() =>
+      result.current.handleStreamingResponse(CONVERSATION_ID, { message: 'A' }, { tempMessageId: 'temp-a' })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // A's stream_start arrives — A captures stream_id, ref = token_A.
+    readerA.push({ event: 'stream_start', content: { stream_id: 'stream-A' } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Start B in the SAME conversation. B's claim overwrites the ref
+    // with its own token_B.
+    const taskB = act(() =>
+      result.current.handleStreamingResponse(CONVERSATION_ID, { message: 'B' }, { tempMessageId: 'temp-b' })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // B's stream_start arrives — B is now actively streaming.
+    // We deliberately do NOT push B's [DONE] yet — B must stay
+    // "live" across A's stale [DONE].
+    readerB.push({ event: 'stream_start', content: { stream_id: 'stream-B' } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Baseline: zero null-clears have fired yet (both streams active,
+    // neither has reached [DONE]).
+    const nullCallsBaseline = setStreamingConversationId.mock.calls.filter(([arg]) => arg === null).length;
+    expect(nullCallsBaseline).toBe(0);
+
+    // A's stale [DONE] fires WHILE B is still mid-stream. This is the
+    // exact race the token-based guard exists to prevent. Pre-fix,
+    // A's [DONE] would check ``ref === A.conversationId`` → TRUE
+    // (because B took the SAME conv) → clear B's state to null.
+    // Post-fix, A's closure-captured token doesn't match B's token
+    // in the ref → no-op.
+    readerA.push('[DONE]');
+    readerA.end();
+    await taskA;
+
+    // Critical assertion: zero null-clears even after A's stale [DONE].
+    // B is still streaming; its state must be intact. If this becomes
+    // 1, the conv-keyed guard regression is back.
+    const nullCallsAfterA = setStreamingConversationId.mock.calls.filter(([arg]) => arg === null).length;
+    expect(nullCallsAfterA).toBe(0);
+
+    // Now release B's [DONE]. B clears its own state — this is the
+    // first and only null-clear that should fire across both streams.
+    readerB.push('[DONE]');
+    readerB.end();
+    await taskB;
+
+    const nullCallsAfterB = setStreamingConversationId.mock.calls.filter(([arg]) => arg === null).length;
+    expect(nullCallsAfterB).toBe(1);
   });
 });

--- a/frontend/src/components/chat/ModernChat/hooks/__tests__/useChatStreaming.test.js
+++ b/frontend/src/components/chat/ModernChat/hooks/__tests__/useChatStreaming.test.js
@@ -1,0 +1,334 @@
+/**
+ * SHU-803 Vitest coverage for useChatStreaming — the slice this ticket
+ * adds (stream_start parsing + stream_id stamping + handleStopStream).
+ *
+ * The hook depends on a query client, an axios chat API, a slew of
+ * sub-hooks, and an SSE reader. Rather than mock every dependency end-to-
+ * end (which would test the mocks instead of the code), this suite
+ * targets the handleStopStream callback in isolation against a real
+ * QueryClient. The stream_start parsing inside the SSE iteration is
+ * covered by the SHU-803 backend integration suite end-to-end; here we
+ * pin the Stop-button callback semantics that AC4/AC5 specify.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { vi } from 'vitest';
+import useChatStreaming from '../useChatStreaming';
+import { chatAPI } from '../../../../../services/api';
+
+vi.mock('../../../../../services/api', () => ({
+  chatAPI: {
+    terminateStream: vi.fn(),
+  },
+  // chatCache.js imports this — without it, getMessagesFromCache
+  // throws and every setQueryData inside the hook explodes.
+  extractDataFromResponse: (response) => {
+    if (response && typeof response === 'object' && 'data' in response) {
+      const firstData = response.data;
+      if (firstData && typeof firstData === 'object' && 'data' in firstData) {
+        return firstData.data;
+      }
+      return firstData;
+    }
+    return response;
+  },
+}));
+
+// useChatStreaming pulls in a few sub-hooks that themselves call out to
+// the query client. The stop-stream callback path doesn't exercise them,
+// but their imports need to resolve. Stub the ones with heavy setup.
+vi.mock('../useReasoningStream', () => ({
+  default: () => ({
+    appendReasoningDelta: vi.fn(),
+    collapseReasoningForPlaceholder: vi.fn(),
+  }),
+}));
+
+vi.mock('../useStreamingPlaceholders', () => ({
+  default: () => ({
+    assignModelInfoToPlaceholder: vi.fn(),
+    seedMetaFromCache: vi.fn(),
+    ensurePlaceholderForVariant: vi.fn(),
+    syncPlaceholderParentIds: vi.fn(),
+  }),
+}));
+
+vi.mock('../useMessageRegeneration', () => ({
+  default: () => ({ handleRegenerate: vi.fn() }),
+}));
+
+// log.error is called on the unexpected-error branch — silence it so
+// failing-by-design tests don't spam the test output.
+vi.mock('../../../../../utils/log', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const CONVERSATION_ID = 'conv-shu-803';
+const STREAM_ID = 'stream-abc-123';
+
+// Extract the messages array from the React Query cache regardless of
+// whether the cache currently holds the plain array (test seed shape)
+// or the double-nested envelope ``{data:{data:[...]}}`` shape that
+// ``rebuildCache`` produces after any setQueryData write inside the hook.
+function getMessagesFromQueryCache(queryClient, conversationId) {
+  const raw = queryClient.getQueryData(['conversation-messages', conversationId]);
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw && typeof raw === 'object' && raw.data) {
+    const inner = raw.data;
+    if (inner && typeof inner === 'object' && Array.isArray(inner.data)) {
+      return inner.data;
+    }
+    if (Array.isArray(inner)) {
+      return inner;
+    }
+  }
+  return [];
+}
+
+function seedCacheWithStreamingPlaceholder(queryClient, overrides = {}) {
+  queryClient.setQueryData(
+    ['conversation-messages', CONVERSATION_ID],
+    [
+      {
+        id: 'placeholder-1',
+        role: 'assistant',
+        content: 'Thinking…',
+        conversation_id: CONVERSATION_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+        streamId: STREAM_ID,
+        message_metadata: {},
+        ...overrides,
+      },
+    ]
+  );
+}
+
+function makeWrapper(queryClient) {
+  const Wrapper = ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  Wrapper.displayName = 'TestQueryClientWrapper';
+  return Wrapper;
+}
+
+function renderUseChatStreaming(queryClient, hookOverrides = {}) {
+  const setError = vi.fn();
+  const result = renderHook(
+    () =>
+      useChatStreaming({
+        queryClient,
+        setError,
+        setStreamingConversationId: vi.fn(),
+        setStreamingStarted: vi.fn(),
+        inputRef: { current: null },
+        selectedConversation: { id: CONVERSATION_ID },
+        setVariantSelection: vi.fn(),
+        startRegeneration: vi.fn(),
+        completeRegeneration: vi.fn(),
+        ragRewriteMode: 'no_rag',
+        scheduleScrollToBottom: vi.fn(),
+        shouldAutoFollowRef: { current: false },
+        focusMessageById: vi.fn(),
+        replaceSideBySideParent: vi.fn(),
+        selectedKBIds: [],
+        ...hookOverrides,
+      }),
+    { wrapper: makeWrapper(queryClient) }
+  );
+  return { ...result, setError };
+}
+
+describe('useChatStreaming.handleStopStream (SHU-803 AC4/AC5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('AC4: POSTs the terminate endpoint with the message streamId', async () => {
+    chatAPI.terminateStream.mockResolvedValueOnce({ status: 202 });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient);
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    expect(chatAPI.terminateStream).toHaveBeenCalledTimes(1);
+    expect(chatAPI.terminateStream).toHaveBeenCalledWith(STREAM_ID);
+  });
+
+  it('AC5: 202 optimistically flips placeholder out of isStreaming and stamps user_terminated', async () => {
+    chatAPI.terminateStream.mockResolvedValueOnce({ status: 202 });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient);
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache).toHaveLength(1);
+    expect(cache[0].isStreaming).toBe(false);
+    expect(cache[0].isPlaceholder).toBe(false);
+    expect(cache[0].message_metadata.stream_state).toBe('user_terminated');
+  });
+
+  it('AC5: 410 STREAM_NOT_ACTIVE is treated as success (same optimistic update)', async () => {
+    // axios convention: 4xx throws; we treat 410 specifically as
+    // "stream already finalized" which is success-equivalent for
+    // the user-facing flow.
+    chatAPI.terminateStream.mockRejectedValueOnce({ response: { status: 410 } });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient);
+    const { result, setError } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache[0].isStreaming).toBe(false);
+    expect(cache[0].message_metadata.stream_state).toBe('user_terminated');
+    // 410 must NOT surface an error toast.
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('AC5: 403 surfaces an error toast and leaves the placeholder unchanged', async () => {
+    chatAPI.terminateStream.mockRejectedValueOnce({ response: { status: 403 } });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient);
+    const { result, setError } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache[0].isStreaming).toBe(true);
+    expect(cache[0].isPlaceholder).toBe(true);
+    expect(cache[0].message_metadata.stream_state).toBeUndefined();
+    expect(setError).toHaveBeenCalledTimes(1);
+    expect(setError.mock.calls[0][0]).toMatch(/don't own/i);
+  });
+
+  it('AC5: 5xx / network errors surface a generic error toast', async () => {
+    chatAPI.terminateStream.mockRejectedValueOnce({ response: { status: 500 } });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient);
+    const { result, setError } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+        isPlaceholder: true,
+      });
+    });
+
+    expect(setError).toHaveBeenCalledTimes(1);
+    expect(setError.mock.calls[0][0]).toMatch(/couldn't stop/i);
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache[0].isStreaming).toBe(true);
+  });
+
+  it('no-op (no POST) when called without a streamId', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    seedCacheWithStreamingPlaceholder(queryClient, { streamId: undefined });
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-1',
+        conversation_id: CONVERSATION_ID,
+        isStreaming: true,
+      });
+    });
+
+    expect(chatAPI.terminateStream).not.toHaveBeenCalled();
+  });
+
+  it('M2: ensemble — every placeholder sharing the streamId is marked stopped', async () => {
+    // Single terminate POST cascades the user_terminated stamp across
+    // every placeholder with the same streamId. Matches the backend
+    // priority-based signal which terminates all variants together.
+    chatAPI.terminateStream.mockResolvedValueOnce({ status: 202 });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(
+      ['conversation-messages', CONVERSATION_ID],
+      [
+        {
+          id: 'placeholder-variant-0',
+          role: 'assistant',
+          conversation_id: CONVERSATION_ID,
+          isStreaming: true,
+          isPlaceholder: true,
+          streamId: STREAM_ID,
+          variant_index: 0,
+          message_metadata: {},
+        },
+        {
+          id: 'placeholder-variant-1',
+          role: 'assistant',
+          conversation_id: CONVERSATION_ID,
+          isStreaming: true,
+          isPlaceholder: true,
+          streamId: STREAM_ID,
+          variant_index: 1,
+          message_metadata: {},
+        },
+      ]
+    );
+    const { result } = renderUseChatStreaming(queryClient);
+
+    await act(async () => {
+      await result.current.handleStopStream({
+        id: 'placeholder-variant-0',
+        conversation_id: CONVERSATION_ID,
+        streamId: STREAM_ID,
+        isStreaming: true,
+      });
+    });
+
+    const cache = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    expect(cache).toHaveLength(2);
+    for (const variant of cache) {
+      expect(variant.isStreaming).toBe(false);
+      expect(variant.isPlaceholder).toBe(false);
+      expect(variant.message_metadata.stream_state).toBe('user_terminated');
+    }
+  });
+});

--- a/frontend/src/components/chat/ModernChat/hooks/__tests__/useMessageRegeneration.test.js
+++ b/frontend/src/components/chat/ModernChat/hooks/__tests__/useMessageRegeneration.test.js
@@ -1,0 +1,292 @@
+/**
+ * SHU-803 follow-up Vitest coverage for useMessageRegeneration — the
+ * Stop-during-regen wiring (`setStreamingConversationId`,
+ * `setStreamingStarted`, `stream_start` → placeholder streamId stamp).
+ *
+ * Pre-fix, this hook ran its own SSE loop independently of
+ * `handleStreamingResponse` and never touched the streaming-state
+ * setters or captured the stream_id. The InputBar therefore never
+ * swapped Send → Stop during regenerate, and even if it had, the
+ * placeholder had no streamId for the terminate POST to target.
+ *
+ * These tests pin the post-fix invariants:
+ *
+ * - On `handleRegenerate` invocation: `setStreamingConversationId` is
+ *   called with the conversation id (synchronously, before the SSE
+ *   request fires) and `setStreamingStarted(false)` is called.
+ * - On `stream_start` SSE event: the regen temp placeholder in cache
+ *   gets `streamId` stamped on it — that's what
+ *   `handleInputBarStop`'s `flattenedMessages.find(...)` lookup keys
+ *   off.
+ * - On first `content_delta`: `setStreamingStarted(true)` flips so
+ *   the InputBar moves from "Initializing…" to enabled Stop.
+ * - On `[DONE]`: both setters are cleared (back to `null` /
+ *   `false`) — the InputBar returns to Send.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { vi } from 'vitest';
+import useMessageRegeneration from '../useMessageRegeneration';
+import { chatRegenerateAPI } from '../../../../../services/api';
+
+vi.mock('../../../../../services/api', () => ({
+  chatRegenerateAPI: {
+    streamRegenerate: vi.fn(),
+  },
+  // chatCache.js imports this — without it, getMessagesFromCache
+  // throws and every setQueryData inside the hook explodes.
+  extractDataFromResponse: (response) => {
+    if (response && typeof response === 'object' && 'data' in response) {
+      const firstData = response.data;
+      if (firstData && typeof firstData === 'object' && 'data' in firstData) {
+        return firstData.data;
+      }
+      return firstData;
+    }
+    return response;
+  },
+}));
+
+vi.mock('../../../../../utils/log', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const CONVERSATION_ID = 'conv-regen-stop';
+const TARGET_MESSAGE_ID = 'target-msg-1';
+const PARENT_ID = 'parent-1';
+const STREAM_ID = 'stream-regen-xyz';
+
+/**
+ * Build a ReadableStream-like reader that yields one chunk containing
+ * all the provided SSE events, then EOF. Matches the chunk shape
+ * `iterateSSE` expects: ``{ done, value: Uint8Array }``.
+ *
+ * Pass either:
+ *   - a string like ``"[DONE]"`` → emits ``data: [DONE]\n\n``
+ *   - an object → JSON-stringified, emitted as ``data: <json>\n\n``
+ */
+function makeMockReader(events) {
+  const encoder = new TextEncoder();
+  const sseText = events.map((e) => `data: ${typeof e === 'string' ? e : JSON.stringify(e)}\n\n`).join('');
+  const value = encoder.encode(sseText);
+  let consumed = false;
+  return {
+    read: async () => {
+      if (consumed) {
+        return { done: true, value: undefined };
+      }
+      consumed = true;
+      return { done: false, value };
+    },
+  };
+}
+
+function makeMockResponse(events) {
+  return {
+    ok: true,
+    body: {
+      getReader: () => makeMockReader(events),
+    },
+  };
+}
+
+function makeWrapper(queryClient) {
+  const Wrapper = ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  Wrapper.displayName = 'RegenTestQueryClientWrapper';
+  return Wrapper;
+}
+
+function renderUseRegeneration(queryClient, overrides = {}) {
+  const setStreamingConversationId = vi.fn();
+  const setStreamingStarted = vi.fn();
+  const setError = vi.fn();
+  const startRegeneration = vi.fn();
+  const completeRegeneration = vi.fn();
+  const setVariantSelection = vi.fn();
+  const scheduleScrollToBottom = vi.fn();
+  const focusMessageById = vi.fn();
+
+  const result = renderHook(
+    () =>
+      useMessageRegeneration({
+        queryClient,
+        conversationRef: { current: { id: CONVERSATION_ID } },
+        ragRewriteMode: 'no_rag',
+        selectedKBIds: [],
+        startRegeneration,
+        completeRegeneration,
+        setVariantSelection,
+        scheduleScrollToBottom,
+        shouldAutoFollowRef: { current: false },
+        focusMessageById,
+        setError,
+        setStreamingConversationId,
+        setStreamingStarted,
+        ...overrides,
+      }),
+    { wrapper: makeWrapper(queryClient) }
+  );
+  return {
+    ...result,
+    setStreamingConversationId,
+    setStreamingStarted,
+    setError,
+    startRegeneration,
+    completeRegeneration,
+  };
+}
+
+/**
+ * Pull the messages array from the React Query cache regardless of
+ * whether the cache currently holds the plain array or the double-
+ * nested envelope ``{data:{data:[...]}}`` that `rebuildCache` writes
+ * after the first `setQueryData` call.
+ */
+function getMessagesFromQueryCache(queryClient, conversationId) {
+  const raw = queryClient.getQueryData(['conversation-messages', conversationId]);
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw && typeof raw === 'object' && raw.data) {
+    const inner = raw.data;
+    if (inner && typeof inner === 'object' && Array.isArray(inner.data)) {
+      return inner.data;
+    }
+    if (Array.isArray(inner)) {
+      return inner;
+    }
+  }
+  return [];
+}
+
+describe('useMessageRegeneration — SHU-803 Stop-during-regen wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets streamingConversationId at the start of regenerate (before SSE response)', async () => {
+    // Capture the moment of dispatch — we use a never-resolving stream
+    // so the test only observes the synchronous prelude (before any
+    // SSE event arrives). The dispatched call to
+    // `setStreamingConversationId` is what flips the InputBar from
+    // Send → Stop the instant the user clicks regenerate.
+    chatRegenerateAPI.streamRegenerate.mockReturnValueOnce(
+      new Promise(() => {
+        /* never resolves */
+      })
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, setStreamingConversationId, setStreamingStarted } = renderUseRegeneration(queryClient);
+
+    act(() => {
+      // Fire-and-forget — we don't await; we want to assert on the
+      // synchronous prelude only.
+      result.current.handleRegenerate(TARGET_MESSAGE_ID, PARENT_ID);
+    });
+
+    expect(setStreamingConversationId).toHaveBeenCalledWith(CONVERSATION_ID);
+    expect(setStreamingStarted).toHaveBeenCalledWith(false);
+  });
+
+  it('stamps streamId on the regen placeholder when stream_start fires', async () => {
+    chatRegenerateAPI.streamRegenerate.mockResolvedValueOnce(
+      makeMockResponse([{ event: 'stream_start', content: { stream_id: STREAM_ID } }, '[DONE]'])
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderUseRegeneration(queryClient);
+
+    await act(async () => {
+      await result.current.handleRegenerate(TARGET_MESSAGE_ID, PARENT_ID);
+    });
+
+    const messages = getMessagesFromQueryCache(queryClient, CONVERSATION_ID);
+    // The placeholder may have been cleaned up by the [DONE] path
+    // depending on the cleanup branch taken; what we care about is
+    // that AT SOME POINT during the iteration the streamId got
+    // stamped onto a placeholder with this stream_id. Easiest
+    // observable: at least one row in the final cache (or its history)
+    // saw the stream_id. We capture this by checking that the
+    // setQueryData call carried a row with the streamId — but since
+    // we only have the final state, we observe via the placeholder
+    // that's still present at [DONE]-cleanup time (it's been flipped
+    // out of `isStreaming` but the streamId stamp persists).
+    const placeholdersOrFinals = messages.filter(
+      (m) => m && (m.streamId === STREAM_ID || (m.isPlaceholder === false && m.streamId === STREAM_ID))
+    );
+    expect(placeholdersOrFinals.length).toBeGreaterThan(0);
+  });
+
+  it('flips streamingStarted to true on first content_delta', async () => {
+    chatRegenerateAPI.streamRegenerate.mockResolvedValueOnce(
+      makeMockResponse([
+        { event: 'stream_start', content: { stream_id: STREAM_ID } },
+        { event: 'content_delta', text: 'Hello ' },
+        { event: 'content_delta', text: 'world.' },
+        '[DONE]',
+      ])
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, setStreamingStarted } = renderUseRegeneration(queryClient);
+
+    await act(async () => {
+      await result.current.handleRegenerate(TARGET_MESSAGE_ID, PARENT_ID);
+    });
+
+    // Sequence: initial `false` (handleRegenerate prelude), then
+    // `true` on first content_delta, then `false` again on
+    // markCompleted at [DONE]. We don't care about call count beyond
+    // "true was observed at least once between false-false bracket."
+    const calls = setStreamingStarted.mock.calls.map(([arg]) => arg);
+    expect(calls).toContain(true);
+    expect(calls).toContain(false);
+  });
+
+  it('clears streamingConversationId on [DONE]', async () => {
+    chatRegenerateAPI.streamRegenerate.mockResolvedValueOnce(
+      makeMockResponse([
+        { event: 'stream_start', content: { stream_id: STREAM_ID } },
+        { event: 'content_delta', text: 'ok' },
+        '[DONE]',
+      ])
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, setStreamingConversationId, setStreamingStarted } = renderUseRegeneration(queryClient);
+
+    await act(async () => {
+      await result.current.handleRegenerate(TARGET_MESSAGE_ID, PARENT_ID);
+    });
+
+    // The final call to each setter should be the clear (null / false)
+    // — that's what releases the InputBar back to Send.
+    const conversationIdCalls = setStreamingConversationId.mock.calls.map(([arg]) => arg);
+    const startedCalls = setStreamingStarted.mock.calls.map(([arg]) => arg);
+    expect(conversationIdCalls[conversationIdCalls.length - 1]).toBeNull();
+    expect(startedCalls[startedCalls.length - 1]).toBe(false);
+  });
+
+  it('clears streamingConversationId on stream error', async () => {
+    chatRegenerateAPI.streamRegenerate.mockResolvedValueOnce(
+      makeMockResponse([{ event: 'error', error: 'simulated provider failure' }])
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result, setStreamingConversationId, setStreamingStarted } = renderUseRegeneration(queryClient);
+
+    await act(async () => {
+      await result.current.handleRegenerate(TARGET_MESSAGE_ID, PARENT_ID);
+    });
+
+    // Error path also goes through markCompleted in the finally block,
+    // so the clear must still fire — otherwise the InputBar would be
+    // stuck on Stop forever after a failed regen.
+    const conversationIdCalls = setStreamingConversationId.mock.calls.map(([arg]) => arg);
+    expect(conversationIdCalls).toContain(null);
+    const startedCalls = setStreamingStarted.mock.calls.map(([arg]) => arg);
+    expect(startedCalls).toContain(false);
+  });
+});

--- a/frontend/src/components/chat/ModernChat/hooks/__tests__/useMessageRegeneration.test.js
+++ b/frontend/src/components/chat/ModernChat/hooks/__tests__/useMessageRegeneration.test.js
@@ -111,6 +111,11 @@ function renderUseRegeneration(queryClient, overrides = {}) {
   const setVariantSelection = vi.fn();
   const scheduleScrollToBottom = vi.fn();
   const focusMessageById = vi.fn();
+  // SHU-803 follow-up: ownership ref. In production this is owned by
+  // useChatStreaming and shared with useMessageRegeneration so both
+  // hooks coordinate on the "who currently owns the global streaming
+  // state" check before any clear.
+  const streamingOwnerRef = { current: null };
 
   const result = renderHook(
     () =>
@@ -128,6 +133,7 @@ function renderUseRegeneration(queryClient, overrides = {}) {
         setError,
         setStreamingConversationId,
         setStreamingStarted,
+        streamingOwnerRef,
         ...overrides,
       }),
     { wrapper: makeWrapper(queryClient) }
@@ -139,6 +145,7 @@ function renderUseRegeneration(queryClient, overrides = {}) {
     setError,
     startRegeneration,
     completeRegeneration,
+    streamingOwnerRef,
   };
 }
 

--- a/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
@@ -670,8 +670,21 @@ const useChatStreaming = ({
         });
         return mutated ? rebuildCache(oldData, updated) : oldData;
       });
+
+      // SHU-803 follow-up (Bug 1): release the InputBar back to Send
+      // immediately. Without this, the input bar would keep showing Stop
+      // until the SSE channel emits `[DONE]`, which only fires after the
+      // backend drain finishes — up to ~90s on OpenRouter. The SSE
+      // channel keeps consuming in the background so the persisted
+      // `final_message` still lands when drain completes (the existing
+      // [DONE] handler is a no-op for streamingConversationId since we
+      // already cleared it here). The user can type and send a new
+      // message right away; the backend persisted the partial Message
+      // at signal time so chronological ordering is preserved.
+      setStreamingConversationId(null);
+      setStreamingStarted(false);
     },
-    [queryClient, setError]
+    [queryClient, setError, setStreamingConversationId, setStreamingStarted]
   );
 
   return {

--- a/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
@@ -123,6 +123,8 @@ const useChatStreaming = ({
     shouldAutoFollowRef,
     focusMessageById,
     setError,
+    setStreamingConversationId,
+    setStreamingStarted,
   });
 
   const handleStreamingResponse = useCallback(

--- a/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
@@ -173,6 +173,19 @@ const useChatStreaming = ({
       // `streamIdByConversationRef` if the map still holds OUR id —
       // a newer same-conv stream might have overwritten the entry.
       let capturedStreamId = null;
+      // SHU-803 follow-up: cleanup helper used by every exit path
+      // ([DONE], abort, error) so the captured stream_id is removed from
+      // the per-conversation map symmetrically. Guarded against the
+      // newer-stream-overwrote-us case so we don't orphan another
+      // stream's Stop-button lookup.
+      const releaseCapturedStreamId = () => {
+        if (
+          capturedStreamId !== null &&
+          streamIdByConversationRef.current.get(String(conversationId)) === capturedStreamId
+        ) {
+          streamIdByConversationRef.current.delete(String(conversationId));
+        }
+      };
       try {
         abortController = new AbortController();
         const conversationIdKey = String(conversationId);
@@ -334,16 +347,8 @@ const useChatStreaming = ({
             }
             // SHU-803: stream completed — clear OUR captured stream_id
             // from the per-conversation map so a future stream gets a
-            // fresh capture from its own stream_start event. Guarded
-            // because the entry may have been overwritten by a newer
-            // same-conversation stream; deleting blindly would orphan
-            // that newer stream's Stop-button lookup.
-            if (
-              capturedStreamId !== null &&
-              streamIdByConversationRef.current.get(String(conversationId)) === capturedStreamId
-            ) {
-              streamIdByConversationRef.current.delete(String(conversationId));
-            }
+            // fresh capture from its own stream_start event.
+            releaseCapturedStreamId();
 
             if (!isMountedRef.current) {
               return;
@@ -582,6 +587,10 @@ const useChatStreaming = ({
         }
       } catch (error) {
         if (error?.name === 'AbortError' || error?.content === 'The user aborted a request.') {
+          // Mirror the [DONE] handler: every stream-exit path releases
+          // our captured stream_id so a future same-conversation stream
+          // doesn't see a stale entry.
+          releaseCapturedStreamId();
           if (!isMountedRef.current) {
             return;
           }
@@ -609,6 +618,10 @@ const useChatStreaming = ({
           return;
         }
         log.error('Streaming error:', error);
+        // Mirror the [DONE] handler: every stream-exit path releases
+        // our captured stream_id so a future same-conversation stream
+        // doesn't see a stale entry.
+        releaseCapturedStreamId();
         if (!isMountedRef.current) {
           return;
         }

--- a/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
@@ -21,6 +21,19 @@ import useMessageRegeneration from './useMessageRegeneration';
 const STREAM_NOT_ACTIVE_STATUS = 410;
 const FORBIDDEN_STATUS = 403;
 
+// SHU-803 follow-up: per-stream-instance token used to identify which
+// invocation of `handleStreamingResponse` / `handleRegenerate` currently
+// owns the global streaming state. See `streamingOwnerRef` for the full
+// rationale. `crypto.randomUUID()` is the preferred source (RFC 4122 v4
+// from the browser's CSPRNG); the fallback handles older environments
+// like vitest's jsdom in some configurations.
+const makeStreamToken = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+export { makeStreamToken };
+
 const useChatStreaming = ({
   queryClient,
   setError,
@@ -46,6 +59,22 @@ const useChatStreaming = ({
   // simultaneous streams can stop each independently. Map values reset
   // when a stream completes or the conversation unmounts.
   const streamIdByConversationRef = useRef(new Map());
+  // SHU-803 follow-up: which stream-instance token currently owns the
+  // global streaming state (`streamingConversationId` +
+  // `streamingStarted`). Each call to `handleStreamingResponse` /
+  // `handleRegenerate` generates a fresh `streamToken` and stores it
+  // here; every clear callsite checks the ref against its OWN closure-
+  // captured token before acting.
+  //
+  // Keyed by **stream-instance token (not conversationId)** because a
+  // conversation-id key falsely matches the same-conversation
+  // follow-up case: user stops stream A, then starts stream B in the
+  // same conversation while A drains; A's later [DONE] would see
+  // `ref === A.conversationId === B.conversationId` and clear B's
+  // state. The token is per-call-instance, so A's closure-captured
+  // token does NOT match B's owner-claim, and A's [DONE] correctly
+  // no-ops.
+  const streamingOwnerRef = useRef(null);
 
   useEffect(() => {
     conversationRef.current = selectedConversation;
@@ -125,11 +154,25 @@ const useChatStreaming = ({
     setError,
     setStreamingConversationId,
     setStreamingStarted,
+    streamingOwnerRef,
   });
 
   const handleStreamingResponse = useCallback(
     async (conversationId, payload, options = {}) => {
       let abortController;
+      // SHU-803 follow-up: per-stream-instance token captured in this
+      // closure. All clear paths below check `streamingOwnerRef.current
+      // === streamToken` — that's the per-stream check that survives
+      // the same-conversation race (stop A → start B in same conv;
+      // A's later [DONE] sees its own captured token, ref holds B's,
+      // no clear). See the `streamingOwnerRef` declaration for full
+      // context.
+      const streamToken = makeStreamToken();
+      // SHU-803 follow-up: this stream's server-assigned streamId once
+      // `stream_start` lands. Captured here so we only delete from
+      // `streamIdByConversationRef` if the map still holds OUR id —
+      // a newer same-conv stream might have overwritten the entry.
+      let capturedStreamId = null;
       try {
         abortController = new AbortController();
         const conversationIdKey = String(conversationId);
@@ -137,6 +180,13 @@ const useChatStreaming = ({
           activeStreamControllersRef.current.set(conversationIdKey, new Set());
         }
         activeStreamControllersRef.current.get(conversationIdKey).add(abortController);
+        // SHU-803 follow-up: claim ownership of the global streaming
+        // state BEFORE setting it. Each clear path below checks the
+        // ref against this stream's captured `streamToken` so a
+        // straggling [DONE] / error / abort from an old (stopped or
+        // navigated-away) stream cannot blow away a newer stream's
+        // state — even if the newer stream is in the same conversation.
+        streamingOwnerRef.current = streamToken;
         setStreamingConversationId(conversationId);
         setStreamingStarted(false);
 
@@ -181,6 +231,11 @@ const useChatStreaming = ({
               conversation_id: conversationId,
               isStreaming: true,
               isPlaceholder: true,
+              // SHU-803 follow-up: stamp this stream's token so
+              // handleStopStream can read it from the cache message
+              // and check its ownership-ref guard correctly. Carries
+              // through the full placeholder lifecycle.
+              streamToken,
             };
             return rebuildCache(oldData, [...existing, streamingMessage]);
           });
@@ -201,17 +256,31 @@ const useChatStreaming = ({
           // has already landed. Ensemble variants share one stream_id;
           // each new variant placeholder needs the id stamped so its
           // Stop button has the value to POST.
+          // SHU-803 follow-up: ALSO stamp this stream's per-instance
+          // streamToken so handleStopStream's ownership guard can
+          // match it against the ref. streamToken is always known
+          // here (set at handleStreamingResponse entry).
           const streamId = streamIdByConversationRef.current.get(String(conversationId));
-          if (streamId && placeholderId) {
+          if (placeholderId) {
             queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
               const existing = getMessagesFromCache(oldData);
               let mutated = false;
               const updated = existing.map((m) => {
-                if (m.id === placeholderId && m.streamId !== streamId) {
-                  mutated = true;
-                  return { ...m, streamId };
+                if (m.id !== placeholderId) {
+                  return m;
                 }
-                return m;
+                const updates = {};
+                if (streamId && m.streamId !== streamId) {
+                  updates.streamId = streamId;
+                }
+                if (m.streamToken !== streamToken) {
+                  updates.streamToken = streamToken;
+                }
+                if (Object.keys(updates).length === 0) {
+                  return m;
+                }
+                mutated = true;
+                return { ...m, ...updates };
               });
               return mutated ? rebuildCache(oldData, updated) : oldData;
             });
@@ -263,17 +332,33 @@ const useChatStreaming = ({
             } catch (_) {
               // Ignore error
             }
-            // SHU-803: stream completed — clear the captured stream_id
-            // so a future stream for the same conversation gets a fresh
-            // capture from its own stream_start event.
-            streamIdByConversationRef.current.delete(String(conversationId));
+            // SHU-803: stream completed — clear OUR captured stream_id
+            // from the per-conversation map so a future stream gets a
+            // fresh capture from its own stream_start event. Guarded
+            // because the entry may have been overwritten by a newer
+            // same-conversation stream; deleting blindly would orphan
+            // that newer stream's Stop-button lookup.
+            if (
+              capturedStreamId !== null &&
+              streamIdByConversationRef.current.get(String(conversationId)) === capturedStreamId
+            ) {
+              streamIdByConversationRef.current.delete(String(conversationId));
+            }
 
             if (!isMountedRef.current) {
               return;
             }
 
-            setStreamingConversationId(null);
-            setStreamingStarted(false);
+            // SHU-803 follow-up: only clear the global streaming state
+            // if THIS stream still owns it. Keyed by per-stream-instance
+            // token (not conversationId) so a newer same-conv stream's
+            // claim isn't matched by this stream's closure-captured
+            // token.
+            if (streamingOwnerRef.current === streamToken) {
+              streamingOwnerRef.current = null;
+              setStreamingConversationId(null);
+              setStreamingStarted(false);
+            }
             if (shouldAutoFollowRef?.current && conversationRef.current?.id === conversationId) {
               scheduleScrollToBottom?.('auto');
             }
@@ -304,10 +389,15 @@ const useChatStreaming = ({
           if (eventType === 'stream_start') {
             const streamId = parsed?.content?.stream_id;
             if (streamId) {
+              // Capture our streamId so the [DONE] / abort / error
+              // cleanup below can verify the map entry still belongs to
+              // us before deleting (a newer same-conv stream may have
+              // overwritten the slot in the interim).
+              capturedStreamId = streamId;
               streamIdByConversationRef.current.set(String(conversationId), streamId);
               queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
                 const existing = getMessagesFromCache(oldData);
-                const updated = existing.map((m) => (placeholderIdSet.has(m.id) ? { ...m, streamId } : m));
+                const updated = existing.map((m) => (placeholderIdSet.has(m.id) ? { ...m, streamId, streamToken } : m));
                 return rebuildCache(oldData, updated);
               });
             }
@@ -497,8 +587,14 @@ const useChatStreaming = ({
           }
 
           // Treat abort as a graceful completion: clear streaming state and stop placeholders.
-          setStreamingConversationId(null);
-          setStreamingStarted(false);
+          // SHU-803 follow-up: ownership-guard the clear, keyed by this
+          // stream's per-instance token — see the [DONE] handler above
+          // for full rationale.
+          if (streamingOwnerRef.current === streamToken) {
+            streamingOwnerRef.current = null;
+            setStreamingConversationId(null);
+            setStreamingStarted(false);
+          }
 
           try {
             queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
@@ -536,8 +632,14 @@ const useChatStreaming = ({
           chatErrorMessage = `I'm sorry, I encountered an error: ${displayMessage}`;
         }
 
-        setStreamingConversationId(null);
-        setStreamingStarted(false);
+        // SHU-803 follow-up: ownership-guard the clear, keyed by this
+        // stream's per-instance token — see the [DONE] handler above
+        // for full rationale.
+        if (streamingOwnerRef.current === streamToken) {
+          streamingOwnerRef.current = null;
+          setStreamingConversationId(null);
+          setStreamingStarted(false);
+        }
 
         // Replace streaming placeholders with error message content
         // This shows the error in the chat bubble instead of "Thinking..."
@@ -652,13 +754,24 @@ const useChatStreaming = ({
       // out of isStreaming and stamp `stream_state="user_terminated"`.
       // Ensembles share a single stream_id across all variants, so a
       // single Stop click marks all variants as stopped together.
+      //
+      // SHU-803 follow-up: clear ``PLACEHOLDER_THINKING`` when a Stop
+      // lands before any ``content_delta`` arrived. Otherwise the
+      // bubble shows "Thinking…" alongside the "Stopped by user"
+      // caption for the entire backend drain window (up to ~90s) —
+      // a contradictory state. Real partial content (anything other
+      // than the thinking placeholder) is preserved so the user can
+      // still see what they got before clicking Stop. When the
+      // backend's final_message eventually lands, the persisted
+      // partial content (which may itself be empty if Stop fired
+      // pre-delta) replaces whatever's here.
       queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
         const existing = getMessagesFromCache(oldData);
         let mutated = false;
         const updated = existing.map((m) => {
           if (m.streamId === streamId && (m.isStreaming || m.isPlaceholder)) {
             mutated = true;
-            return {
+            const updatedMessage = {
               ...m,
               isStreaming: false,
               isPlaceholder: false,
@@ -667,6 +780,10 @@ const useChatStreaming = ({
                 stream_state: 'user_terminated',
               },
             };
+            if (m.content === PLACEHOLDER_THINKING) {
+              updatedMessage.content = '';
+            }
+            return updatedMessage;
           }
           return m;
         });
@@ -683,8 +800,20 @@ const useChatStreaming = ({
       // already cleared it here). The user can type and send a new
       // message right away; the backend persisted the partial Message
       // at signal time so chronological ordering is preserved.
-      setStreamingConversationId(null);
-      setStreamingStarted(false);
+      //
+      // Ownership-guard the clear keyed by the stream's per-instance
+      // streamToken (stamped on the placeholder at
+      // handleStreamingResponse entry). A conversationId-keyed guard
+      // here would falsely match a newer same-conversation stream
+      // started between when the user's click captured the cached
+      // message and when the terminate POST resolved. The per-stream
+      // token survives that race.
+      const streamToken = message?.streamToken;
+      if (streamToken && streamingOwnerRef.current === streamToken) {
+        streamingOwnerRef.current = null;
+        setStreamingConversationId(null);
+        setStreamingStarted(false);
+      }
     },
     [queryClient, setError, setStreamingConversationId, setStreamingStarted]
   );

--- a/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useChatStreaming.js
@@ -13,6 +13,14 @@ import useReasoningStream from './useReasoningStream';
 import useStreamingPlaceholders from './useStreamingPlaceholders';
 import useMessageRegeneration from './useMessageRegeneration';
 
+// SHU-803 AC5: response-status codes the Stop POST distinguishes.
+// 202 = signal accepted (axios resolves 2xx). 410 = STREAM_NOT_ACTIVE —
+// the stream already finalized before the POST landed; treated as
+// success-equivalent for the UI. 403 = caller doesn't own the stream
+// (defensive; shouldn't happen for the streaming user).
+const STREAM_NOT_ACTIVE_STATUS = 410;
+const FORBIDDEN_STATUS = 403;
+
 const useChatStreaming = ({
   queryClient,
   setError,
@@ -33,6 +41,11 @@ const useChatStreaming = ({
   const conversationRef = useRef(selectedConversation);
   const isMountedRef = useRef(true);
   const activeStreamControllersRef = useRef(new Map());
+  // SHU-803 AC1: stream_id captured from the first `stream_start` SSE
+  // event. Keyed by conversationId so a multi-tab user with multiple
+  // simultaneous streams can stop each independently. Map values reset
+  // when a stream completes or the conversation unmounts.
+  const streamIdByConversationRef = useRef(new Map());
 
   useEffect(() => {
     conversationRef.current = selectedConversation;
@@ -171,8 +184,8 @@ const useChatStreaming = ({
           });
         }
 
-        const ensurePlaceholderForVariant = (variantIndex) =>
-          ensurePlaceholderForVariantImpl({
+        const ensurePlaceholderForVariant = (variantIndex) => {
+          const placeholderId = ensurePlaceholderForVariantImpl({
             conversationId,
             variantIndex,
             placeholderLookup,
@@ -182,6 +195,27 @@ const useChatStreaming = ({
             resolvedParentId,
             placeholderRootOption,
           });
+          // SHU-803: stamp streamId on this placeholder if stream_start
+          // has already landed. Ensemble variants share one stream_id;
+          // each new variant placeholder needs the id stamped so its
+          // Stop button has the value to POST.
+          const streamId = streamIdByConversationRef.current.get(String(conversationId));
+          if (streamId && placeholderId) {
+            queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
+              const existing = getMessagesFromCache(oldData);
+              let mutated = false;
+              const updated = existing.map((m) => {
+                if (m.id === placeholderId && m.streamId !== streamId) {
+                  mutated = true;
+                  return { ...m, streamId };
+                }
+                return m;
+              });
+              return mutated ? rebuildCache(oldData, updated) : oldData;
+            });
+          }
+          return placeholderId;
+        };
 
         const syncPlaceholderParentIds = (newParentId) => {
           resolvedParentId = syncPlaceholderParentIdsImpl({
@@ -227,6 +261,10 @@ const useChatStreaming = ({
             } catch (_) {
               // Ignore error
             }
+            // SHU-803: stream completed — clear the captured stream_id
+            // so a future stream for the same conversation gets a fresh
+            // capture from its own stream_start event.
+            streamIdByConversationRef.current.delete(String(conversationId));
 
             if (!isMountedRef.current) {
               return;
@@ -254,6 +292,25 @@ const useChatStreaming = ({
           }
 
           const eventType = parsed?.event;
+
+          // SHU-803 AC1: capture the stream_id from the first SSE event
+          // so the Stop button has the id it needs to POST the terminate
+          // request. The event is additive — pre-SHU-803 clients ignore
+          // it. Stamping the streamId on every current placeholder lets
+          // MessageItem read it directly from the message in cache
+          // (rather than threading another ref through the render tree).
+          if (eventType === 'stream_start') {
+            const streamId = parsed?.content?.stream_id;
+            if (streamId) {
+              streamIdByConversationRef.current.set(String(conversationId), streamId);
+              queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
+                const existing = getMessagesFromCache(oldData);
+                const updated = existing.map((m) => (placeholderIdSet.has(m.id) ? { ...m, streamId } : m));
+                return rebuildCache(oldData, updated);
+              });
+            }
+            continue;
+          }
 
           if (eventType === 'user_message' && parsed?.content) {
             const finalUser = parsed.content;
@@ -546,9 +603,81 @@ const useChatStreaming = ({
     ]
   );
 
+  // SHU-803 AC4/AC5: Stop-button handler. POSTs the terminate endpoint
+  // and (on 202 / 410) immediately flips the placeholder out of
+  // `isStreaming` with a client-side `stream_state="user_terminated"`
+  // stamp so the user sees "Stopped by user" without waiting for the
+  // backend's `final_message` to arrive (drain may take many seconds
+  // on end-only-usage providers). When `final_message` lands, the
+  // persisted Message replaces the placeholder and stream_state will
+  // already match — see SHU-803 plan Decisions Log.
+  //
+  // Accepts a message object (so we can read streamId + conversation
+  // context off it). On 403, surfaces an error toast. On 5xx / network,
+  // same. The SSE iteration continues consuming the channel — we do NOT
+  // abort the AbortController; that's reserved for unmount / error.
+  const handleStopStream = useCallback(
+    async (message) => {
+      const streamId = message?.streamId;
+      const conversationId = message?.conversation_id;
+      if (!streamId) {
+        return;
+      }
+
+      let success = false;
+      try {
+        await chatAPI.terminateStream(streamId);
+        success = true;
+      } catch (error) {
+        const status = error?.response?.status;
+        if (status === STREAM_NOT_ACTIVE_STATUS) {
+          // STREAM_NOT_ACTIVE — the stream already finalized before
+          // the POST landed. AC5 treats this as success.
+          success = true;
+        } else if (status === FORBIDDEN_STATUS) {
+          setError("You don't own this stream — can't stop it.");
+        } else {
+          log.error('Failed to stop streaming response', error);
+          setError("Couldn't stop the response. Please try again.");
+        }
+      }
+
+      if (!success || !conversationId) {
+        return;
+      }
+
+      // Optimistic update: flip EVERY placeholder sharing this stream_id
+      // out of isStreaming and stamp `stream_state="user_terminated"`.
+      // Ensembles share a single stream_id across all variants, so a
+      // single Stop click marks all variants as stopped together.
+      queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
+        const existing = getMessagesFromCache(oldData);
+        let mutated = false;
+        const updated = existing.map((m) => {
+          if (m.streamId === streamId && (m.isStreaming || m.isPlaceholder)) {
+            mutated = true;
+            return {
+              ...m,
+              isStreaming: false,
+              isPlaceholder: false,
+              message_metadata: {
+                ...(m.message_metadata || {}),
+                stream_state: 'user_terminated',
+              },
+            };
+          }
+          return m;
+        });
+        return mutated ? rebuildCache(oldData, updated) : oldData;
+      });
+    },
+    [queryClient, setError]
+  );
+
   return {
     handleStreamingResponse,
     handleRegenerate,
+    handleStopStream,
   };
 };
 

--- a/frontend/src/components/chat/ModernChat/hooks/useMessageRegeneration.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useMessageRegeneration.js
@@ -397,6 +397,11 @@ const useMessageRegeneration = ({
           if (!hasContentStarted) {
             hasContentStarted = true;
             extra.reasoning_collapsed = true;
+            // SHU-803 follow-up: mirror the content_delta branch so the
+            // InputBar's "Initializing…" → enabled transition fires when
+            // an upstream emits raw ``parsed.content`` strings instead
+            // of typed ``content_delta`` events.
+            setStreamingStarted?.(true);
           }
           updateTempRegenContent(conversationId, tempId, regenAccum, extra);
         }

--- a/frontend/src/components/chat/ModernChat/hooks/useMessageRegeneration.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useMessageRegeneration.js
@@ -17,6 +17,12 @@ const useMessageRegeneration = ({
   shouldAutoFollowRef,
   focusMessageById,
   setError,
+  // SHU-803 follow-up: regenerate runs its own SSE loop independent of
+  // `handleStreamingResponse`, so it needs these state setters wired in
+  // directly. Without them, `streamingConversationId` stays null during
+  // a regen and the InputBar never flips Send → Stop.
+  setStreamingConversationId,
+  setStreamingStarted,
 }) => {
   const isMountedRef = useRef(false);
   const abortControllerRef = useRef(null);
@@ -80,6 +86,14 @@ const useMessageRegeneration = ({
       }
 
       startRegeneration(messageId, parentId, tempId);
+
+      // SHU-803 follow-up: mark the conversation as streaming BEFORE
+      // the SSE request fires so the InputBar swaps Send → Stop
+      // immediately. The Stop button stays disabled (with
+      // "Initializing…" tooltip) until the stream_start SSE event
+      // lands and stamps the streamId on the placeholder.
+      setStreamingConversationId?.(conversationId);
+      setStreamingStarted?.(false);
 
       queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
         const existing = getMessagesFromCache(oldData);
@@ -179,6 +193,12 @@ const useMessageRegeneration = ({
         }
 
         completeRegeneration(messageId);
+        // SHU-803 follow-up: release the InputBar back to Send. Idempotent
+        // with the optimistic clear in handleStopStream — if the user
+        // clicked Stop, streamingConversationId was already null; the
+        // setter no-ops on identity equality in React.
+        setStreamingConversationId?.(null);
+        setStreamingStarted?.(false);
       };
 
       try {
@@ -236,6 +256,25 @@ const useMessageRegeneration = ({
           }
 
           const eventType = parsed?.event;
+
+          // SHU-803 follow-up: stamp the streamId from stream_start on
+          // the regen placeholder so InputBar's handleInputBarStop can
+          // pick it up via `flattenedMessages.find(...)`. Without this,
+          // the Stop button stays disabled even when streaming.
+          if (eventType === 'stream_start') {
+            const streamId = parsed?.content?.stream_id;
+            if (streamId) {
+              queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
+                const existing = getMessagesFromCache(oldData);
+                const updated = existing.map((m) =>
+                  m.id === tempId && m.streamId !== streamId ? { ...m, streamId } : m
+                );
+                return rebuildCache(oldData, updated);
+              });
+            }
+            continue;
+          }
+
           if (eventType === 'final_message' && parsed?.content) {
             const created = {
               ...(parsed.content || {}),
@@ -284,6 +323,10 @@ const useMessageRegeneration = ({
             if (!hasContentStarted) {
               hasContentStarted = true;
               extra.reasoning_collapsed = true;
+              // SHU-803 follow-up: gate the InputBar's "Initializing…"
+              // → enabled transition on first content delta (matches
+              // the main streaming path's behavior).
+              setStreamingStarted?.(true);
             }
             updateTempRegenContent(conversationId, tempId, regenAccum, extra);
             continue;
@@ -388,6 +431,8 @@ const useMessageRegeneration = ({
       shouldAutoFollowRef,
       focusMessageById,
       conversationRef,
+      setStreamingConversationId,
+      setStreamingStarted,
     ]
   );
 

--- a/frontend/src/components/chat/ModernChat/hooks/useMessageRegeneration.js
+++ b/frontend/src/components/chat/ModernChat/hooks/useMessageRegeneration.js
@@ -4,6 +4,7 @@ import log from '../../../../utils/log';
 import { getMessagesFromCache, rebuildCache } from '../utils/chatCache';
 import { iterateSSE, tryParseJSON } from '../utils/sseParser';
 import { PLACEHOLDER_THINKING } from '../utils/chatConfig';
+import { makeStreamToken } from './useChatStreaming';
 
 const useMessageRegeneration = ({
   queryClient,
@@ -23,6 +24,11 @@ const useMessageRegeneration = ({
   // a regen and the InputBar never flips Send → Stop.
   setStreamingConversationId,
   setStreamingStarted,
+  // SHU-803 follow-up: owned by `useChatStreaming`; tracks which
+  // conversation currently holds the global streaming state. Both
+  // hooks compete to set/clear that state, so the ref serves as the
+  // canonical "do I still own this?" check before any clear.
+  streamingOwnerRef,
 }) => {
   const isMountedRef = useRef(false);
   const abortControllerRef = useRef(null);
@@ -91,7 +97,14 @@ const useMessageRegeneration = ({
       // the SSE request fires so the InputBar swaps Send → Stop
       // immediately. The Stop button stays disabled (with
       // "Initializing…" tooltip) until the stream_start SSE event
-      // lands and stamps the streamId on the placeholder.
+      // lands and stamps the streamId on the placeholder. Also claim
+      // ownership of the global streaming state — keyed by a per-
+      // stream token so a newer same-conv stream's claim isn't
+      // matched by this regen's closure.
+      const streamToken = makeStreamToken();
+      if (streamingOwnerRef) {
+        streamingOwnerRef.current = streamToken;
+      }
       setStreamingConversationId?.(conversationId);
       setStreamingStarted?.(false);
 
@@ -193,12 +206,16 @@ const useMessageRegeneration = ({
         }
 
         completeRegeneration(messageId);
-        // SHU-803 follow-up: release the InputBar back to Send. Idempotent
-        // with the optimistic clear in handleStopStream — if the user
-        // clicked Stop, streamingConversationId was already null; the
-        // setter no-ops on identity equality in React.
-        setStreamingConversationId?.(null);
-        setStreamingStarted?.(false);
+        // SHU-803 follow-up: release the InputBar back to Send, but
+        // only if this regen still owns the global streaming state.
+        // Keyed by this regen's per-instance streamToken (not
+        // conversationId) so a newer same-conv stream's claim isn't
+        // matched by this regen's closure.
+        if (streamingOwnerRef && streamingOwnerRef.current === streamToken) {
+          streamingOwnerRef.current = null;
+          setStreamingConversationId?.(null);
+          setStreamingStarted?.(false);
+        }
       };
 
       try {
@@ -257,18 +274,25 @@ const useMessageRegeneration = ({
 
           const eventType = parsed?.event;
 
-          // SHU-803 follow-up: stamp the streamId from stream_start on
-          // the regen placeholder so InputBar's handleInputBarStop can
-          // pick it up via `flattenedMessages.find(...)`. Without this,
-          // the Stop button stays disabled even when streaming.
+          // SHU-803 follow-up: stamp the streamId AND this regen's
+          // streamToken on the temp placeholder so the InputBar's
+          // handleInputBarStop can pick them up via
+          // `flattenedMessages.find(...)` AND so handleStopStream's
+          // ownership-ref guard has the per-stream token to compare.
           if (eventType === 'stream_start') {
             const streamId = parsed?.content?.stream_id;
             if (streamId) {
               queryClient.setQueryData(['conversation-messages', conversationId], (oldData) => {
                 const existing = getMessagesFromCache(oldData);
-                const updated = existing.map((m) =>
-                  m.id === tempId && m.streamId !== streamId ? { ...m, streamId } : m
-                );
+                const updated = existing.map((m) => {
+                  if (m.id !== tempId) {
+                    return m;
+                  }
+                  if (m.streamId === streamId && m.streamToken === streamToken) {
+                    return m;
+                  }
+                  return { ...m, streamId, streamToken };
+                });
                 return rebuildCache(oldData, updated);
               });
             }
@@ -433,6 +457,7 @@ const useMessageRegeneration = ({
       conversationRef,
       setStreamingConversationId,
       setStreamingStarted,
+      streamingOwnerRef,
     ]
   );
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -439,6 +439,12 @@ export const chatAPI = {
     api.post(`/chat/conversations/${conversationId}/send`, data, config),
   streamMessage: (conversationId, data, options = {}) =>
     sseStreamRequest(`${api.defaults.baseURL}/chat/conversations/${conversationId}/send`, data, options),
+  // SHU-803: terminate an in-flight chat stream. Returns 202 on success,
+  // 410 STREAM_NOT_ACTIVE if the stream already finalized, 403 if the
+  // caller isn't the stream's owner. Caller treats 202 and 410 as
+  // success (the stream's done either way); only surface a toast on 4xx
+  // ownership rejections or 5xx server errors.
+  terminateStream: (streamId) => api.post(`/chat/streams/${streamId}/terminate`),
   switchConversationModel: (conversationId, data) =>
     api.post(`/chat/conversations/${conversationId}/switch-model`, data),
 


### PR DESCRIPTION
## Description
Finishes the user-facing Stop feature that SHU-802 laid the backend groundwork for, and closes the billing-evasion abuse vector that surfaced during SHU-802 smoke testing: a user could craft a long-tail prompt, click Stop after the useful part, and pay $0 because most providers emit usage only as the final SSE chunk.

The implementation became larger than the original ticket scope because manual testing surfaced two genuine UX bugs (Stop button scrolled off-screen as content grew; partial answer disappeared during the backend drain window) plus several race conditions in the streaming hook lifecycle that needed proper protection. All of those are addressed in-branch.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Related to #SHU-802, built on top of
Follow-up #SHU-810, will harden the cancel functionality and provide more accurate billing


## Changes Made
### Backend

- **Cancel-then-drain pipeline** on user-terminate. The consumer loop calls `ResponsesAdapter.cancel()` (OpenAI Responses API path) as a best-effort upstream cancel, then enters a silent-consume "drain" mode to capture the end-of-stream usage chunk. Drain is uncapped (capping it would re-open the abuse vector); upper-bounded by the httpx 120s read timeout and the lifespan-shutdown escape valve.
- **Early-persist at terminate-signal time.** The partial `Message` row commits the moment the user clicks Stop, not at drain-finish. Fixes both the "vanishing partial content during drain" bug and the chronological-ordering race when a follow-up message is sent before drain completes.
- **`_iter_with_signal_break` wrapper** races provider chunks against the terminate signal so the early-persist fires immediately on signal, even when the provider has gone silent (slow networks, rate-limit pauses, reasoning models thinking).
- **Dedicated `StreamLifecycle.intentional_stop_event`** so a prior `client_disconnected` doesn't consume the wrapper's wake-up before a later intentional stop arrives.
- **Per-adapter partial-usage fixes**: Anthropic now captures `input_tokens` from `message_start`'s nested usage shape (previously only `message_delta` was captured); pricing normalization in `model_pricing.py` strips OpenRouter `vendor/` prefixes and `:tier` suffixes so DB-rate fallback resolves for `google/gemma-4-31b-it:nitro` and similar slugs.

### Frontend

- **Stop button placement** is in the input bar (replaces Send while streaming) rather than on the assistant bubble. The original ticket called for in-bubble; manual testing revealed the bubble's bottom edge scrolled below the viewport as content grew, moving the button with each delta and making it unclickable. Input-bar placement is a stable, predictable target.
- **Per-stream token ownership** of the global streaming state — earlier `conversationId`-keyed guards couldn't distinguish two streams in the same conversation, so a stopped stream's eventual `[DONE]` could clobber a newer stream's state. `makeStreamToken()` generates a per-invocation token; every clear callsite checks the closure-captured token against the ref.
- **Stop wired into the regenerate path** too. `useMessageRegeneration` runs its own SSE loop independent of `handleStreamingResponse`, and originally didn't capture `stream_start` or set `streamingConversationId` — so Stop never appeared during regen.
- **UX polish**: caption text differs between `user_terminated` ("Stopped by user") and `shutdown` ("Response stopped") to preserve accurate attribution; `PLACEHOLDER_THINKING` content is cleared on the optimistic Stop update so the bubble doesn't show "Thinking…" alongside the stopped caption.


## Testing
### Tests

| Suite | Tests | Coverage |
|---|---|---|
| `test_stream_lifecycle.py` | 35 | Signal priority + `intentional_stop_event` semantics |
| `test_iter_with_signal_break.py` (new) | 8 | Wrapper race semantics, silent-provider gap, cleanup |
| `test_drain_handler.py` | 12 | Lifespan-shutdown drain |
| `test_chat_force_terminate_real_usage_integration.py` (new) | 9 + teardown | Per-adapter partial-usage capture (Anthropic, Gemini, OpenAI Completions, OpenAI Responses, OpenRouter cost both wire + DB-rate paths) |
| `test_chat_early_persist_integration.py` (new) | 4 + teardown | Chronological ordering race, regen+terminate variant_index, silent-provider gap |
| `useChatStreaming.test.js` | 13 | `handleStopStream` semantics, `stream_start` parsing, ownership-token race regression, `Thinking…` clear |
| `useMessageRegeneration.test.js` (new) | 5 | Regen Stop wiring (stream_start capture, `streamingConversationId` lifecycle) |
| `InputBar.test.jsx` (new) | 7 | Send↔Stop swap, disabled `Initializing…` state, debounce |
| `MessageItem.test.jsx` | 6 | Stopped-state caption (`user_terminated` vs `shutdown` attribution) |

All unit + integration suites green; no regressions in SHU-802 disconnect-persistence or force-terminate suites.

### Manual validation

Walked through 8 end-to-end scenarios against live providers with logs + DB verified for each:

1. **OpenAI Responses (gpt-5.4-nano)** — Stop button UX + drain captures usage. Cancel endpoint returned 404 in production (covered by the follow-up ticket below).
2. **OpenRouter (Gemma 4 Nitro)** — drain captures end-of-stream usage; total_cost non-zero via DB-rate fallback.
3. **Anthropic direct (Claude Opus 4.6)** — native `AnthropicAdapter` path; `message_start` nested-usage capture confirmed (the AC9b fix).
4. **Chronological ordering race** — terminate + immediate Hello; persisted rows landed in conversational order despite the drain still running for ~30s in the background.
5. **Regen + Stop** — regenerated variant gets correct `variant_index` (sibling-max), `regenerated_from_message_id` stamped.
6. **Ensemble + Stop** — both variants stamped together; one click cascades to all.
7. **Ensemble + Regen + Stop** — sibling-max calculation works across pre-existing ensemble variants.
8. **Same-conversation race (Codex follow-up scenario)** — Stop A, immediately send long-response B; logs confirmed A's `[DONE]` fired *square in the middle* of B's 41s streaming window. InputBar stayed on Stop throughout — the per-stream token guard held.



## Deployment Notes
- [N/A] Database migrations required
- [N/A] Environment variables added/changed
- [N/A] Dependencies added/updated
- [N/A] Configuration changes needed

## Reviewer Notes
### Follow-up ticket

Filed a follow-up ticket SHU-810 for **cancel-endpoint reliability**. Manual testing showed OpenAI's `/v1/responses/{id}/cancel` returns 404 in practice for streaming responses across multiple models (likely requires `background: true` mode, which would break our streaming UX). The current architecture handles this correctly via the drain backstop — billing fidelity is preserved — but the cancel call is effectively dormant for all production providers Shu currently talks to. The follow-up scopes a **surgical investigation + targeted fix** to actually realize the cost-savings the architecture was designed for, with the existing "try cancel, fall through to drain" contract preserved and explicit trade-off guards to prevent re-opening the SHU-803 abuse vector. Out of scope for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop button to halt in-progress message generation; terminated messages show “Stopped by user” or “Response stopped”.
  * Server-side terminate-stream endpoint with client-side stop action; partial assistant messages can be early-persisted at termination.

* **Improvements**
  * Model pricing lookup now handles varied model name formats with DB fallback.
  * More accurate usage capture, cancel support for providers, and stronger shutdown/termination signaling to reduce race conditions.

* **Tests**
  * Extensive new unit and integration tests covering streaming, termination, pricing, and cancel behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->