### PR TITLE
refactor: [SHU-846] move DB role provisioning out of migration 009_00011

### DIFF
--- a/backend/migrations/versions/009_00011_tenant_isolation.py
+++ b/backend/migrations/versions/009_00011_tenant_isolation.py
@@ -33,6 +33,7 @@ Create Date: 2026-05-15
 """
 
 import os
+import uuid
 
 import sqlalchemy as sa
 from alembic import op
@@ -385,11 +386,24 @@ def upgrade() -> None:
     # injection — a schema migration has no business validating the API port.
     deployment_mode = DeploymentMode(os.environ.get("SHU_DEPLOYMENT_MODE") or DeploymentMode.SELF_HOSTED.value)
     seed_tenant_id = os.environ.get("SHU_TENANT_ID") or None
-    if deployment_mode is DeploymentMode.SILO and not seed_tenant_id:
-        raise RuntimeError(
-            "SHU_TENANT_ID is required when SHU_DEPLOYMENT_MODE=silo — it is the "
-            "tenant_id seed and the NOT NULL DEFAULT backfilled onto existing rows."
-        )
+    if deployment_mode is DeploymentMode.SILO:
+        if not seed_tenant_id:
+            raise RuntimeError(
+                "SHU_TENANT_ID is required when SHU_DEPLOYMENT_MODE=silo — it is the "
+                "tenant_id seed and the NOT NULL DEFAULT backfilled onto existing rows."
+            )
+        # Must be a valid UUID: it is inserted as the tenants.id / tenant_id
+        # values, which r009_0003 later converts with ``::uuid``. A non-UUID
+        # would pass here and fail that cast mid-chain. get_settings_instance()
+        # used to enforce this; the narrow env read (SHU-846) replaced it, so
+        # validate explicitly here.
+        try:
+            uuid.UUID(seed_tenant_id)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"SHU_TENANT_ID must be a valid UUID (got {seed_tenant_id!r}); "
+                "r009_0003 casts tenant ids to uuid and would fail otherwise."
+            ) from exc
     tables = list(_TENANT_SCOPED_TABLES)
 
     # =========================================================================

--- a/backend/migrations/versions/009_00011_tenant_isolation.py
+++ b/backend/migrations/versions/009_00011_tenant_isolation.py
@@ -13,9 +13,19 @@ Sections, in apply order:
      ``tenants(id)`` validated NOT-VALID-then-VALIDATE for self-hosted /
      silo backfill safety. DEFAULT literal per deployment mode keeps the
      ALTER metadata-only on PG 11+.
-  C. ``shu_admin`` (BYPASSRLS) and ``shu_app`` (no BYPASSRLS) roles, grants,
-     unique constraints on the SD-function lookup columns, and the
+  C. Unique constraints on the SD-function lookup columns, and the
      SECURITY DEFINER family of pre-auth tenant resolvers.
+
+This migration is SCHEMA ONLY. Database roles and their grants are NOT created
+here — that is environment provisioning, not schema:
+  * local dev / self-hosted: ``scripts/database.py setup`` creates the roles.
+  * hosted silo: the app connects as the per-tenant ``tenant_<slug>`` role
+    (owns its tables; RLS enforces via FORCE + the ``app.tenant_id`` GUC), so
+    no extra role exists. The RLS policy is ``TO PUBLIC`` (role-agnostic) so it
+    applies to whatever non-BYPASSRLS role connects.
+  * pooled (SHU-758, not yet built): CP/Pulumi provisions the shared app role,
+    a minimal-privilege BYPASSRLS system role, and the per-table grants +
+    SECURITY-DEFINER function ownership. THAT is where the role wiring lives.
 
 Revision: 009_00011
 Revises: r009_0001
@@ -27,7 +37,7 @@ import os
 import sqlalchemy as sa
 from alembic import op
 
-from shu.core.config import SELF_HOSTED_TENANT_UUID, DeploymentMode, get_settings_instance
+from shu.core.config import SELF_HOSTED_TENANT_UUID, DeploymentMode
 
 # Renamed from "009" → "009_00011" and re-slotted to run AFTER r009_0001 (was
 # down_revision="008"). This file was authored 2026-05-15 — four days after
@@ -174,25 +184,6 @@ def _resolve_default(mode: DeploymentMode, tenant_id: str | None) -> str | None:
     raise RuntimeError(f"Unknown deployment mode: {mode!r}")
 
 
-def _read_password(env_var: str) -> str:
-    # CREATE ROLE PASSWORD doesn't accept bind parameters, so we interpolate.
-    # Doubling single quotes is the standard Postgres string-literal escape.
-    #
-    # Required, not optional: a missing env var would create a LOGIN-capable role
-    # with whatever hardcoded fallback we shipped — i.e. a well-known credential
-    # for anyone able to reach the DB port. Local dev injects these via
-    # `make migrate-local-lab`; production via the deploy pipeline. Either way,
-    # absence is a misconfiguration we want to fail on, not paper over.
-    value = os.environ.get(env_var)
-    if not value:
-        raise RuntimeError(
-            f"{env_var} is required to create the shu_admin / shu_app roles. "
-            "Set it in the deploy environment (or the `make migrate-local-lab` target for dev) "
-            "before running this migration."
-        )
-    return value.replace("'", "''")
-
-
 # ----------------------------------------------------------------------------
 # Idempotency helpers
 #
@@ -321,7 +312,9 @@ def _defuse_orphan_composite_fk_refs() -> None:
 
 
 # Section C SQL kept as a single string so the function bodies (which include
-# $$ delimiters) read naturally alongside their grants.
+# $$ delimiters) read naturally. Only the function definitions + REVOKE-from-
+# PUBLIC hardening live here; ownership (to a BYPASSRLS role) and EXECUTE grants
+# are deployment role-wiring, provisioned outside this migration.
 _SD_FUNCTIONS_SQL = r"""
 -- tenant_for_user_id: authenticated request, post-JWT-decode lookup.
 CREATE OR REPLACE FUNCTION tenant_for_user_id(p_user_id text)
