### PR TITLE
fix(migrations): re-slot 009 tenant_isolation after r009_0001

### DIFF
--- a/backend/migrations/versions/009_00011_tenant_isolation.py
+++ b/backend/migrations/versions/009_00011_tenant_isolation.py
@@ -17,8 +17,8 @@ Sections, in apply order:
      unique constraints on the SD-function lookup columns, and the
      SECURITY DEFINER family of pre-auth tenant resolvers.
 
-Revision: 009
-Revises: 008
+Revision: 009_00011
+Revises: r009_0001
 Create Date: 2026-05-15
 """
 
@@ -29,8 +29,20 @@ from alembic import op
 
 from shu.core.config import SELF_HOSTED_TENANT_UUID, DeploymentMode, get_settings_instance
 
-revision = "009"
-down_revision = "008"
+# Renamed from "009" → "009_00011" and re-slotted to run AFTER r009_0001 (was
+# down_revision="008"). This file was authored 2026-05-15 — four days after
+# r009_0001 (2026-05-11) had already shipped and stamped the deployed silo
+# tenants — but was inserted ahead of it with the lower "009" id, so those DBs
+# (stamped at r009_0001) never executed this DDL. Pointing down_revision at
+# r009_0001 makes this migration a descendant of the tenants' current head, so
+# `alembic upgrade` runs it on the next deploy; the "009_00011" id reflects
+# that chain position (immediately after r009_0001) instead of falsely sorting
+# before it. The rename is safe because no DB is stamped at exactly "009": the
+# deployed silo tenants are at r009_0001, and every other DB is at the head
+# r009_0006 (alembic_version records only the head, not intermediate history).
+# r009_0002 (which depends on this schema) now revises 009_00011.
+revision = "009_00011"
+down_revision = "r009_0001"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/r009_0001_messages_unique_variant_index.py
+++ b/backend/migrations/versions/r009_0001_messages_unique_variant_index.py
@@ -1,7 +1,7 @@
 """Dedupe colliding (parent_message_id, variant_index) rows and add UNIQUE constraint.
 
 Revision ID: r009_0001
-Revises: 009
+Revises: 008
 Create Date: 2026-05-11
 
 SHU-759 — closes a pre-existing race in regen variant_index computation
