### PR TITLE
Tenant column text to UUID

### DIFF
--- a/backend/migrations/versions/r009_0003_uuid_column_types.py
+++ b/backend/migrations/versions/r009_0003_uuid_column_types.py
@@ -1,0 +1,293 @@
+"""Convert tenants.id and every tenant_id column to native `uuid`.
+
+Revision ID: r009_0003
+Revises: r009_0002
+Create Date: 2026-05-22
+
+Narrow scope: only the columns SHU-761 actually introduced and reads in
+its RLS hot path. Other UUID-storing columns across the schema (every
+``id`` column on every BaseModel-inheriting table, every ``String(36)``
+FK column) stay as ``text`` / ``varchar`` for now — flipping those is a
+deliberate type-uniformity sweep we may do later, but it's not what the
+reviewer's specific pushback on 009 was about.
+
+What this migration touches:
+
+* ``tenants.id`` (the parent of every ``tenant_id`` FK).
+* ``tenant_id`` on each of the 39 tenant-scoped tables enumerated below.
+
+Why uuid here:
+
+* The reviewer flagged ``tenants.id text PRIMARY KEY`` in 009 because:
+  - storage is ~2.5x smaller as native uuid (16 vs ~40 bytes per cell),
+  - comparisons are a single 128-bit op vs byte-by-byte string compare,
+  - the column type itself enforces UUID shape on insert.
+* The savings show up most on ``tenant_id`` indexes, which are scanned
+  by every RLS-policied query in the database.
+* RLS predicates change from ``tenant_id = current_setting(...)`` to
+  ``tenant_id = current_setting(...)::uuid``. One cast site per policy,
+  fired once per query at policy-evaluation time — not per row.
+
+Strategy:
+
+1. Snapshot every FK on ``tenants`` and on every tenant-scoped table via
+   ``pg_get_constraintdef()`` — captures the canonical Postgres-rendered
+   SQL so we can round-trip without hand-listing each constraint.
+2. Drop all snapshotted FKs and the ``tenant_isolation`` RLS policy on
+   every tenant-scoped table. Columns can't change type while either
+   binds them.
+3. ``ALTER tenants.id`` to uuid (after ``DROP DEFAULT`` — see below).
+4. ``ALTER`` each ``tenant_id`` to uuid (after ``DROP DEFAULT``).
+5. Restore FKs from the snapshot. Postgres re-validates against the new
+   uuid columns on the way back in.
+6. Recreate RLS policies with the ``::uuid`` cast on the GUC.
+
+DROP DEFAULT step: 009 added every ``tenant_id`` column with a text
+``DEFAULT '<placeholder-uuid>'`` so ``ADD COLUMN NOT NULL`` was
+metadata-only on PG 11+. Postgres won't auto-cast that text default to
+uuid, so we shed it first. App code always supplies ``tenant_id``
+explicitly via the ``tenant_context`` ContextVar, so the default isn't
+needed post-migration.
+
+ORM-side changes that go in the same PR (NOT in this migration file):
+* ``TenantScopedMixin.tenant_id`` flips from ``String`` to
+  ``UUID(as_uuid=False)`` so Python keeps round-tripping strings (no
+  code churn on comparisons or JSON serialization).
+* ``Tenant.id`` flips the same way.
+
+Downgrade casts uuid back to ``text``. Note that this does NOT restore
+the original ``varchar(36)`` constraint on any column — the original
+``tenant_id`` columns were already declared as raw ``text`` by 009, so
+the downgrade is a faithful inverse for *these* columns only. Columns
+this migration never touches are unaffected.
+
+Policy: idempotent only on a clean re-run after a successful upgrade;
+not partial-re-runnable (temp tables drop at session end). Use
+``alembic downgrade`` to revert, not partial re-application.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "r009_0003"
+down_revision = "r009_0002"
+branch_labels = None
+depends_on = None
+
+
+_TENANTS_TABLE = "tenants"
+
+# Mirror of 009's `_TENANT_SCOPED_TABLES`. If 009 ever picks up a new
+# tenant-scoped table, this list grows in lockstep — same drift hazard
+# 009 already documents.
+_TENANT_SCOPED_TABLES: tuple[str, ...] = (
+    "access_policies",
+    "access_policy_bindings",
+    "access_policy_statements",
+    "agent_memory",
+    "attachments",
+    "billing_state",
+    "billing_state_audit",
+    "conversations",
+    "document_chunks",
+    "document_participants",
+    "document_projects",
+    "document_queries",
+    "documents",
+    "email_send_log",
+    "experience_runs",
+    "experience_steps",
+    "experiences",
+    "knowledge_bases",
+    "llm_usage",
+    "mcp_server_connections",
+    "message_attachments",
+    "messages",
+    "model_configuration_kb_prompts",
+    "model_configuration_knowledge_bases",
+    "model_configurations",
+    "password_reset_token",
+    "plugin_executions",
+    "plugin_feeds",
+    "plugin_storage",
+    "plugin_subscriptions",
+    "prompt_assignments",
+    "prompts",
+    "provider_credentials",
+    "provider_identities",
+    "system_settings",
+    "user_group_memberships",
+    "user_groups",
+    "user_preferences",
+    "users",
+)
+
+
+def _touched_tables_sql() -> str:
+    """Postgres array literal of the tables we snapshot / restore FKs on."""
+    tables = (_TENANTS_TABLE,) + _TENANT_SCOPED_TABLES
+    return ",".join(f"'{t}'" for t in tables)
+
+
+def upgrade() -> None:
+    """tenants.id + every tenant_id column → uuid."""
+
+    # 1. Snapshot every FK touching one of our tables. Captures both the
+    #    composite FKs from 009 (the (col, tenant_id) → (id, tenant_id)
+    #    shape) and the simple tenant_id → tenants.id FKs.
+    op.execute(
+        """
+        CREATE TEMP TABLE _r009_0003_fk_snapshot (
+            table_name text NOT NULL,
+            constraint_name text NOT NULL,
+            definition text NOT NULL
+        ) ON COMMIT DROP
+        """
+    )
+    op.execute(
+        f"""
+        INSERT INTO _r009_0003_fk_snapshot (table_name, constraint_name, definition)
+        SELECT cls.relname, con.conname, pg_get_constraintdef(con.oid)
+        FROM pg_constraint con
+        JOIN pg_class cls ON cls.oid = con.conrelid
+        LEFT JOIN pg_class ref_cls ON ref_cls.oid = con.confrelid
+        WHERE con.contype = 'f'
+          AND (cls.relname = ANY (ARRAY[{_touched_tables_sql()}])
+               OR ref_cls.relname = ANY (ARRAY[{_touched_tables_sql()}]))
+        """
+    )
+
+    # 2. Drop all snapshotted FKs and every tenant_isolation policy.
+    op.execute(
+        """
+        DO $$
+        DECLARE r RECORD;
+        BEGIN
+            FOR r IN SELECT table_name, constraint_name FROM _r009_0003_fk_snapshot LOOP
+                EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I',
+                               r.table_name, r.constraint_name);
+            END LOOP;
+        END $$
+        """
+    )
+    for table in _TENANT_SCOPED_TABLES:
+        op.execute(f"DROP POLICY IF EXISTS tenant_isolation ON {table}")
+
+    # 3. Flip tenants.id.
+    op.execute(f"ALTER TABLE {_TENANTS_TABLE} ALTER COLUMN id DROP DEFAULT")
+    op.execute(
+        f"ALTER TABLE {_TENANTS_TABLE} ALTER COLUMN id TYPE uuid USING id::uuid"
+    )
+
+    # 4. Flip every tenant_id column. DROP DEFAULT first to shed the
+    #    009-era text placeholder; app code always supplies tenant_id
+    #    explicitly so the default isn't re-added.
+    for table in _TENANT_SCOPED_TABLES:
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN tenant_id DROP DEFAULT")
+        op.execute(
+            f"ALTER TABLE {table} ALTER COLUMN tenant_id TYPE uuid USING tenant_id::uuid"
+        )
+
+    # 5. Restore FKs verbatim from the snapshot.
+    op.execute(
+        """
+        DO $$
+        DECLARE r RECORD;
+        BEGIN
+            FOR r IN SELECT table_name, constraint_name, definition FROM _r009_0003_fk_snapshot LOOP
+                EXECUTE format('ALTER TABLE %I ADD CONSTRAINT %I %s',
+                               r.table_name, r.constraint_name, r.definition);
+            END LOOP;
+        END $$
+        """
+    )
+
+    # 6. Recreate RLS policies with the ::uuid cast on the GUC. The GUC
+    #    itself stays text (set_config takes text), so the cast happens
+    #    once per query at policy-evaluation time, not per row.
+    for table in _TENANT_SCOPED_TABLES:
+        op.execute(
+            f"""
+            CREATE POLICY tenant_isolation ON {table}
+            AS PERMISSIVE FOR ALL TO shu_app
+            USING (tenant_id = current_setting('app.tenant_id', true)::uuid)
+            WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)
+            """
+        )
+
+
+def downgrade() -> None:
+    """Symmetric reverse: uuid → text on the same column set."""
+
+    op.execute(
+        """
+        CREATE TEMP TABLE _r009_0003_fk_snapshot (
+            table_name text NOT NULL,
+            constraint_name text NOT NULL,
+            definition text NOT NULL
+        ) ON COMMIT DROP
+        """
+    )
+    op.execute(
+        f"""
+        INSERT INTO _r009_0003_fk_snapshot (table_name, constraint_name, definition)
+        SELECT cls.relname, con.conname, pg_get_constraintdef(con.oid)
+        FROM pg_constraint con
+        JOIN pg_class cls ON cls.oid = con.conrelid
+        LEFT JOIN pg_class ref_cls ON ref_cls.oid = con.confrelid
+        WHERE con.contype = 'f'
+          AND (cls.relname = ANY (ARRAY[{_touched_tables_sql()}])
+               OR ref_cls.relname = ANY (ARRAY[{_touched_tables_sql()}]))
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        DECLARE r RECORD;
+        BEGIN
+            FOR r IN SELECT table_name, constraint_name FROM _r009_0003_fk_snapshot LOOP
+                EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I',
+                               r.table_name, r.constraint_name);
+            END LOOP;
+        END $$
+        """
+    )
+    for table in _TENANT_SCOPED_TABLES:
+        op.execute(f"DROP POLICY IF EXISTS tenant_isolation ON {table}")
+
+    op.execute(f"ALTER TABLE {_TENANTS_TABLE} ALTER COLUMN id DROP DEFAULT")
+    op.execute(
+        f"ALTER TABLE {_TENANTS_TABLE} ALTER COLUMN id TYPE text USING id::text"
+    )
+    for table in _TENANT_SCOPED_TABLES:
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN tenant_id DROP DEFAULT")
+        op.execute(
+            f"ALTER TABLE {table} ALTER COLUMN tenant_id TYPE text USING tenant_id::text"
+        )
+
+    op.execute(
+        """
+        DO $$
+        DECLARE r RECORD;
+        BEGIN
+            FOR r IN SELECT table_name, constraint_name, definition FROM _r009_0003_fk_snapshot LOOP
+                EXECUTE format('ALTER TABLE %I ADD CONSTRAINT %I %s',
+                               r.table_name, r.constraint_name, r.definition);
+            END LOOP;
+        END $$
+        """
+    )
+
+    # Restore the pre-r009_0003 RLS policy shape (no ::uuid cast).
+    for table in _TENANT_SCOPED_TABLES:
+        op.execute(
+            f"""
+            CREATE POLICY tenant_isolation ON {table}
+            AS PERMISSIVE FOR ALL TO shu_app
+            USING (tenant_id = current_setting('app.tenant_id', true))
+            WITH CHECK (tenant_id = current_setting('app.tenant_id', true))
+            """
+        )

--- a/backend/src/shu/models/base.py
+++ b/backend/src/shu/models/base.py
@@ -7,7 +7,7 @@ for all database models.
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import ForeignKey, String
+from sqlalchemy import ForeignKey, String, Uuid
 from sqlalchemy.dialects.postgresql import TIMESTAMP
 from sqlalchemy.exc import MissingGreenlet
 from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
@@ -52,7 +52,7 @@ class TenantScopedMixin:
     # index=True: every query under RLS filters on tenant_id, so the index is what
     # keeps that mandatory predicate cheap.
     tenant_id: Mapped[str] = mapped_column(
-        String,
+        Uuid(as_uuid=False),
         ForeignKey("tenants.id", ondelete="RESTRICT"),
         nullable=False,
         index=True,

--- a/backend/src/shu/models/billing_state.py
+++ b/backend/src/shu/models/billing_state.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import BigInteger, Boolean, CheckConstraint, Column, ForeignKey, Integer, String, Text
+from sqlalchemy import BigInteger, Boolean, CheckConstraint, Column, ForeignKey, Integer, Text, Uuid
 from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -44,8 +44,18 @@ class BillingState(TenantScopedMixin, Base):
 
     # Override the mixin's tenant_id column to make it the primary key.
     # No explicit index — the PK constraint creates one implicitly.
+    #
+    # `Uuid(as_uuid=False)` matches `TenantScopedMixin.tenant_id` and the
+    # `tenants.id` UUID column in Postgres. Declaring the column as
+    # `String` here would still pass the FK referential check, but
+    # SQLAlchemy would bind the INSERT parameter as `$1::VARCHAR` and
+    # asyncpg/Postgres refuses the implicit `varchar → uuid` cast,
+    # surfacing as `DatatypeMismatchError` at flush time. The
+    # `as_uuid=False` form keeps the Python attribute as `str` so the
+    # `before_flush` listener can keep stamping the string returned by
+    # `tenant_context.get()` without converting to `uuid.UUID`.
     tenant_id: Mapped[str] = mapped_column(
-        String,
+        Uuid(as_uuid=False),
         ForeignKey("tenants.id", ondelete="RESTRICT"),
         primary_key=True,
     )

--- a/backend/src/shu/models/tenant.py
+++ b/backend/src/shu/models/tenant.py
@@ -8,7 +8,7 @@ infrastructure that every tenant-scoped FK references.
 
 from datetime import datetime
 
-from sqlalchemy import String, func
+from sqlalchemy import Uuid, func
 from sqlalchemy.dialects.postgresql import TIMESTAMP
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -31,7 +31,7 @@ class Tenant(Base):
 
     __tablename__ = "tenants"
 
-    id: Mapped[str] = mapped_column(String, primary_key=True)
+    id: Mapped[str] = mapped_column(Uuid(as_uuid=False), primary_key=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),
         server_default=func.now(),


### PR DESCRIPTION
# CHANGE THE BASE OF THIS PR BEFORE MERGING

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
<!-- Link to related issues using #issue_number -->
Closes #

## Changes Made
<!-- List the main changes made in this PR -->
-
-
-

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All tests passing locally

## Code Quality Checklist
<!-- All items must be checked before merging -->

### Backend (Python)

- [ ] Type hints added to all new functions/classes
- [ ] Docstrings added to all public functions/classes
- [ ] Unit tests written for new code
- [ ] ConfigurationManager used (no hardcoded values)
- [ ] Dependency injection used (no direct instantiation)
- [ ] Timezone-aware datetimes used
- [ ] No breaking migration changes
- [ ] Files end with trailing newlines

### Frontend (React/JavaScript)

- [ ] Functional components with hooks used
- [ ] log.js used instead of console.*
- [ ] React Query used for server state
- [ ] Envelope utilities used (extractDataFromResponse)
- [ ] Material-UI components used
- [ ] Components < 500 LOC
- [ ] Custom hooks for complex logic

### API

- [ ] ShuResponse helper used
- [ ] Envelope format followed
- [ ] Proper HTTP status codes
- [ ] Pydantic schemas defined in schemas/

### Linting

- [ ] Pre-commit hooks pass
- [ ] CI linting checks pass
- [ ] No linting warnings ignored without justification

### Documentation

- [ ] Code comments added where needed
- [ ] README updated (if applicable)
- [ ] API docs updated (if applicable)
- [ ] Migration guide provided (if breaking change)

### Security

- [ ] No hardcoded secrets or credentials
- [ ] No sensitive data in logs
- [ ] Input validation added
- [ ] Authentication/authorization checked

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Deployment Notes
<!-- Any special deployment considerations? -->
- [ ] Database migrations required
- [ ] Environment variables added/changed
- [ ] Dependencies added/updated
- [ ] Configuration changes needed

## Reviewer Notes
<!-- Anything specific you want reviewers to focus on? -->

## Post-Merge Tasks
<!-- Tasks to complete after merging -->
- [ ] Update documentation
- [ ] Notify stakeholders
- [ ] Monitor logs/metrics
- [ ] Update related issues

---

**By submitting this PR, I confirm that:**

- [ ] I have run `make lint-fix` and all linting checks pass
- [ ] I have tested my changes locally
- [ ] I have followed the coding standards in `docs/policies/DEVELOPMENT_STANDARDS.md`
- [ ] I have read and followed the linting policy in `docs/policies/LINTING_POLICY.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated the database schema to use native UUID format for all tenant identifier columns instead of text storage, improving data consistency, performance, and system type safety.
  * Updated application models to align with the new UUID-based tenant identification system, eliminating potential implicit type casting concerns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Shu/shu/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->