@@ -331,9 +324,7 @@ SECURITY DEFINER
 SET search_path = pg_catalog, public
 STABLE
 AS $$ SELECT tenant_id FROM users WHERE id = p_user_id $$;
-ALTER FUNCTION tenant_for_user_id(text) OWNER TO shu_admin;
 REVOKE ALL ON FUNCTION tenant_for_user_id(text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION tenant_for_user_id(text) TO shu_app;
 
 -- tenant_for_email: login / password-reset request / SSO callback.
 CREATE OR REPLACE FUNCTION tenant_for_email(p_email text)
@@ -343,9 +334,7 @@ SECURITY DEFINER
 SET search_path = pg_catalog, public
 STABLE
 AS $$ SELECT tenant_id FROM users WHERE email = p_email $$;
-ALTER FUNCTION tenant_for_email(text) OWNER TO shu_admin;
 REVOKE ALL ON FUNCTION tenant_for_email(text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION tenant_for_email(text) TO shu_app;
 
 -- tenant_for_reset_token: argument is the sha256 hex digest, never the
 -- plaintext. Returns NULL on miss so all five tenant_for_* lookups behave
@@ -360,9 +349,7 @@ SECURITY DEFINER
 SET search_path = pg_catalog, public
 STABLE
 AS $$ SELECT tenant_id FROM password_reset_token WHERE token_hash = p_token_hash $$;
-ALTER FUNCTION tenant_for_reset_token(text) OWNER TO shu_admin;
 REVOKE ALL ON FUNCTION tenant_for_reset_token(text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION tenant_for_reset_token(text) TO shu_app;
 
 -- tenant_for_verification_token: same sha256-hash convention as reset_token.
 -- Plain SQL so all five tenant_for_* lookups return NULL on miss uniformly.
@@ -373,9 +360,7 @@ SECURITY DEFINER
 SET search_path = pg_catalog, public
 STABLE
 AS $$ SELECT tenant_id FROM users WHERE email_verification_token_hash = p_hash $$;
-ALTER FUNCTION tenant_for_verification_token(text) OWNER TO shu_admin;
 REVOKE ALL ON FUNCTION tenant_for_verification_token(text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION tenant_for_verification_token(text) TO shu_app;
 
 -- tenant_for_stripe_customer: webhook arrives with the customer id and no
 -- Shu user context. Plain SQL is fine since billing_state has at most one
@@ -387,14 +372,24 @@ SECURITY DEFINER
 SET search_path = pg_catalog, public
 STABLE
 AS $$ SELECT tenant_id FROM billing_state WHERE stripe_customer_id = p_customer_id $$;
-ALTER FUNCTION tenant_for_stripe_customer(text) OWNER TO shu_admin;
 REVOKE ALL ON FUNCTION tenant_for_stripe_customer(text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION tenant_for_stripe_customer(text) TO shu_app;
 """
 
 
 def upgrade() -> None:
-    settings = get_settings_instance()
+    # Seed identity comes from the deployment env directly, NOT the full app
+    # Settings object. This migration must depend only on the DB connection plus
+    # the two values it actually uses (deployment mode + tenant id). Loading
+    # Settings here previously coupled the migration to every app config field
+    # and crashed in hosted on the Kubernetes service-link `SHU_API_PORT=tcp://…`
+    # injection — a schema migration has no business validating the API port.
+    deployment_mode = DeploymentMode(os.environ.get("SHU_DEPLOYMENT_MODE") or DeploymentMode.SELF_HOSTED.value)
+    seed_tenant_id = os.environ.get("SHU_TENANT_ID") or None
+    if deployment_mode is DeploymentMode.SILO and not seed_tenant_id:
+        raise RuntimeError(
+            "SHU_TENANT_ID is required when SHU_DEPLOYMENT_MODE=silo — it is the "
+            "tenant_id seed and the NOT NULL DEFAULT backfilled onto existing rows."
+        )
     tables = list(_TENANT_SCOPED_TABLES)
 
     # =========================================================================
@@ -407,7 +402,7 @@ def upgrade() -> None:
         ")"
     )
 
-    seed_id = _resolve_default(settings.deployment_mode, settings.tenant_id)
+    seed_id = _resolve_default(deployment_mode, seed_tenant_id)
     if seed_id is not None:
         # ON CONFLICT DO NOTHING keeps re-runs against partially-seeded DBs idempotent.
         op.execute(
@@ -417,7 +412,7 @@ def upgrade() -> None:
     # =========================================================================
     # B. tenant_id columns + indexes + FK constraints
     # =========================================================================
-    column_default = _resolve_default(settings.deployment_mode, settings.tenant_id)
+    column_default = _resolve_default(deployment_mode, seed_tenant_id)
 
     for table_name in tables:
         if column_default is not None:
@@ -558,108 +553,14 @@ def upgrade() -> None:
             )
 
     # =========================================================================
-    # C. Roles + grants + unique lookup constraints + SECURITY DEFINER functions
-    # =========================================================================
-    admin_pw = _read_password("SHU_ADMIN_DB_PASSWORD")
-    app_pw = _read_password("SHU_APP_DB_PASSWORD")
-
-    # CREATE ROLE has no IF NOT EXISTS. Roles are cluster-wide and persist
-    # past DB drops, so DO blocks keep re-runs idempotent.
-    op.execute(
-        f"""
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'shu_admin') THEN
-                CREATE ROLE shu_admin WITH LOGIN BYPASSRLS PASSWORD '{admin_pw}';
-            END IF;
-        END $$;
-        """
-    )
-    op.execute(
-        f"""
-        DO $$
-        BEGIN
-            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'shu_app') THEN
-                CREATE ROLE shu_app WITH LOGIN PASSWORD '{app_pw}';
-            END IF;
-        END $$;
-        """
-    )
-
-    db_name = op.get_bind().execute(sa.text("SELECT current_database()")).scalar()
-
-    op.execute(f'GRANT CONNECT ON DATABASE "{db_name}" TO shu_app')
-    op.execute(f'GRANT CONNECT ON DATABASE "{db_name}" TO shu_admin')
-    op.execute("GRANT USAGE ON SCHEMA public TO shu_app")
-    op.execute("GRANT USAGE ON SCHEMA public TO shu_admin")
-
-    for table_name in tables:
-        op.execute(f"GRANT SELECT, INSERT, UPDATE, DELETE ON {table_name} TO shu_app")
-    op.execute("GRANT SELECT ON tenants TO shu_app")
-
-    # Global tables — RLS-exempt but still touched by request-path code, so
-    # shu_app needs the right grants or routine requests will 'permission
-    # denied' after cutover. Verbs are the minimum each table actually needs:
-    #   llm_providers, llm_models — admin UI provider/model CRUD (DML)
-    #   plugin_definitions        — plugin registry sync on startup writes rows (DML)
-    #   llm_provider_type_definitions — read-only at runtime; seeded by migrations (SELECT)
-    # If a future global table is added, its grants belong alongside its
-    # CREATE TABLE migration, not here. (``system_settings`` is tenant-scoped
-    # — its grants come from the per-table loop above.)
-    for table_name in ("llm_providers", "llm_models", "plugin_definitions"):
-        op.execute(f"GRANT SELECT, INSERT, UPDATE, DELETE ON {table_name} TO shu_app")
-    op.execute("GRANT SELECT ON llm_provider_type_definitions TO shu_app")
-
-    # Sequences cover Identity columns and legacy autoincrement PKs.
-    op.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO shu_app")
-
-    # Future objects created by shu_admin in later migrations auto-inherit
-    # the right grants — no need to chase them table-by-table.
-    op.execute(
-        "ALTER DEFAULT PRIVILEGES FOR ROLE shu_admin IN SCHEMA public "
-        "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO shu_app"
-    )
-    op.execute(
-        "ALTER DEFAULT PRIVILEGES FOR ROLE shu_admin IN SCHEMA public "
-        "GRANT USAGE, SELECT ON SEQUENCES TO shu_app"
-    )
-
-    # BYPASSRLS gives shu_admin a read path past RLS but not table privileges.
-    # The SD functions below read these tables under shu_admin ownership.
-    op.execute("GRANT SELECT ON users TO shu_admin")
-    op.execute("GRANT SELECT ON password_reset_token TO shu_admin")
-    op.execute("GRANT SELECT ON billing_state TO shu_admin")
-
-    # Catalog / tenant-provisioning writes — shu_admin owns operator-only
-    # operations that need to write across tenants: seeding the ``tenants``
-    # catalog, creating the first admin user for a new tenant, stubbing the
-    # per-tenant ``billing_state`` row. These are CLI / control-plane paths
-    # (e.g. ``backend/scripts/seed_tenant.py``), not request-path code.
+    # C. Unique lookup constraints + SECURITY DEFINER functions
     #
-    # SELECT is included alongside the write verbs because ``INSERT ... ON
-    # CONFLICT DO NOTHING`` (the idempotent shape these scripts use) needs
-    # SELECT on the conflict target to check existence — INSERT alone errors
-    # with "permission denied for table".
-    op.execute("GRANT SELECT, INSERT, UPDATE, DELETE ON tenants TO shu_admin")
-    op.execute("GRANT INSERT, UPDATE ON users TO shu_admin")
-    op.execute("GRANT INSERT, UPDATE ON billing_state TO shu_admin")
-
-    # shu_app needs to read ``alembic_version`` because the API's startup
-    # schema-baseline check (``verify_schema_version`` in main.py) queries
-    # it before serving traffic. Alembic creates the table itself the first
-    # time a migration runs, so no GRANT happens automatically — we add it
-    # here, gated on the table existing (skipped if alembic was never used).
-    op.execute(
-        """
-        DO $$
-        BEGIN
-            IF EXISTS (SELECT FROM pg_class WHERE relname = 'alembic_version') THEN
-                GRANT SELECT ON alembic_version TO shu_app;
-                GRANT SELECT ON alembic_version TO shu_admin;
-            END IF;
-        END $$;
-        """
-    )
+    # Role creation and grants used to live here. They are deployment role-
+    # wiring, not schema, and have moved out: local dev / self-hosted create the
+    # roles in `scripts/database.py setup`; hosted silo connects as the per-
+    # tenant role (no extra role); pooled (SHU-758) provisions the shared app +
+    # BYPASSRLS system roles and their grants via CP/Pulumi. See module docstring.
+    # =========================================================================
 
     # Unique constraints on SD-function lookup columns — the functions return
     # a single row via WHERE col = $1, so the schema must enforce that.
@@ -767,7 +668,7 @@ def upgrade() -> None:
         # ENABLE / FORCE are idempotent in Postgres — no guard needed.
         op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
         # FORCE so even the table owner can't bypass the policy — only roles
-        # with BYPASSRLS (shu_admin) get through.
+        # with BYPASSRLS get through.
         op.execute(f"ALTER TABLE {table_name} FORCE ROW LEVEL SECURITY")
         # CREATE POLICY would fail on a re-run; drop-then-create is the
         # standard idempotent shape and also lets us pick up policy-body
@@ -776,7 +677,12 @@ def upgrade() -> None:
             table_name,
             "tenant_isolation",
             (
-                "AS PERMISSIVE FOR ALL TO shu_app "
+                # TO PUBLIC (role-agnostic): the policy applies to whatever
+                # non-BYPASSRLS role connects — the per-tenant role in silo, the
+                # shared app role in pooled — so the schema doesn't hardcode a
+                # role name that may not exist in a given deployment. BYPASSRLS
+                # roles still bypass; the app.tenant_id GUC is the filter.
+                "AS PERMISSIVE FOR ALL TO PUBLIC "
                 "USING (tenant_id = current_setting('app.tenant_id', true)) "
                 "WITH CHECK (tenant_id = current_setting('app.tenant_id', true))"
             ),
@@ -854,50 +760,9 @@ def downgrade() -> None:
     op.execute("DROP INDEX IF EXISTS ix_password_reset_token_token_hash")
     op.execute("CREATE INDEX ix_password_reset_token_token_hash ON password_reset_token (token_hash)")
 
-    op.execute(
-        """
-        DO $$
-        BEGIN
-            IF EXISTS (SELECT FROM pg_class WHERE relname = 'alembic_version') THEN
-                REVOKE SELECT ON alembic_version FROM shu_app;
-                REVOKE SELECT ON alembic_version FROM shu_admin;
-            END IF;
-        END $$;
-        """
-    )
-    op.execute("REVOKE INSERT, UPDATE ON billing_state FROM shu_admin")
-    op.execute("REVOKE INSERT, UPDATE ON users FROM shu_admin")
-    op.execute("REVOKE SELECT, INSERT, UPDATE, DELETE ON tenants FROM shu_admin")
-    op.execute("REVOKE SELECT ON billing_state FROM shu_admin")
-    op.execute("REVOKE SELECT ON password_reset_token FROM shu_admin")
-    op.execute("REVOKE SELECT ON users FROM shu_admin")
-
-    op.execute(
-        "ALTER DEFAULT PRIVILEGES FOR ROLE shu_admin IN SCHEMA public "
-        "REVOKE USAGE, SELECT ON SEQUENCES FROM shu_app"
-    )
-    op.execute(
-        "ALTER DEFAULT PRIVILEGES FOR ROLE shu_admin IN SCHEMA public "
-        "REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM shu_app"
-    )
-    op.execute("REVOKE USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public FROM shu_app")
-    op.execute("REVOKE SELECT ON llm_provider_type_definitions FROM shu_app")
-    for table_name in ("llm_providers", "llm_models", "plugin_definitions"):
-        op.execute(f"REVOKE SELECT, INSERT, UPDATE, DELETE ON {table_name} FROM shu_app")
-    op.execute("REVOKE SELECT ON tenants FROM shu_app")
-    for table_name in tables:
-        op.execute(f"REVOKE SELECT, INSERT, UPDATE, DELETE ON {table_name} FROM shu_app")
-
-    db_name = op.get_bind().execute(sa.text("SELECT current_database()")).scalar()
-    op.execute("REVOKE USAGE ON SCHEMA public FROM shu_admin")
-    op.execute("REVOKE USAGE ON SCHEMA public FROM shu_app")
-    op.execute(f'REVOKE CONNECT ON DATABASE "{db_name}" FROM shu_admin')
-    op.execute(f'REVOKE CONNECT ON DATABASE "{db_name}" FROM shu_app')
-
-    op.execute("DROP OWNED BY shu_app")
-    op.execute("DROP ROLE IF EXISTS shu_app")
-    op.execute("DROP OWNED BY shu_admin")
-    op.execute("DROP ROLE IF EXISTS shu_admin")
+    # Roles and grants are no longer created by this migration (they are
+    # environment provisioning — see the module docstring and upgrade's
+    # Section C), so there is nothing to revoke or drop here.
 
     # Reverse section B
     for table_name in tables:

--- a/backend/migrations/versions/r009_0003_uuid_column_types.py
+++ b/backend/migrations/versions/r009_0003_uuid_column_types.py
@@ -239,7 +239,7 @@ def upgrade() -> None:
         op.execute(
             f"""
             CREATE POLICY tenant_isolation ON {table}
-            AS PERMISSIVE FOR ALL TO shu_app
+            AS PERMISSIVE FOR ALL TO PUBLIC
             USING (tenant_id = current_setting('app.tenant_id', true)::uuid)
             WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)
             """
@@ -314,7 +314,7 @@ def downgrade() -> None:
         op.execute(
             f"""
             CREATE POLICY tenant_isolation ON {table}
-            AS PERMISSIVE FOR ALL TO shu_app
+            AS PERMISSIVE FOR ALL TO PUBLIC
             USING (tenant_id = current_setting('app.tenant_id', true))
             WITH CHECK (tenant_id = current_setting('app.tenant_id', true))
             """

--- a/backend/scripts/database.py
+++ b/backend/scripts/database.py
@@ -495,10 +495,12 @@ def cmd_setup(
     admin_user: str | None = None,
     admin_password: str | None = None,
 ) -> bool:
-    """Full database setup: init-db.sql + migrations + requirements check.
+    """Full database setup: init-db.sql + role bootstrap + migrations + requirements.
 
-    Admin credentials are used for init-db.sql (requires superuser for extensions).
-    Migrations run as the app user from the URL.
+    Admin credentials are used for init-db.sql (requires superuser for extensions)
+    and for the role bootstrap. Migrations run as the admin (BYPASSRLS) role from
+    SHU_DB_ADMIN_URL when configured (env.py's guard refuses the RLS-bound app
+    role), falling back to the provided URL when no admin DSN is set.
     """
     print(f"{LOG_PREFIX} Starting full database setup...", flush=True)
 
@@ -514,8 +516,14 @@ def cmd_setup(
     if not ensure_app_roles(url, admin_user, admin_password):
         return False
 
-    # Step 2: Run migrations
-    if not cmd_migrate(url):
+    # Step 2: Run migrations as the admin (BYPASSRLS) role when one is configured.
+    # _get_alembic_config writes whatever URL we pass into sqlalchemy.url, which
+    # env.py then uses verbatim — so to honor env.py's "prefer SHU_DB_ADMIN_URL"
+    # intent (and avoid its guard rejecting the RLS-bound app role) we must hand
+    # cmd_migrate the admin DSN explicitly. Falls back to the app URL (e.g. the
+    # docker-compose superuser) when SHU_DB_ADMIN_URL is unset.
+    migrate_url = _normalize_url(os.getenv("SHU_DB_ADMIN_URL") or url)
+    if not cmd_migrate(migrate_url):
         return False
 
     # Step 3: Check requirements
@@ -644,6 +652,41 @@ def cmd_create_role(
         conn.close()
 
 
+def _ensure_role(cur, name: str, password: str | None, *, bypassrls: bool) -> None:
+    """Create the role if missing; otherwise reconcile its LOGIN/BYPASSRLS flags.
+
+    BYPASSRLS is security-critical: an app role that wrongly HAS it silently
+    disables RLS (cross-tenant exposure), and an admin role that LACKS it can't
+    serve the bypass engine. So an existing role with wrong flags is ALTERed to
+    the correct state and the correction logged loudly, rather than left as-is.
+    Passwords on existing roles are not touched. Caller must have validated
+    ``name`` as a safe identifier; the BYPASSRLS/LOGIN keywords are static.
+    """
+    bypass_kw = "BYPASSRLS" if bypassrls else "NOBYPASSRLS"
+    cur.execute("SELECT rolcanlogin, rolbypassrls FROM pg_roles WHERE rolname = %s", (name,))
+    row = cur.fetchone()
+    if row is None:
+        cur.execute(
+            sql.SQL("CREATE ROLE {} WITH LOGIN " + bypass_kw + " PASSWORD %s").format(sql.Identifier(name)),
+            (password,),
+        )
+        print(f"{LOG_PREFIX} Role '{name}' created ({bypass_kw})", flush=True)
+        return
+
+    can_login, has_bypass = row
+    fixes: list[str] = []
+    if not can_login:
+        fixes.append("LOGIN")
+    if bool(has_bypass) != bypassrls:
+        fixes.append(bypass_kw)
+    if fixes:
+        cur.execute(sql.SQL("ALTER ROLE {} WITH " + " ".join(fixes)).format(sql.Identifier(name)))
+        print(
+            f"{LOG_PREFIX} WARNING: role '{name}' had incorrect attributes; reconciled ({' '.join(fixes)})",
+            flush=True,
+        )
+
+
 def ensure_app_roles(
     url: str,
     admin_user: str | None = None,
@@ -670,10 +713,12 @@ def ensure_app_roles(
     Idempotent: existing roles are left as-is; the GRANT is a no-op if already a
     member. No-op (success) when ``SHU_DATABASE_URL`` carries no username.
     """
-    app_parsed = urlparse(_normalize_url(os.getenv("SHU_DATABASE_URL") or url))
+    # Use the resolved app DSN (`url`) — NOT a fresh os.getenv — so a
+    # `--database-url` override is honored instead of silently re-reading the env.
+    app_parsed = urlparse(_normalize_url(url))
     app_role, app_pw = app_parsed.username, app_parsed.password
     if not app_role:
-        print(f"{LOG_PREFIX} Role bootstrap skipped: no username in SHU_DATABASE_URL", flush=True)
+        print(f"{LOG_PREFIX} Role bootstrap skipped: no username in the database URL", flush=True)
         return True
 
     admin_db_url = os.getenv("SHU_DB_ADMIN_URL")
@@ -691,24 +736,11 @@ def ensure_app_roles(
     try:
         with conn.cursor() as cur:
             # Admin (BYPASSRLS) role first — the app role is granted into it below.
+            # Each call creates the role if missing, else reconciles LOGIN/BYPASSRLS.
             if admin_role:
-                cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (admin_role,))
-                if not cur.fetchone():
-                    cur.execute(
-                        sql.SQL("CREATE ROLE {} WITH LOGIN BYPASSRLS PASSWORD %s").format(
-                            sql.Identifier(admin_role)
-                        ),
-                        (admin_role_pw,),
-                    )
-                    print(f"{LOG_PREFIX} Role '{admin_role}' (BYPASSRLS) created", flush=True)
+                _ensure_role(cur, admin_role, admin_role_pw, bypassrls=True)
 
-            cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (app_role,))
-            if not cur.fetchone():
-                cur.execute(
-                    sql.SQL("CREATE ROLE {} WITH LOGIN PASSWORD %s").format(sql.Identifier(app_role)),
-                    (app_pw,),
-                )
-                print(f"{LOG_PREFIX} Role '{app_role}' created", flush=True)
+            _ensure_role(cur, app_role, app_pw, bypassrls=False)
 
             if admin_role:
                 # Membership: app inherits the admin role's table access; its own

--- a/backend/scripts/database.py
+++ b/backend/scripts/database.py
@@ -506,7 +506,15 @@ def cmd_setup(
     if not execute_init_sql(url, admin_user, admin_password):
         return False
 
-    # Step 2: Run migrations (as app user)
+    # Step 1.5: Ensure the app/admin DB roles exist (dev / self-hosted only).
+    # Migration 009_00011 no longer creates roles — that is environment
+    # provisioning, not schema (SHU-846). They must exist before migrations,
+    # which run as the admin (BYPASSRLS) role. Hosted provisions roles via
+    # CP/Pulumi, not this script.
+    if not ensure_app_roles(url, admin_user, admin_password):
+        return False
+
+    # Step 2: Run migrations
     if not cmd_migrate(url):
         return False
 
@@ -631,6 +639,86 @@ def cmd_create_role(
             return True
     except psycopg2.Error as e:
         print(f"{LOG_PREFIX} Error creating role: {e}", file=sys.stderr)
+        return False
+    finally:
+        conn.close()
+
+
+def ensure_app_roles(
+    url: str,
+    admin_user: str | None = None,
+    admin_password: str | None = None,
+) -> bool:
+    """Provision the app + admin DB roles for local dev / self-hosted setups.
+
+    Migration 009_00011 used to create these roles (and grant to them) inline;
+    that is environment provisioning, not schema, and moved out here (SHU-846).
+    Hosted (silo/pooled) provisions roles via CP/Pulumi — this runs for the
+    docker-compose / from-scratch dev path only, invoked by ``cmd_setup``.
+
+    Roles + credentials are derived from the deployment's own DSNs:
+      * ``SHU_DATABASE_URL``  -> the app role (RLS-enforced, no BYPASSRLS).
+      * ``SHU_DB_ADMIN_URL``  -> the admin role (BYPASSRLS), optional.
+
+    The app role is made a MEMBER of the admin role so it inherits table access
+    (whatever the admin role owns or is granted — migrations run as the admin
+    role and own the schema) while keeping its own non-BYPASSRLS attribute. Role
+    attributes are not inherited through membership, so RLS still applies to the
+    app role. This avoids duplicating the schema's grant list in this script;
+    pooled production instead provisions explicit minimal grants via CP/Pulumi.
+
+    Idempotent: existing roles are left as-is; the GRANT is a no-op if already a
+    member. No-op (success) when ``SHU_DATABASE_URL`` carries no username.
+    """
+    app_parsed = urlparse(_normalize_url(os.getenv("SHU_DATABASE_URL") or url))
+    app_role, app_pw = app_parsed.username, app_parsed.password
+    if not app_role:
+        print(f"{LOG_PREFIX} Role bootstrap skipped: no username in SHU_DATABASE_URL", flush=True)
+        return True
+
+    admin_db_url = os.getenv("SHU_DB_ADMIN_URL")
+    admin_parsed = urlparse(_normalize_url(admin_db_url)) if admin_db_url else None
+    admin_role = admin_parsed.username if admin_parsed else None
+    admin_role_pw = admin_parsed.password if admin_parsed else None
+
+    for name in (app_role, admin_role):
+        if name is not None and not _validate_identifier(name):
+            print(f"{LOG_PREFIX} Error: invalid role name '{name}' in DSN", file=sys.stderr)
+            return False
+
+    superuser_url = _get_admin_url(url, admin_user, admin_password)
+    conn = _connect(superuser_url)
+    try:
+        with conn.cursor() as cur:
+            # Admin (BYPASSRLS) role first — the app role is granted into it below.
+            if admin_role:
+                cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (admin_role,))
+                if not cur.fetchone():
+                    cur.execute(
+                        sql.SQL("CREATE ROLE {} WITH LOGIN BYPASSRLS PASSWORD %s").format(
+                            sql.Identifier(admin_role)
+                        ),
+                        (admin_role_pw,),
+                    )
+                    print(f"{LOG_PREFIX} Role '{admin_role}' (BYPASSRLS) created", flush=True)
+
+            cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (app_role,))
+            if not cur.fetchone():
+                cur.execute(
+                    sql.SQL("CREATE ROLE {} WITH LOGIN PASSWORD %s").format(sql.Identifier(app_role)),
+                    (app_pw,),
+                )
+                print(f"{LOG_PREFIX} Role '{app_role}' created", flush=True)
+
+            if admin_role:
+                # Membership: app inherits the admin role's table access; its own
+                # non-BYPASSRLS attribute means RLS still constrains it.
+                cur.execute(
+                    sql.SQL("GRANT {} TO {}").format(sql.Identifier(admin_role), sql.Identifier(app_role))
+                )
+        return True
+    except psycopg2.Error as e:
+        print(f"{LOG_PREFIX} Error provisioning app roles: {e}", file=sys.stderr)
         return False
     finally:
         conn.close()


### PR DESCRIPTION
Role creation, grants, and RLS policy `TO shu_app` were environment provisioning, not schema changes. Extract them from the migration into `scripts/database.py::ensure_app_roles` (called by `cmd_setup`), make RLS policies `TO PUBLIC` so the schema is role-agnostic across silo/ pooled deployments, and read deployment config directly from env vars instead of loading the full Settings object (avoids Kubernetes service-link injection crashes on `SHU_API_PORT`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved database tenant isolation and row-level security mechanisms.
  * Simplified database role provisioning and management for self-hosted deployments.
  * Restructured database migrations for better maintainability and schema clarity.

* **Chores**
  * Enhanced database setup and provisioning workflows to streamline initial deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->