@@ -30,7 +30,16 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "r009_0001"
-down_revision = "009"
+# Slotted directly after the 008 squash. 009 (tenant_isolation) was authored
+# AFTER this migration shipped (009 Create Date 2026-05-15 vs this one's
+# 2026-05-11) and was retroactively inserted *before* it in the chain — so
+# silo tenants already stamped at r009_0001 skipped 009's DDL entirely (the
+# tenants table / tenant_id columns / RLS policies were never created). That
+# migration is now renamed to "009_00011" and re-slotted to run *after*
+# r009_0001 (see 009_00011_tenant_isolation.py), which is safe because this
+# migration touches only messages(parent_message_id,
+# variant_index) and has no dependency on the tenant schema.
+down_revision = "008"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/r009_0002_drop_stray_unique_indexes.py
+++ b/backend/migrations/versions/r009_0002_drop_stray_unique_indexes.py
@@ -1,7 +1,7 @@
 """Drop stray pre-RLS unique indexes on tenant-scoped columns.
 
 Revision ID: r009_0002
-Revises: r009_0001
+Revises: 009_00011
 Create Date: 2026-05-21
 
 Before SHU-761, several tenant-scoped tables were created with
@@ -38,7 +38,12 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "r009_0002"
-down_revision = "r009_0001"
+# Revises 009_00011 (was r009_0001). The tenant_isolation migration (renamed
+# from "009") is now re-slotted between r009_0001 and this migration — see
+# 009_00011_tenant_isolation.py — so this DROP/SWAP of the legacy per-column
+# unique indexes still runs after it has created the composite (tenant_id,
+# <col>) UNIQUEs it depends on.
+down_revision = "009_00011"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/r009_0003_uuid_column_types.py
+++ b/backend/migrations/versions/r009_0003_uuid_column_types.py
@@ -68,6 +68,7 @@ not partial-re-runnable (temp tables drop at session end). Use
 
 from __future__ import annotations
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -133,6 +134,33 @@ def _touched_tables_sql() -> str:
 
 def upgrade() -> None:
     """tenants.id + every tenant_id column → uuid."""
+
+    # 0. Guard the bare ALTERs below against a missing / already-converted
+    #    schema (DB_MIGRATION_POLICY §Policy — never issue an unguarded ALTER):
+    #    * tenants.id absent  → 009_00011 (this migration's schema prerequisite)
+    #      never ran. With 009_00011 re-slotted ahead of r009_0002 that can't
+    #      happen on a forward upgrade; if it does the chain is broken, so fail
+    #      loud with a
+    #      pointer rather than the opaque `relation "tenants" does not exist`.
+    #    * tenants.id already uuid → the conversion ran before; re-run is a
+    #      no-op (makes the migration re-runnable after a stamp-only recovery).
+    bind = op.get_bind()
+    id_type = bind.execute(
+        sa.text(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = :t AND column_name = 'id'"
+        ),
+        {"t": _TENANTS_TABLE},
+    ).scalar()
+    if id_type is None:
+        raise RuntimeError(
+            f'relation "{_TENANTS_TABLE}" / its id column is missing — migration '
+            "009_00011 (tenant_isolation) must run before r009_0003. The revision "
+            "chain is 008 → r009_0001 → 009_00011 → r009_0002 → r009_0003; check "
+            "down_revisions."
+        )
+    if id_type == "uuid":
+        return
 
     # 1. Snapshot every FK touching one of our tables. Captures both the
     #    composite FKs from 009 (the (col, tenant_id) → (id, tenant_id)

--- a/backend/src/tests/unit/core/test_tenant_inventory.py
+++ b/backend/src/tests/unit/core/test_tenant_inventory.py
@@ -7,8 +7,8 @@ to hold:
    tenant-scoped (carries the ``tenant_id`` column from
    ``TenantScopedMixin``) or explicitly listed here as a shared catalog.
 2. ``_TENANT_SCOPED_TABLES`` / ``_COMPOSITE_FKS`` in
-   ``backend/migrations/versions/009_tenant_isolation.py`` — migration
-   009 freezes these so it stays deterministic on fresh installs that
+   ``backend/migrations/versions/009_00011_tenant_isolation.py`` — that
+   migration freezes these so it stays deterministic on fresh installs that
    land after later model edits.
 3. ``composite_fk_inventory.json`` next to the migrations — the
    committed snapshot of every tenant-scoped → tenant-scoped composite FK.
@@ -34,7 +34,7 @@ import shu.auth.models  # noqa: F401 - register every model on Base.metadata
 import shu.models  # noqa: F401 - same
 from shu.core.database import Base
 
-_MIGRATION = importlib.import_module("migrations.versions.009_tenant_isolation")
+_MIGRATION = importlib.import_module("migrations.versions.009_00011_tenant_isolation")
 
 # Anchored on __file__ so the tests run from any cwd (pytest, IDE, CI).
 _BACKEND_ROOT = Path(__file__).resolve().parents[4]
@@ -184,8 +184,8 @@ def test_009_frozen_table_list_matches_live_graph() -> None:
     """``_TENANT_SCOPED_TABLES`` + post-009 allowlist must cover the live graph.
 
     On drift:
-    * If 009 is still downgrade-able, edit ``_TENANT_SCOPED_TABLES`` in
-      ``backend/migrations/versions/009_tenant_isolation.py``.
+    * If 009_00011 is still downgrade-able, edit ``_TENANT_SCOPED_TABLES`` in
+      ``backend/migrations/versions/009_00011_tenant_isolation.py``.
     * Otherwise, write a new migration covering each table (tenant_id +
       index + FK to tenants(id) + RLS policy) and add it to
       ``_ALLOWED_POST_009_TABLES`` above.


### PR DESCRIPTION
Rename migration 009 → 009_00011 and set its down_revision to r009_0001 so silo tenants already stamped at r009_0001 receive the tenant isolation DDL on next deploy. Update r009_0001 to revise 008 directly, r009_0002 to revise 009_00011, and add an idempotency guard in r009_0003 that fails fast if tenant_isolation never ran. Update test imports and docstrings to reflect the rename.

migration 009 came out after 009_0001 and it hit between two deployments. As a result, it never ran in alpha. It is being reslotted to address this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized database migration sequence and updated dependencies for proper execution ordering
  * Added validation guards to prevent unsafe database schema conversions during migrations
  * Updated test references to reflect migration file reorganization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->