### PR TITLE
fix(auth): [SHU-840] admin_emails list takes precedence over first-us…

### DIFF
--- a/backend/src/shu/services/user_service.py
+++ b/backend/src/shu/services/user_service.py
@@ -116,10 +116,18 @@ class UserService:
         return True
 
     def determine_user_role(self, email: str, is_first_user: bool) -> UserRole:
-        # Determine user role
-        is_admin_email = email.lower() in [admin_email.lower() for admin_email in self.settings.admin_emails]
+        admin_emails = self.settings.admin_emails
+        is_admin_email = email.lower() in [admin_email.lower() for admin_email in admin_emails]
+        if is_admin_email:
+            return UserRole.ADMIN
 
-        if is_first_user or is_admin_email:
+        # First-user-becomes-admin is a bootstrap convenience for self-hosted
+        # installs with NO configured admins. When ADMIN_EMAILS is set — every
+        # hosted silo tenant, where the control plane seeds the customer's email
+        # into it at provision — that list is authoritative: a stranger who
+        # races to register first on a fresh tenant must NOT inherit admin
+        # (SHU-840). The configured admin still gets admin via is_admin_email.
+        if is_first_user and not admin_emails:
             return UserRole.ADMIN
         return UserRole.REGULAR_USER
 
@@ -129,7 +137,14 @@ class UserService:
         return result.scalar_one_or_none() is None
 
     def is_active(self, user_role: UserRole, is_first_user: bool) -> bool:
-        return is_first_user or user_role == UserRole.ADMIN or self.settings.auto_activate_users
+        if user_role == UserRole.ADMIN or self.settings.auto_activate_users:
+            return True
+        # First-user auto-activation is the same self-hosted bootstrap as the
+        # admin grant above: only when no admins are configured. Otherwise a
+        # stranger who registers first on a hosted tenant (now a regular_user,
+        # not admin) would still land ACTIVE — they must instead wait for the
+        # configured admin to activate them (SHU-840).
+        return is_first_user and not self.settings.admin_emails
 
     async def get_user_auth_method(self, db: AsyncSession, email: str) -> str | None:
         auth_method_result = await db.execute(select(User.auth_method).where(func.lower(User.email) == email.lower()))

--- a/backend/src/tests/unit/api/test_sso_properties.py
+++ b/backend/src/tests/unit/api/test_sso_properties.py
@@ -18,10 +18,13 @@ class TestRoleActivationConsistency:
     Property 6: Role and activation logic is consistent across providers.
 
     For any SSO provider (Google or Microsoft) and any email address, the role
-    determination and activation logic SHALL produce identical results. Specifically:
-    - If the user is the first user in the system, they SHALL be assigned admin role and be active
+    determination and activation logic SHALL produce identical results. With
+    admin_emails configured (as here — and as on every hosted silo tenant), that
+    list is authoritative (SHU-840):
     - If the email is in the configured admin_emails list, they SHALL be assigned admin role and be active
-    - Otherwise, they SHALL be assigned regular_user role and be inactive (requiring admin activation)
+    - Otherwise they SHALL be assigned regular_user role and be inactive (requiring admin activation),
+      including the first user — first-user-becomes-admin applies only to a self-hosted install with NO
+      configured admins.
 
     **Validates: Requirements 3.3, 3.4**
     """
@@ -48,10 +51,10 @@ class TestRoleActivationConsistency:
 
         **Validates: Requirements 3.3, 3.4**
 
-        This property verifies that for any provider and email combination:
-        1. First user always becomes admin and is active
-        2. Admin emails always become admin and are active
-        3. Regular users are assigned regular_user role and are inactive
+        This property verifies that for any provider and email combination, with
+        admin_emails configured (authoritative — SHU-840):
+        1. Admin emails become admin and are active
+        2. Everyone else — including the first user — is regular_user and inactive
         """
         from shu.auth.models import UserRole
         from shu.services.user_service import UserService
@@ -69,19 +72,17 @@ class TestRoleActivationConsistency:
         role = service.determine_user_role(email, is_first_user)
         is_active = service.is_active(role, is_first_user)
 
