### PR TITLE
fix(migrations): defuse orphan FK refs and set owner_id ON DELETE SET…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,14 +158,14 @@
         "filename": "backend/scripts/database.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 66
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/scripts/database.py",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 64
+        "line_number": 71
       }
     ],
     "backend/scripts/run_dev.py": [
@@ -832,5 +832,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-01T18:32:07Z"
+  "generated_at": "2026-05-28T21:51:34Z"
 }

--- a/backend/migrations/versions/009_tenant_isolation.py
+++ b/backend/migrations/versions/009_tenant_isolation.py
@@ -223,6 +223,91 @@ def _replace_policy(table: str, policy: str, body: str) -> None:
     op.execute(f"CREATE POLICY {policy} ON {table} {body}")
 
 
+def _defuse_orphan_composite_fk_refs() -> None:
+    """Convert dangling child→parent references into a VALIDATE-compatible state.
+
+    The pre-009 schema had gaps where child columns lacked a foreign key to
+    their parent (notably ``knowledge_bases.owner_id`` → ``users.id``). That
+    allowed legitimate operations — e.g. spinning up a privileged user to
+    ingest a corpus, then deleting the user once done — to leave child rows
+    pointing at a parent that no longer exists. The data in the child row is
+    real and worth keeping; the dangling reference is the lie.
+
+    For each composite FK we're about to validate:
+      * If the child column is NULLABLE: set dangling refs to NULL. The
+        composite FK is satisfied vacuously by a NULL child column (SQL
+        MATCH SIMPLE), so VALIDATE then passes without touching the row's
+        other data.
+      * If the child column is NOT NULL: there is no clean recovery — the
+        row literally cannot exist without a valid parent. Collect every
+        such case and raise ONE error listing all of them, so the operator
+        sees the full remediation list rather than fixing-and-rerunning one
+        constraint at a time.
+
+    Idempotent: a re-run finds zero orphans (we just nulled them) and exits
+    silently.
+    """
+    bind = op.get_bind()
+    nulled: list[tuple[str, str, int]] = []
+    blocked: list[tuple[str, str, str, str, int]] = []
+
+    for child, child_col, parent, parent_col in _COMPOSITE_FKS:
+        is_nullable = bind.execute(
+            sa.text(
+                "SELECT is_nullable = 'YES' FROM information_schema.columns "
+                "WHERE table_schema = current_schema() AND table_name = :t AND column_name = :c"
+            ),
+            {"t": child, "c": child_col},
+        ).scalar()
+
+        orphan_count = bind.execute(
+            sa.text(
+                f"SELECT COUNT(*) FROM {child} c "
+                f"WHERE c.{child_col} IS NOT NULL "
+                f"  AND NOT EXISTS ("
+                f"    SELECT 1 FROM {parent} p "
+                f"    WHERE p.tenant_id = c.tenant_id AND p.{parent_col} = c.{child_col}"
+                f"  )"
+            )
+        ).scalar()
+
+        if not orphan_count:
+            continue
+
+        if is_nullable:
+            bind.execute(
+                sa.text(
+                    f"UPDATE {child} SET {child_col} = NULL "
+                    f"WHERE {child_col} IS NOT NULL "
+                    f"  AND NOT EXISTS ("
+                    f"    SELECT 1 FROM {parent} p "
+                    f"    WHERE p.tenant_id = {child}.tenant_id AND p.{parent_col} = {child}.{child_col}"
+                    f"  )"
+                )
+            )
+            nulled.append((child, child_col, orphan_count))
+        else:
+            blocked.append((child, child_col, parent, parent_col, orphan_count))
+
+    for child, child_col, n in nulled:
+        print(
+            f"[009] Nulled {n} orphan ref(s) in {child}.{child_col} "
+            f"(nullable; parent row missing — data preserved, ownership cleared)",
+            flush=True,
+        )
+
+    if blocked:
+        lines = [
+            "Composite FK validation would fail: NOT NULL child columns reference",
+            "missing parent rows. The migration cannot auto-resolve these because",
+            "the row cannot exist without a valid parent. Resolve manually, then",
+            "re-run. Orphan inventory:",
+        ]
+        for child, child_col, parent, parent_col, n in blocked:
+            lines.append(f"  - {child}.{child_col} -> {parent}({parent_col}): {n} orphan(s)")
+        raise RuntimeError("\n".join(lines))
+
+
 # Section C SQL kept as a single string so the function bodies (which include
 # $$ delimiters) read naturally alongside their grants.
 _SD_FUNCTIONS_SQL = r"""
@@ -601,6 +686,13 @@ def upgrade() -> None:
     # row to reference a parent in a different tenant — Postgres refuses the
     # insert. The existing single-column FK stays in place alongside.
     # =========================================================================
+
+    # Pre-flight: defuse dangling refs left by pre-009 schema gaps (e.g.
+    # knowledge_bases.owner_id had no FK to users.id, so deleting a user
+    # silently orphaned their KBs). Nullable child columns get their dangling
+    # refs nulled; NOT NULL columns fail loud with the full inventory.
+    _defuse_orphan_composite_fk_refs()
+
     inventory = list(_COMPOSITE_FKS)
 
     parent_uniques = sorted({(parent, parent_col) for _, _, parent, parent_col in inventory})

--- a/backend/migrations/versions/r009_0004_kb_owner_id_set_null.py
+++ b/backend/migrations/versions/r009_0004_kb_owner_id_set_null.py
@@ -1,0 +1,54 @@
+"""Set ON DELETE SET NULL (owner_id) on knowledge_bases_owner_id_tfk.
+
+Revision ID: r009_0004
+Revises: r009_0003
+Create Date: 2026-05-28
+
+knowledge_bases.owner_id is nullable by design: a knowledge base outlives its
+creator. The common pattern is spinning up a privileged user to ingest a
+corpus, then deleting that user once ingestion is done — the corpus stays.
+
+009 added the composite FK ``(tenant_id, owner_id) REFERENCES users(tenant_id,
+id)`` without an ``ON DELETE`` clause, which defaults to NO ACTION. That
+would block the user deletion in the pattern above. This migration changes
+it to ``ON DELETE SET NULL (owner_id)`` — when a user is deleted, the KB's
+``owner_id`` becomes NULL (an honest "no current owner" state) and the row
+survives. The column-list ``(owner_id)`` scopes the NULL to that one column
+only — without it, ``tenant_id`` would also be nulled, breaking RLS.
+
+Requires PostgreSQL 15+ for the column-list syntax on ``ON DELETE SET NULL``.
+
+Idempotent: DROP IF EXISTS + ADD CONSTRAINT recreates the constraint in the
+desired shape regardless of prior state.
+
+Policy: idempotent per docs/policies/DB_MIGRATION_POLICY.md §Policy.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "r009_0004"
+down_revision = "r009_0003"
+branch_labels = None
+depends_on = None
+
+
+CONSTRAINT_NAME = "knowledge_bases_owner_id_tfk"
+
+
+def upgrade() -> None:
+    op.execute(f"ALTER TABLE knowledge_bases DROP CONSTRAINT IF EXISTS {CONSTRAINT_NAME}")
+    op.execute(
+        f"ALTER TABLE knowledge_bases ADD CONSTRAINT {CONSTRAINT_NAME} "
+        f"FOREIGN KEY (tenant_id, owner_id) REFERENCES users(tenant_id, id) "
+        f"ON DELETE SET NULL (owner_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"ALTER TABLE knowledge_bases DROP CONSTRAINT IF EXISTS {CONSTRAINT_NAME}")
+    op.execute(
+        f"ALTER TABLE knowledge_bases ADD CONSTRAINT {CONSTRAINT_NAME} "
+        f"FOREIGN KEY (tenant_id, owner_id) REFERENCES users(tenant_id, id)"
+    )

--- a/backend/scripts/database.py
+++ b/backend/scripts/database.py
@@ -44,6 +44,13 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 INIT_SQL_PATH = PROJECT_ROOT.parent / "init-db.sql"
 ALEMBIC_INI_PATH = PROJECT_ROOT / "alembic.ini"
 
+# Mirror the sys.path setup in migrations/env.py so that helpers which load
+# migration files before alembic invokes env.py (e.g. _resolve_orphaned_revision
+# → walk_revisions()) can resolve `from shu...` imports inside migration modules.
+_SRC_PATH = PROJECT_ROOT / "src"
+if str(_SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(_SRC_PATH))
+
 LOG_PREFIX = "[database]"
 
 


### PR DESCRIPTION
… NULL

- Add `_defuse_orphan_composite_fk_refs()` pre-flight in 009 to null dangling nullable child refs and raise a clear inventory error for NOT NULL ones before composite FK validation runs
- Add migration r009_0004 to change knowledge_bases composite FK to ON DELETE SET NULL (owner_id), preserving KBs when owners are deleted
- Fix sys.path setup in database.py to resolve src imports outside alembic