-        # Property assertions
-        if is_first_user:
-            # First user is always admin and active
-            assert role == UserRole.ADMIN, f"First user should be admin, got {role}"
-            assert is_active is True, "First user should be active"
-        elif is_admin_email:
-            # Admin email is always admin and active
+        # Property assertions. admin_emails is configured (non-empty), so it is
+        # authoritative (SHU-840): admin iff the email is on the list. is_first_user
+        # does NOT grant admin or activation here.
+        if is_admin_email:
             assert role == UserRole.ADMIN, f"Admin email should be admin, got {role}"
             assert is_active is True, "Admin email user should be active"
         else:
-            # Regular user is regular_user and inactive
-            assert role == UserRole.REGULAR_USER, f"Regular user should be regular_user, got {role}"
-            assert is_active is False, "Regular user should be inactive"
+            assert role == UserRole.REGULAR_USER, (
+                f"Non-admin email should be regular_user even as first user, got {role}"
+            )
+            assert is_active is False, "Non-admin user should be inactive"
 
     @given(
         _provider_key_1=st.sampled_from(["google", "microsoft"]),

--- a/backend/src/tests/unit/services/test_user_service.py
+++ b/backend/src/tests/unit/services/test_user_service.py
@@ -21,8 +21,8 @@ class TestIsActive:
         service.settings.admin_emails = []
         return service
 
-    def test_first_user_always_active(self, user_service):
-        """First user is always active regardless of role or auto_activate setting."""
+    def test_first_user_active_when_no_admins_configured(self, user_service):
+        """First user is active (self-hosted bootstrap) when ADMIN_EMAILS is empty."""
         assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=True) is True
 
     def test_admin_always_active(self, user_service):
@@ -46,6 +46,63 @@ class TestIsActive:
     def test_auto_activate_does_not_change_first_user_behavior(self, user_service):
         """First-user activation is unchanged when auto_activate is enabled."""
         user_service.settings.auto_activate_users = True
+        assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=True) is True
+
+
+class TestAdminEmailsAuthoritative:
+    """SHU-840: when ADMIN_EMAILS is configured (every hosted silo tenant — the
+    CP seeds the customer's email at provision), that list is the sole authority
+    for admin + first-login activation. A stranger who races to register first
+    must not inherit admin, nor land active. First-user-becomes-admin and
+    first-user-auto-active remain only as the self-hosted, no-admins-configured
+    bootstrap."""
+
+    @pytest.fixture
+    def user_service(self):
+        service = UserService()
+        service.settings = MagicMock()
+        service.settings.auto_activate_users = False
+        service.settings.admin_emails = ["owner@acme.com"]
+        return service
+
+    def test_configured_admin_email_is_admin(self, user_service):
+        assert (
+            user_service.determine_user_role("owner@acme.com", is_first_user=False)
+            == UserRole.ADMIN
+        )
+
+    def test_configured_admin_email_match_is_case_insensitive(self, user_service):
+        assert (
+            user_service.determine_user_role("Owner@ACME.com", is_first_user=True)
+            == UserRole.ADMIN
+        )
+
+    def test_first_user_not_in_admin_list_is_regular(self, user_service):
+        # The hole: a stranger registering first on a fresh tenant whose
+        # ADMIN_EMAILS names the customer must NOT become admin.
+        assert (
+            user_service.determine_user_role("stranger@evil.com", is_first_user=True)
+            == UserRole.REGULAR_USER
+        )
+
+    def test_first_user_not_in_admin_list_is_inactive(self, user_service):
+        # ...and must not be auto-activated either — only the configured admin
+        # can activate them.
+        assert (
+            user_service.is_active(UserRole.REGULAR_USER, is_first_user=True) is False
+        )
+
+    def test_configured_admin_is_active(self, user_service):
+        assert user_service.is_active(UserRole.ADMIN, is_first_user=False) is True
+
+    def test_bootstrap_preserved_when_no_admins_configured(self, user_service):
+        # Self-hosted with no ADMIN_EMAILS: first user still bootstraps as an
+        # active admin.
+        user_service.settings.admin_emails = []
+        assert (
+            user_service.determine_user_role("anyone@self.host", is_first_user=True)
+            == UserRole.ADMIN
+        )
         assert user_service.is_active(UserRole.REGULAR_USER, is_first_user=True) is True
 
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -134,6 +134,11 @@ const AuthenticatedApp = () => {
         <Routes>
           <Route path="/verify-email" element={<VerifyEmailPage />} />
           <Route path="/reset-password" element={<ResetPasswordPage />} />
+          {/* URL-addressable registration so the CP welcome email can deep-link
+              new customers straight to the register form with their email
+              pre-filled (?email=). Falls back to AuthPage's catch-all login
+              for everything else. */}
+          <Route path="/register" element={<AuthPage initialMode="register" />} />
           <Route path="*" element={<AuthPage />} />
         </Routes>
       </Router>

--- a/frontend/src/components/AuthPage.js
+++ b/frontend/src/components/AuthPage.js
@@ -1,12 +1,19 @@
 import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import GoogleLogin from './GoogleLogin';
 import PasswordLogin from './PasswordLogin';
 import PasswordRegistration from './PasswordRegistration';
 import ForgotPasswordPage from './ForgotPasswordPage';
 import configService from '../services/config';
 
-const AuthPage = () => {
-  const [authMode, setAuthMode] = useState('password'); // 'google', 'password', 'register', 'forgot-password'
+// `initialMode` lets a route open a specific pane (the /register route opens
+// 'register'); defaults to the login form. An `email` query param pre-fills the
+// registration form — the CP welcome email links to /register?email=<addr> so
+// the customer registers with the exact address ADMIN_EMAILS grants admin to.
+const AuthPage = ({ initialMode = 'password' }) => {
+  const [searchParams] = useSearchParams();
+  const prefilledEmail = searchParams.get('email') || '';
+  const [authMode, setAuthMode] = useState(initialMode); // 'google', 'password', 'register', 'forgot-password'
   const [googleSsoEnabled, setGoogleSsoEnabled] = useState(false);
   const [microsoftSsoEnabled, setMicrosoftSsoEnabled] = useState(false);
 
@@ -74,7 +81,7 @@ const AuthPage = () => {
         />
       );
     case 'register':
-      return <PasswordRegistration onSwitchToLogin={handleSwitchToLogin} />;
+      return <PasswordRegistration onSwitchToLogin={handleSwitchToLogin} initialEmail={prefilledEmail} />;
     case 'forgot-password':
       return <ForgotPasswordPage onSwitchToLogin={handleSwitchToLogin} />;
     case 'password':

--- a/frontend/src/components/PasswordRegistration.js
+++ b/frontend/src/components/PasswordRegistration.js
@@ -7,10 +7,10 @@ import log from '../utils/log';
 
 const RESEND_COOLDOWN_SECONDS = 60;
 
-const PasswordRegistration = ({ onSwitchToLogin }) => {
+const PasswordRegistration = ({ onSwitchToLogin, initialEmail = '' }) => {
   const { resendVerification } = useAuth();
   const [formData, setFormData] = useState({
-    email: '',
+    email: initialEmail,
     password: '',
     confirmPassword: '',
     name: '',

--- a/frontend/src/components/__tests__/AuthPage.test.jsx
+++ b/frontend/src/components/__tests__/AuthPage.test.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/display-name -- jest.mock factory stubs need no display name */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AuthPage from '../AuthPage';
+
+// Isolate AuthPage's routing/prefill logic from the child panes' own plumbing
+// (useAuth, api, MUI). Each stub surfaces the props AuthPage passes it.
+jest.mock('../PasswordRegistration', () => (props) => (
+  <div data-testid="register-form" data-initial-email={props.initialEmail || ''} />
+));
+jest.mock('../PasswordLogin', () => () => <div data-testid="login-form" />);
+jest.mock('../GoogleLogin', () => () => <div data-testid="google-login" />);
+jest.mock('../ForgotPasswordPage', () => () => <div data-testid="forgot-form" />);
+jest.mock('../../services/config', () => ({
+  __esModule: true,
+  default: {
+    fetchConfig: jest.fn().mockResolvedValue(undefined),
+    isGoogleSsoEnabled: () => false,
+    isMicrosoftSsoEnabled: () => false,
+  },
+}));
+
+const renderAt = (path, props = {}) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AuthPage {...props} />
+    </MemoryRouter>
+  );
+
+describe('AuthPage register routing + email prefill', () => {
+  it('initialMode="register" renders the registration form, not login', async () => {
+    renderAt('/register', { initialMode: 'register' });
+    expect(await screen.findByTestId('register-form')).not.toBeNull();
+    expect(screen.queryByTestId('login-form')).toBeNull();
+  });
+
+  it('prefills the registration email from ?email=', async () => {
+    renderAt('/register?email=foo%40bar.com', { initialMode: 'register' });
+    const form = await screen.findByTestId('register-form');
+    expect(form.getAttribute('data-initial-email')).toBe('foo@bar.com');
+  });
+
+  it('decodes reserved characters (e.g. +) in the email param', async () => {
+    renderAt('/register?email=owner%2Bshu%40acme.com', { initialMode: 'register' });
+    const form = await screen.findByTestId('register-form');
+    expect(form.getAttribute('data-initial-email')).toBe('owner+shu@acme.com');
+  });
+
+  it('defaults to the login form when no initialMode is given', async () => {
+    renderAt('/auth');
+    expect(await screen.findByTestId('login-form')).not.toBeNull();
+    expect(screen.queryByTestId('register-form')).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/AuthPage.test.jsx
+++ b/frontend/src/components/__tests__/AuthPage.test.jsx
@@ -1,21 +1,23 @@
-/* eslint-disable react/display-name -- jest.mock factory stubs need no display name */
+/* eslint-disable react/display-name -- vi.mock factory stubs need no display name */
 import React from 'react';
+import { vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AuthPage from '../AuthPage';
 
 // Isolate AuthPage's routing/prefill logic from the child panes' own plumbing
 // (useAuth, api, MUI). Each stub surfaces the props AuthPage passes it.
-jest.mock('../PasswordRegistration', () => (props) => (
-  <div data-testid="register-form" data-initial-email={props.initialEmail || ''} />
-));
-jest.mock('../PasswordLogin', () => () => <div data-testid="login-form" />);
-jest.mock('../GoogleLogin', () => () => <div data-testid="google-login" />);
-jest.mock('../ForgotPasswordPage', () => () => <div data-testid="forgot-form" />);
-jest.mock('../../services/config', () => ({
-  __esModule: true,
+// vi.mock is hoisted by vitest above the imports, so AuthPage picks up the
+// stubs rather than the real components.
+vi.mock('../PasswordRegistration', () => ({
+  default: (props) => <div data-testid="register-form" data-initial-email={props.initialEmail || ''} />,
+}));
+vi.mock('../PasswordLogin', () => ({ default: () => <div data-testid="login-form" /> }));
+vi.mock('../GoogleLogin', () => ({ default: () => <div data-testid="google-login" /> }));
+vi.mock('../ForgotPasswordPage', () => ({ default: () => <div data-testid="forgot-form" /> }));
+vi.mock('../../services/config', () => ({
   default: {
-    fetchConfig: jest.fn().mockResolvedValue(undefined),
+    fetchConfig: vi.fn().mockResolvedValue(undefined),
     isGoogleSsoEnabled: () => false,
     isMicrosoftSsoEnabled: () => false,
   },


### PR DESCRIPTION
…er bootstrap

When ADMIN_EMAILS is configured (all hosted silo tenants), treat it as authoritative: a stranger who registers first must not inherit admin or land active. First-user-becomes-admin/active is preserved only for self-hosted installs with no configured admins (SHU-840).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Admin role and first-user activation now follow configured admin emails; first user is only admin/active when no admin emails are set.
* **New Features**
  * Added a URL-addressable /register route and registration mode for the unauthenticated app.
  * Registration form can be prefilled from an email query parameter.
* **Tests**
  * Updated and added tests covering admin/activation rules, register routing, and email-prefill behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->