### PR TITLE
Shu 844 per user my usage dashboard

### DIFF
--- a/backend/migrations/versions/r009_0007_llm_usage_per_user_index.py
+++ b/backend/migrations/versions/r009_0007_llm_usage_per_user_index.py
@@ -1,0 +1,66 @@
+"""Add composite index on llm_usage for per-user time-windowed queries.
+
+Revision ID: r009_0007
+Revises: r009_0006
+Create Date: 2026-06-04
+
+SHU-844 — the per-user "My Usage" dashboard aggregates llm_usage filtered by
+user_id (tenant isolation comes from RLS) and windowed on created_at. The live
+table has only ix_llm_usage_tenant_id; the model declares index=True on user_id
+but the index was never actually created (model/migration drift, see SHU-844
+notes). This adds the composite index that backs both the per-user model
+breakdown (WHERE user_id = :uid AND created_at >= :start) and the
+date_trunc('day', created_at) daily rollup.
+
+Built CONCURRENTLY because llm_usage is a hot, ever-growing table — a plain
+CREATE INDEX would hold an ACCESS EXCLUSIVE lock and block writes for the whole
+build. Mirrors the CONCURRENTLY + invalid-index-guard pattern in 009.
+
+Policy: idempotent per docs/policies/DB_MIGRATION_POLICY.md §Policy.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "r009_0007"
+down_revision = "r009_0006"
+branch_labels = None
+depends_on = None
+
+_INDEX_NAME = "ix_llm_usage_tenant_user_created"
+_TABLE = "llm_usage"
+_COLUMNS = "(tenant_id, user_id, created_at)"
+
+
+def upgrade() -> None:
+    """Create the composite index CONCURRENTLY (idempotent).
+
+    CONCURRENTLY needs autocommit — alembic's autocommit_block() ends the
+    current transaction, runs the body outside a tx, then opens a fresh one.
+    An interrupted CREATE INDEX CONCURRENTLY leaves an index in the catalog
+    with pg_index.indisvalid = false; IF NOT EXISTS would silently skip the
+    rebuild and the migration would "succeed" with a non-functional index, so
+    drop any invalid sibling first.
+    """
+    with op.get_context().autocommit_block():
+        conn = op.get_bind()
+        invalid = conn.execute(
+            text(
+                "SELECT 1 FROM pg_class c "
+                "JOIN pg_index i ON i.indexrelid = c.oid "
+                "WHERE c.relname = :name AND i.indisvalid = false"
+            ),
+            {"name": _INDEX_NAME},
+        ).first()
+        if invalid is not None:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")
+        op.execute(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} ON {_TABLE} {_COLUMNS}")
+
+
+def downgrade() -> None:
+    """Drop the composite index CONCURRENTLY (idempotent)."""
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")

--- a/backend/src/shu/billing/adapters.py
+++ b/backend/src/shu/billing/adapters.py
@@ -66,6 +66,20 @@ class UsageSummaryImpl:
     by_model: dict[str, ModelUsageImpl]
 
 
+@dataclass
+class DailyModelUsageImpl:
+    """One (UTC day, model) bucket for the My Usage time-series (SHU-844)."""
+
+    day: datetime
+    model_id: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: Decimal
+    request_count: int
+    # See UsageRecordImpl.model_name — same snapshot semantics.
+    model_name: str | None = None
+
+
 # =============================================================================
 # UsageProvider Implementation
 # =============================================================================
@@ -84,6 +98,28 @@ class UsageProviderImpl:
 
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
+
+    @staticmethod
+    def _billable_period_conditions(
+        period_start: datetime,
+        period_end: datetime,
+        user_id: str | None,
+    ) -> list:
+        """WHERE clauses shared by the period aggregations.
+
+        Filters to billable (Shu-managed) providers within the half-open
+        ``[start, end)`` window. When ``user_id`` is given, scopes to that one
+        user — the per-user "My Usage" path (SHU-844). Tenant isolation is
+        enforced by RLS regardless of this filter.
+        """
+        conditions = [
+            LLMUsage.created_at >= period_start,
+            LLMUsage.created_at < period_end,
+            LLMProvider.is_system_managed.is_(True),
+        ]
+        if user_id is not None:
+            conditions.append(LLMUsage.user_id == user_id)
+        return conditions
 
     async def get_usage_for_period(
         self,
@@ -124,10 +160,14 @@ class UsageProviderImpl:
         self,
         period_start: datetime,
         period_end: datetime,
+        *,
+        user_id: str | None = None,
     ) -> UsageSummaryImpl:
         """Get aggregated usage summary for a billing period.
 
-        Returns totals and breakdown by model.
+        Returns totals and breakdown by model. When ``user_id`` is provided the
+        summary is scoped to that single user (the per-user "My Usage" view,
+        SHU-844); otherwise it is the whole tenant (the admin dashboard).
         """
         # Aggregate by model. Group on the snapshot model_name as well so rows
         # whose model_id FK was nulled out (provider/model deleted — SHU-727)
@@ -143,11 +183,7 @@ class UsageProviderImpl:
                 func.count(LLMUsage.id).label("request_count"),
             )
             .join(LLMProvider, LLMUsage.provider_id == LLMProvider.id)
-            .where(
-                LLMUsage.created_at >= period_start,
-                LLMUsage.created_at < period_end,
-                LLMProvider.is_system_managed.is_(True),
-            )
+            .where(*self._billable_period_conditions(period_start, period_end, user_id))
             .group_by(LLMUsage.model_id, LLMUsage.model_name)
         )
 
@@ -190,6 +226,51 @@ class UsageProviderImpl:
             total_cost_usd=total_cost,
             by_model=by_model,
         )
+
+    async def get_daily_usage_for_user(
+        self,
+        user_id: str,
+        period_start: datetime,
+        period_end: datetime,
+    ) -> list[DailyModelUsageImpl]:
+        """Per-(day, model) billable usage for one user over the period.
+
+        Powers the My Usage time-series chart (SHU-844). Days are bucketed with
+        ``date_trunc('day', created_at)``; ``created_at`` is stored UTC-naive,
+        so buckets are UTC calendar days — the frontend labels them as such.
+        Returns the raw per-(day, model) rows; the frontend pivots them into
+        per-model chart series.
+        """
+        day = func.date_trunc("day", LLMUsage.created_at).label("day")
+        result = await self._db.execute(
+            select(
+                day,
+                LLMUsage.model_id,
+                LLMUsage.model_name,
+                func.sum(LLMUsage.input_tokens).label("input_tokens"),
+                func.sum(LLMUsage.output_tokens).label("output_tokens"),
+                func.sum(LLMUsage.total_cost).label("total_cost"),
+                func.count(LLMUsage.id).label("request_count"),
+            )
+            .join(LLMProvider, LLMUsage.provider_id == LLMProvider.id)
+            .where(*self._billable_period_conditions(period_start, period_end, user_id))
+            .group_by(day, LLMUsage.model_id, LLMUsage.model_name)
+            .order_by(day)
+        )
+
+        return [
+            DailyModelUsageImpl(
+                day=row.day,
+                model_id=row.model_id or "unknown",
+                model_name=row.model_name,
+                input_tokens=int(row.input_tokens or 0),
+                output_tokens=int(row.output_tokens or 0),
+                # Decimal preserved to the API boundary, same as get_usage_summary.
+                cost_usd=row.total_cost if row.total_cost is not None else Decimal("0"),
+                request_count=int(row.request_count or 0),
+            )
+            for row in result
+        ]
 
 
 # =============================================================================

--- a/backend/src/shu/billing/adapters.py
+++ b/backend/src/shu/billing/adapters.py
@@ -9,6 +9,7 @@ Provides:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -78,6 +79,64 @@ class DailyModelUsageImpl:
     request_count: int
     # See UsageRecordImpl.model_name — same snapshot semantics.
     model_name: str | None = None
+
+
+# Chart-series cap for the My Usage time-series. Beyond this many distinct
+# models in a period, the smallest-spend models are folded into a single
+# "Other models" bucket so the stacked chart / legend stays readable and the
+# payload bounded (SHU-844 AC: top-N + "other" if extreme). Generous enough
+# that a typical user (a handful of models) sees every model unchanged.
+_MAX_CHART_MODELS = 10
+_OTHER_MODEL_ID = "__other__"
+_OTHER_MODEL_NAME = "Other models"
+
+
+def _bound_daily_models(rows: list[DailyModelUsageImpl], limit: int) -> list[DailyModelUsageImpl]:
+    """Cap daily rows at the top ``limit`` models by period cost.
+
+    Models outside the top ``limit`` (ranked by total cost over the period) are
+    folded into one ``_OTHER_MODEL_ID`` bucket per day — summing tokens, cost,
+    and request counts so each day's stacked total is preserved. Keyed by
+    ``model_id`` to match how the frontend pivots rows into per-model series.
+
+    No-op when the distinct-model count is within ``limit`` (the common case),
+    so only pathological model churn is bounded. Row order is irrelevant to the
+    consumer (it re-buckets by model and sorts days), so folded rows are simply
+    appended.
+    """
+    totals: dict[str, Decimal] = defaultdict(Decimal)
+    for row in rows:
+        totals[row.model_id] += row.cost_usd
+    if len(totals) <= limit:
+        return rows
+
+    # Rank by (cost, model_id) so ties resolve deterministically.
+    top_ids = {mid for mid, _ in sorted(totals.items(), key=lambda kv: (kv[1], kv[0]), reverse=True)[:limit]}
+
+    kept: list[DailyModelUsageImpl] = []
+    other_by_day: dict[datetime, DailyModelUsageImpl] = {}
+    for row in rows:
+        if row.model_id in top_ids:
+            kept.append(row)
+            continue
+        agg = other_by_day.get(row.day)
+        if agg is None:
+            other_by_day[row.day] = DailyModelUsageImpl(
+                day=row.day,
+                model_id=_OTHER_MODEL_ID,
+                model_name=_OTHER_MODEL_NAME,
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cost_usd=row.cost_usd,
+                request_count=row.request_count,
+            )
+        else:
+            agg.input_tokens += row.input_tokens
+            agg.output_tokens += row.output_tokens
+            agg.cost_usd += row.cost_usd
+            agg.request_count += row.request_count
+
+    return kept + list(other_by_day.values())
 
 
 # =============================================================================
@@ -238,8 +297,9 @@ class UsageProviderImpl:
         Powers the My Usage time-series chart (SHU-844). Days are bucketed with
         ``date_trunc('day', created_at)``; ``created_at`` is stored UTC-naive,
         so buckets are UTC calendar days — the frontend labels them as such.
-        Returns the raw per-(day, model) rows; the frontend pivots them into
-        per-model chart series.
+        Returns per-(day, model) rows, capped at the top ``_MAX_CHART_MODELS``
+        models by period cost (the rest folded into an "Other models" bucket);
+        the frontend pivots them into per-model chart series.
         """
         day = func.date_trunc("day", LLMUsage.created_at).label("day")
         result = await self._db.execute(
@@ -258,7 +318,7 @@ class UsageProviderImpl:
             .order_by(day)
         )
 
-        return [
+        rows = [
             DailyModelUsageImpl(
                 day=row.day,
                 model_id=row.model_id or "unknown",
@@ -271,6 +331,7 @@ class UsageProviderImpl:
             )
             for row in result
         ]
+        return _bound_daily_models(rows, _MAX_CHART_MODELS)
 
 
 # =============================================================================

--- a/backend/src/shu/billing/router.py
+++ b/backend/src/shu/billing/router.py
@@ -240,6 +240,12 @@ async def get_subscription_status(
         "total_grant_amount": str(state.total_grant_amount),
         "remaining_grant_amount": str(remaining_grant_amount),
         "seat_price_usd": str(state.seat_price_usd),
+        # Markup rate (e.g. 1.3 == +30%) applied to provider cost to get billed
+        # dollars. Not sensitive — it's the published pricing — and non-admins
+        # need it so the per-user My Usage cost reads in billed dollars like the
+        # shared pool (SHU-844). None when CP supplied no rate; the client then
+        # falls back to the USAGE_MARKUP_MULTIPLIER constant.
+        "usage_markup_multiplier": usage_markup_multiplier,
     }
 
     # SHU-773: entitlement / limit / usage blocks ship only when CP is
@@ -262,7 +268,6 @@ async def get_subscription_status(
                 "current_period_end": state.current_period_end.isoformat() if state.current_period_end else None,
                 "cancel_at_period_end": state.cancel_at_period_end,
                 "canceled_at": state.canceled_at.isoformat() if state.canceled_at else None,
-                "usage_markup_multiplier": usage_markup_multiplier,
             }
         )
 

--- a/backend/src/shu/billing/router.py
+++ b/backend/src/shu/billing/router.py
@@ -458,6 +458,87 @@ async def get_current_usage(
     )
 
 
+@router.get(
+    "/usage/me",
+    summary="Get the current user's own usage",
+    description="Get the authenticated user's own token usage and cost for the current billing period.",
+)
+async def get_my_usage(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    user: Annotated[User, Depends(get_current_user)],
+) -> JSONResponse:
+    """Get the requesting user's own usage for the current billing period.
+
+    Available to ANY authenticated user (SHU-844) — scoped server-side to
+    ``user.id`` with no client-supplied user parameter, so one user can never
+    read another's usage. RLS additionally scopes to the tenant. Mirrors the
+    admin ``/usage`` payload (so the frontend can reuse CostByModelTable) and
+    adds a ``by_day`` per-(day, model) series for the time chart. BYOK usage is
+    excluded — only Shu-managed (billable) providers count, matching ``/usage``.
+    """
+    state = await get_current_billing_state()
+    period_start = state.current_period_start
+    period_end = state.current_period_end
+
+    if not (period_start and period_end):
+        return ShuResponse.success(
+            {
+                "current_period_unknown": True,
+                "period_start": None,
+                "period_end": None,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "total_cost_usd": 0.0,
+                "request_count": 0,
+                "by_model": [],
+                "by_day": [],
+            }
+        )
+
+    # llm_usage.user_id is stored as a string (the recorder str()s the owner id);
+    # str() here keeps the comparison aligned regardless of the User.id type.
+    scoped_user_id = str(user.id)
+    provider = UsageProviderImpl(db)
+    summary = await provider.get_usage_summary(period_start, period_end, user_id=scoped_user_id)
+    daily = await provider.get_daily_usage_for_user(scoped_user_id, period_start, period_end)
+    request_count = sum(m.request_count for m in summary.by_model.values())
+
+    return ShuResponse.success(
+        {
+            "current_period_unknown": False,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "total_input_tokens": summary.total_input_tokens,
+            "total_output_tokens": summary.total_output_tokens,
+            "total_cost_usd": float(summary.total_cost_usd),
+            "request_count": request_count,
+            "by_model": [
+                {
+                    "model_id": m.model_id,
+                    "model_name": m.model_name,
+                    "input_tokens": m.input_tokens,
+                    "output_tokens": m.output_tokens,
+                    "cost_usd": float(m.cost_usd),
+                    "request_count": m.request_count,
+                }
+                for m in summary.by_model.values()
+            ],
+            "by_day": [
+                {
+                    "date": d.day.date().isoformat(),
+                    "model_id": d.model_id,
+                    "model_name": d.model_name,
+                    "input_tokens": d.input_tokens,
+                    "output_tokens": d.output_tokens,
+                    "cost_usd": float(d.cost_usd),
+                    "request_count": d.request_count,
+                }
+                for d in daily
+            ],
+        }
+    )
+
+
 # =============================================================================
 # Seat management
 # =============================================================================

--- a/backend/src/shu/billing/router.py
+++ b/backend/src/shu/billing/router.py
@@ -44,7 +44,7 @@ from shu.billing.seat_service import (
     get_seat_service,
 )
 from shu.billing.service import BillingService, CustomerMismatchError
-from shu.billing.stripe_client import StripeClient, StripeClientError
+from shu.billing.stripe_client import StripeClient, StripeClientError, find_seat_item, resolve_period_end
 from shu.core.logging import get_logger
 from shu.core.response import ShuResponse
 from shu.core.tenant import UnknownStripeCustomerError, tenant_context_for_stripe_customer
@@ -395,6 +395,64 @@ async def cancel_trial(
 # =============================================================================
 
 
+def _calendar_month_period() -> tuple[datetime, datetime]:
+    """Last-resort usage period: the current UTC calendar month, [1st, next-1st).
+
+    Used only when neither CP nor Stripe can supply a period, so the usage
+    dashboards still show recent activity rather than rendering blank.
+    """
+    start = datetime.now(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    end = start.replace(year=start.year + 1, month=1) if start.month == 12 else start.replace(month=start.month + 1)
+    return start, end
+
+
+async def _stripe_subscription_period(settings: BillingSettings) -> tuple[datetime, datetime] | None:
+    """Resolve the active Stripe subscription's current period, or None.
+
+    Fallback for CP-less deployments (SHU-844): when CP doesn't supply a period
+    but Stripe is configured, read it straight from the subscription. The
+    2026-03-25 API moved current_period_* onto the seat item, so prefer that
+    (resolve_period_end handles the same for the end). Best-effort — any Stripe
+    hiccup returns None so a read-only usage view falls back rather than 502s.
+    """
+    if not settings.is_configured or not settings.subscription_id:
+        return None
+    try:
+        subscription = await StripeClient(settings).get_subscription(settings.subscription_id)
+        if subscription is None:
+            return None
+        seat_item = find_seat_item(subscription)
+        end_ts = resolve_period_end(subscription, seat_item)
+        start_ts = (
+            seat_item["current_period_start"]
+            if seat_item is not None and "current_period_start" in seat_item
+            else subscription["current_period_start"]
+        )
+        return datetime.fromtimestamp(int(start_ts), UTC), datetime.fromtimestamp(int(end_ts), UTC)
+    except (StripeClientError, stripe.StripeError, KeyError, ValueError, TypeError) as exc:
+        logger.warning("Stripe usage-period fallback failed; using calendar-month default", extra={"error": str(exc)})
+        return None
+
+
+async def _resolve_usage_period(settings: BillingSettings) -> tuple[datetime, datetime]:
+    """Resolve the usage period with graceful fallback: CP -> Stripe -> calendar month.
+
+    Since SHU-774 the period comes from the CP-sourced BillingState. CP-less
+    deployments (self-hosted with Stripe, or pure dev) otherwise have no period
+    and the usage dashboards render blank, so fall back to the live Stripe
+    subscription period, then to the current calendar month (SHU-844). The
+    returned period is always populated — callers no longer special-case an
+    "unknown period" branch.
+    """
+    state = await get_current_billing_state()
+    if state.current_period_start and state.current_period_end:
+        return state.current_period_start, state.current_period_end
+    stripe_period = await _stripe_subscription_period(settings)
+    if stripe_period is not None:
+        return stripe_period
+    return _calendar_month_period()
+
+
 @router.get(
     "/usage",
     summary="Get current usage",
@@ -403,34 +461,14 @@ async def cancel_trial(
 )
 async def get_current_usage(
     db: Annotated[AsyncSession, Depends(get_db)],
+    settings: Annotated[BillingSettings, Depends(get_billing_settings_dependency)],
 ) -> JSONResponse:
-    """Get usage for the current billing period.
+    """Get tenant-wide usage for the current billing period.
 
-    Returns an unknown-period response with empty totals when the billing
-    period hasn't been populated yet (no subscription webhook received yet).
-    Otherwise returns total tokens used, breakdown by model, and estimated
-    cost for the active subscription period.
+    Period resolution falls back CP -> Stripe -> calendar month so the
+    dashboard still renders for CP-less deployments (SHU-844).
     """
-    # Period bounds come from the CP-sourced BillingState (SHU-774); the
-    # local billing_state columns aren't written anymore after the webhook
-    # persistence callbacks were lifted.
-    state = await get_current_billing_state()
-    period_start = state.current_period_start
-    period_end = state.current_period_end
-
-    if not (period_start and period_end):
-        return ShuResponse.success(
-            {
-                "current_period_unknown": True,
-                "period_start": None,
-                "period_end": None,
-                "total_input_tokens": 0,
-                "total_output_tokens": 0,
-                "total_cost_usd": 0.0,
-                "by_model": [],
-            }
-        )
-
+    period_start, period_end = await _resolve_usage_period(settings)
     usage_provider = UsageProviderImpl(db)
     summary = await usage_provider.get_usage_summary(period_start, period_end)
 
@@ -438,6 +476,7 @@ async def get_current_usage(
     # Display precision is fine; billing precision is preserved internally.
     return ShuResponse.success(
         {
+            "current_period_unknown": False,
             "period_start": period_start.isoformat(),
             "period_end": period_end.isoformat(),
             "total_input_tokens": summary.total_input_tokens,
@@ -466,6 +505,7 @@ async def get_current_usage(
 async def get_my_usage(
     db: Annotated[AsyncSession, Depends(get_db)],
     user: Annotated[User, Depends(get_current_user)],
+    settings: Annotated[BillingSettings, Depends(get_billing_settings_dependency)],
 ) -> JSONResponse:
     """Get the requesting user's own usage for the current billing period.
 
@@ -475,25 +515,9 @@ async def get_my_usage(
     admin ``/usage`` payload (so the frontend can reuse CostByModelTable) and
     adds a ``by_day`` per-(day, model) series for the time chart. BYOK usage is
     excluded — only Shu-managed (billable) providers count, matching ``/usage``.
+    Period resolution falls back CP -> Stripe -> calendar month (SHU-844).
     """
-    state = await get_current_billing_state()
-    period_start = state.current_period_start
-    period_end = state.current_period_end
-
-    if not (period_start and period_end):
-        return ShuResponse.success(
-            {
-                "current_period_unknown": True,
-                "period_start": None,
-                "period_end": None,
-                "total_input_tokens": 0,
-                "total_output_tokens": 0,
-                "total_cost_usd": 0.0,
-                "request_count": 0,
-                "by_model": [],
-                "by_day": [],
-            }
-        )
+    period_start, period_end = await _resolve_usage_period(settings)
 
     # llm_usage.user_id is stored as a string (the recorder str()s the owner id);
     # str() here keeps the comparison aligned regardless of the User.id type.

--- a/backend/src/shu/plugins/host/kb_capability.py
+++ b/backend/src/shu/plugins/host/kb_capability.py
@@ -74,7 +74,7 @@ class KbCapability(ImmutableCapabilityMixin):
         ko_obj = ko if isinstance(ko, KnowledgeObject) else KnowledgeObject(**ko)
         db = await get_db_session()
         try:
-            ko_id = await _host_upsert_knowledge_object(db, knowledge_base_id, ko_obj)
+            ko_id = await _host_upsert_knowledge_object(db, knowledge_base_id, ko_obj, user_id=self._user_id)
             logger.info(
                 "host.kb.upsert",
                 extra={

--- a/backend/src/shu/services/context_window_manager.py
+++ b/backend/src/shu/services/context_window_manager.py
@@ -45,6 +45,7 @@ class ContextWindowManager:
         conversation: Conversation,
         max_tokens: int,
         recent_message_limit_override: int | None = None,
+        user_id: str | None = None,
     ) -> list[ChatMessage]:
         """Apply pruning/summarization to the message list."""
 
@@ -85,7 +86,7 @@ class ContextWindowManager:
         managed_messages: list[ChatMessage] = []
 
         if older_messages:
-            summary = await self._summarize_conversation_history(older_messages)
+            summary = await self._summarize_conversation_history(older_messages, user_id=user_id)
             if summary:
                 # Use 'user' role instead of 'system' to avoid adapter compatibility issues.
                 # Adapters like Anthropic/Gemini expect system content via ChatContext.system_prompt,
@@ -115,6 +116,7 @@ class ContextWindowManager:
     async def _summarize_conversation_history(
         self,
         messages: list[ChatMessage],
+        user_id: str | None = None,
     ) -> str | None:
         if not messages:
             return None
@@ -134,7 +136,7 @@ class ContextWindowManager:
                 result = await self.side_call_service.call(
                     message_sequence=[{"role": "user", "content": summary_prompt}],
                     system_prompt=None,
-                    user_id="system",
+                    user_id=user_id,
                 )
                 if result.success:
                     logger.info("Generated conversation summary via side-call service")

--- a/backend/src/shu/services/knowledge_object_service.py
+++ b/backend/src/shu/services/knowledge_object_service.py
@@ -76,7 +76,9 @@ def _choose_file_type(ko: KnowledgeObject) -> str:
     return "txt"
 
 
-async def upsert_knowledge_object(db: AsyncSession, knowledge_base_id: str, ko: KnowledgeObject) -> str:
+async def upsert_knowledge_object(
+    db: AsyncSession, knowledge_base_id: str, ko: KnowledgeObject, user_id: str | None = None
+) -> str:
     """Upsert a KnowledgeObject into the KB-backed storage and trigger indexing.
 
     - Creates or updates a Document row using KO fields
@@ -160,6 +162,7 @@ async def upsert_knowledge_object(db: AsyncSession, knowledge_base_id: str, ko: 
         document=document,
         title=title,
         content=content,
+        user_id=user_id,
     )
 
     from ..models.document import DocumentStatus

--- a/backend/src/shu/services/message_context_builder.py
+++ b/backend/src/shu/services/message_context_builder.py
@@ -146,6 +146,7 @@ class MessageContextBuilder:
             conversation=conversation,
             max_tokens=effective_max_tokens,
             recent_message_limit_override=recent_messages_limit,
+            user_id=str(current_user.id),
         )
 
         return ChatContext(system_prompt=combined_system, messages=chat_messages), all_source_metadata

--- a/backend/src/tests/integ/test_billing_usage_me_integration.py
+++ b/backend/src/tests/integ/test_billing_usage_me_integration.py
@@ -1,0 +1,343 @@
+"""Integration tests for GET /api/v1/billing/usage/me (SHU-844).
+
+Verifies the per-user "My Usage" endpoint:
+- scopes strictly to the requesting user (one user never sees another's usage),
+- excludes BYOK (is_system_managed=False) providers,
+- returns the current_period_unknown shape when there's no active period,
+- buckets the by_day series per UTC day per model.
+
+Framework: the custom async runner (NOT pytest). Test functions take
+(client, db, auth_headers). Run a single suite in-container, e.g.:
+    docker exec shu-api-dev sh -lc \
+      "cd /app/src && SHU_WORKERS_ENABLED=false python -m tests.integ.test_billing_usage_me_integration"
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from integ.base_integration_test import BaseIntegrationTestSuite
+from integ.helpers.auth import cleanup_test_user, create_active_user_with_id
+from integ.response_utils import extract_data
+from shu.core.logging import get_logger
+from shu.core.tenant import tenant_context_for_tenant_id
+
+logger = get_logger(__name__)
+
+# A fixed billing period; seeded usage created_at values fall inside it.
+PERIOD_START = datetime(2026, 6, 1, tzinfo=UTC)
+PERIOD_END = datetime(2026, 7, 1, tzinfo=UTC)
+IN_PERIOD = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
+
+
+def _patch_period():
+    """Patch the router's billing-state lookup to supply a known period.
+
+    The endpoint only reads `state.current_period_start/end`, so a SimpleNamespace
+    is enough — no full BillingState needed. The self-hosted test env otherwise
+    returns HEALTHY_DEFAULT (no period → current_period_unknown)."""
+
+    async def _fake_state():
+        return SimpleNamespace(current_period_start=PERIOD_START, current_period_end=PERIOD_END)
+
+    return patch("shu.billing.router.get_current_billing_state", _fake_state)
+
+
+async def _seed_provider(db, *, system_managed: bool) -> str:
+    """Create an LLM provider (billable or BYOK). Returns provider_id.
+
+    Providers are global (not tenant-scoped); name carries 'test' so the
+    framework cleanup reclaims it between tests.
+    """
+    from shu.models.llm_provider import LLMProvider
+
+    async with tenant_context_for_tenant_id(None):
+        provider = LLMProvider(
+            name=f"shu844-test-provider-{uuid.uuid4().hex[:8]}",
+            provider_type="openai",
+            is_active=True,
+            is_system_managed=system_managed,
+        )
+        db.add(provider)
+        await db.commit()
+        await db.refresh(provider)
+        return provider.id
+
+
+async def _seed_usage(
+    db,
+    *,
+    user_id: str,
+    provider_id: str,
+    model_name: str,
+    input_tokens: int,
+    output_tokens: int,
+    total_cost: str,
+    created_at: datetime,
+) -> None:
+    """Seed one llm_usage row attributed to a user (tenant stamped via context)."""
+    from shu.models.llm_provider import LLMUsage
+
+    async with tenant_context_for_tenant_id(None):
+        db.add(
+            LLMUsage(
+                user_id=str(user_id),
+                provider_id=provider_id,
+                model_id=None,
+                provider_name="shu844-test",
+                model_name=model_name,
+                request_type="chat",
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+                total_cost=Decimal(total_cost),
+                success=True,
+                created_at=created_at,
+            )
+        )
+        await db.commit()
+
+
+async def _cleanup_seeded(db) -> None:
+    """Remove rows this suite seeded.
+
+    The API can't delete Shu-managed (is_system_managed) providers, so the
+    framework cleanup 403s on them; sweep our markers directly. llm_usage is
+    RLS-scoped, so the DELETE runs inside tenant context.
+    """
+    from sqlalchemy import text
+
+    async with tenant_context_for_tenant_id(None):
+        await db.execute(text("DELETE FROM llm_usage WHERE provider_name = 'shu844-test'"))
+        await db.execute(text("DELETE FROM llm_providers WHERE name LIKE 'shu844-test-provider-%'"))
+        await db.commit()
+
+
+async def test_usage_me_scopes_to_caller(client, db, auth_headers):
+    """A fresh user sees ONLY their own billable usage — another user's rows never leak in.
+
+    Uses the framework admin as the "other user" so only one new seat is taken
+    (the dev tenant enforces a seat limit). The fresh user has no prior usage,
+    so asserting their exact totals proves the user_id scoping holds.
+    """
+    a_headers, a_id = await create_active_user_with_id(client, auth_headers)
+    admin_id = auth_headers["_user_id"]  # the framework's existing admin user
+    try:
+        provider_id = await _seed_provider(db, system_managed=True)
+        # Fresh user A's usage.
+        await _seed_usage(
+            db,
+            user_id=a_id,
+            provider_id=provider_id,
+            model_name="model-a",
+            input_tokens=100,
+            output_tokens=50,
+            total_cost="0.002",
+            created_at=IN_PERIOD,
+        )
+        # A DIFFERENT user's usage (admin), same tenant/provider/period — must be excluded from A's view.
+        await _seed_usage(
+            db,
+            user_id=admin_id,
+            provider_id=provider_id,
+            model_name="model-admin",
+            input_tokens=200,
+            output_tokens=100,
+            total_cost="0.004",
+            created_at=IN_PERIOD,
+        )
+
+        with _patch_period():
+            resp_a = await client.get("/api/v1/billing/usage/me", headers=a_headers)
+
+        assert resp_a.status_code == 200, resp_a.text
+        data_a = extract_data(resp_a)
+
+        # A sees exactly their own row — not the admin's 200/100, not their sum.
+        assert data_a["current_period_unknown"] is False
+        assert data_a["total_input_tokens"] == 100, data_a
+        assert data_a["total_output_tokens"] == 50, data_a
+        assert float(data_a["total_cost_usd"]) == 0.002, data_a
+        assert data_a["request_count"] == 1, data_a
+        model_names = [m.get("model_name") for m in data_a["by_model"]]
+        assert "model-admin" not in model_names, data_a
+    finally:
+        await cleanup_test_user(client, auth_headers, a_id)
+        await _cleanup_seeded(db)
+
+
+async def test_usage_me_excludes_byok(client, db, auth_headers):
+    """BYOK (is_system_managed=False) usage is excluded; only billable usage counts."""
+    headers, user_id = await create_active_user_with_id(client, auth_headers)
+    try:
+        billable = await _seed_provider(db, system_managed=True)
+        byok = await _seed_provider(db, system_managed=False)
+        await _seed_usage(
+            db,
+            user_id=user_id,
+            provider_id=billable,
+            model_name="billable-model",
+            input_tokens=100,
+            output_tokens=50,
+            total_cost="0.002",
+            created_at=IN_PERIOD,
+        )
+        await _seed_usage(
+            db,
+            user_id=user_id,
+            provider_id=byok,
+            model_name="byok-model",
+            input_tokens=300,
+            output_tokens=200,
+            total_cost="0.010",
+            created_at=IN_PERIOD,
+        )
+
+        with _patch_period():
+            resp = await client.get("/api/v1/billing/usage/me", headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        data = extract_data(resp)
+        # Only the billable row counts; the BYOK row is filtered out.
+        assert data["total_input_tokens"] == 100, data
+        assert data["total_output_tokens"] == 50, data
+        model_names = [m.get("model_name") for m in data["by_model"]]
+        assert "byok-model" not in model_names, data
+        assert "billable-model" in model_names, data
+    finally:
+        await cleanup_test_user(client, auth_headers, user_id)
+        await _cleanup_seeded(db)
+
+
+async def test_usage_me_unknown_period(client, db, auth_headers):
+    """With no active billing period (default self-hosted test env), returns the unknown shape."""
+    headers, user_id = await create_active_user_with_id(client, auth_headers)
+    try:
+        # No _patch_period(): get_current_billing_state -> HEALTHY_DEFAULT (no period).
+        resp = await client.get("/api/v1/billing/usage/me", headers=headers)
+        assert resp.status_code == 200, resp.text
+        data = extract_data(resp)
+        assert data["current_period_unknown"] is True, data
+        assert data["period_start"] is None
+        assert data["period_end"] is None
+        assert data["total_input_tokens"] == 0
+        assert data["total_output_tokens"] == 0
+        assert data["total_cost_usd"] == 0.0
+        assert data["request_count"] == 0
+        assert data["by_model"] == []
+        assert data["by_day"] == []
+    finally:
+        await cleanup_test_user(client, auth_headers, user_id)
+        await _cleanup_seeded(db)
+
+
+async def test_usage_me_by_day_buckets(client, db, auth_headers):
+    """by_day buckets per UTC day per model; aggregated by_model matches the daily sum."""
+    headers, user_id = await create_active_user_with_id(client, auth_headers)
+    try:
+        provider_id = await _seed_provider(db, system_managed=True)
+        day1 = datetime(2026, 6, 5, 2, 0, 0, tzinfo=UTC)
+        day1_late = datetime(2026, 6, 5, 20, 0, 0, tzinfo=UTC)
+        day2 = datetime(2026, 6, 6, 3, 0, 0, tzinfo=UTC)
+        # Day 1: two rows on model-1 (same UTC day → one bucket) + one on model-2.
+        await _seed_usage(
+            db,
+            user_id=user_id,
+            provider_id=provider_id,
+            model_name="model-1",
+            input_tokens=100,
+            output_tokens=50,
+            total_cost="0.001",
+            created_at=day1,
+        )
+        await _seed_usage(
+            db,
+            user_id=user_id,
+            provider_id=provider_id,
+            model_name="model-1",
+            input_tokens=40,
+            output_tokens=10,
+            total_cost="0.001",
+            created_at=day1_late,
+        )
+        await _seed_usage(
+            db,
+            user_id=user_id,
+            provider_id=provider_id,
+            model_name="model-2",
+            input_tokens=70,
+            output_tokens=30,
+            total_cost="0.001",
+            created_at=day1,
+        )
+        # Day 2: one row on model-1.
+        await _seed_usage(
+            db,
+            user_id=user_id,
+            provider_id=provider_id,
+            model_name="model-1",
+            input_tokens=200,
+            output_tokens=100,
+            total_cost="0.002",
+            created_at=day2,
+        )
+
+        with _patch_period():
+            resp = await client.get("/api/v1/billing/usage/me", headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        data = extract_data(resp)
+        by_day = data["by_day"]
+
+        d1_m1 = [d for d in by_day if d["date"] == "2026-06-05" and d["model_name"] == "model-1"]
+        d1_m2 = [d for d in by_day if d["date"] == "2026-06-05" and d["model_name"] == "model-2"]
+        d2_m1 = [d for d in by_day if d["date"] == "2026-06-06" and d["model_name"] == "model-1"]
+        assert len(d1_m1) == 1, by_day
+        assert d1_m1[0]["input_tokens"] == 140, d1_m1  # 100 + 40 same UTC day
+        assert d1_m1[0]["request_count"] == 2, d1_m1
+        assert len(d1_m2) == 1 and d1_m2[0]["input_tokens"] == 70, by_day
+        assert len(d2_m1) == 1 and d2_m1[0]["input_tokens"] == 200, by_day
+
+        # by_model model-1 total = day1 (140) + day2 (200) = 340 input.
+        m1 = next(m for m in data["by_model"] if m["model_name"] == "model-1")
+        assert m1["input_tokens"] == 340, data["by_model"]
+    finally:
+        await cleanup_test_user(client, auth_headers, user_id)
+        await _cleanup_seeded(db)
+
+
+async def test_usage_me_requires_auth(client, db, auth_headers):
+    """Unauthenticated requests are rejected (get_current_user gate)."""
+    logger.info("=== EXPECTED TEST OUTPUT: 401 for unauthenticated /billing/usage/me ===")
+    resp = await client.get("/api/v1/billing/usage/me")
+    assert resp.status_code == 401, resp.text
+
+
+class BillingUsageMeTestSuite(BaseIntegrationTestSuite):
+    """Integration suite for GET /api/v1/billing/usage/me (SHU-844)."""
+
+    def get_test_functions(self) -> list[Callable]:
+        return [
+            test_usage_me_scopes_to_caller,
+            test_usage_me_excludes_byok,
+            test_usage_me_unknown_period,
+            test_usage_me_by_day_buckets,
+            test_usage_me_requires_auth,
+        ]
+
+    def get_suite_name(self) -> str:
+        return "Billing Usage (My Usage) Tests"
+
+    def get_suite_description(self) -> str:
+        return "Per-user /billing/usage/me: scoping, BYOK exclusion, period handling, by_day bucketing (SHU-844)"
+
+
+if __name__ == "__main__":
+    suite = BillingUsageMeTestSuite()
+    sys.exit(suite.run())

--- a/backend/src/tests/integ/test_billing_usage_me_integration.py
+++ b/backend/src/tests/integ/test_billing_usage_me_integration.py
@@ -3,7 +3,8 @@
 Verifies the per-user "My Usage" endpoint:
 - scopes strictly to the requesting user (one user never sees another's usage),
 - excludes BYOK (is_system_managed=False) providers,
-- returns the current_period_unknown shape when there's no active period,
+- falls back to the current UTC calendar month when neither CP nor Stripe
+  supplies a billing period (so the response always has a resolved period),
 - buckets the by_day series per UTC day per model.
 
 Framework: the custom async runner (NOT pytest). Test functions take

--- a/backend/src/tests/integ/test_billing_usage_me_integration.py
+++ b/backend/src/tests/integ/test_billing_usage_me_integration.py
@@ -37,16 +37,17 @@ IN_PERIOD = datetime(2026, 6, 5, 12, 0, 0, tzinfo=UTC)
 
 
 def _patch_period():
-    """Patch the router's billing-state lookup to supply a known period.
+    """Patch the router's period resolver to a fixed, known period.
 
-    The endpoint only reads `state.current_period_start/end`, so a SimpleNamespace
-    is enough — no full BillingState needed. The self-hosted test env otherwise
-    returns HEALTHY_DEFAULT (no period → current_period_unknown)."""
+    Patching the resolver directly keeps the seeding tests deterministic and
+    bypasses the CP -> Stripe -> calendar-month fallback chain (Stripe is
+    configured in the dev container, so the real resolver would otherwise hit
+    it)."""
 
-    async def _fake_state():
-        return SimpleNamespace(current_period_start=PERIOD_START, current_period_end=PERIOD_END)
+    async def _fake_period(settings):
+        return PERIOD_START, PERIOD_END
 
-    return patch("shu.billing.router.get_current_billing_state", _fake_state)
+    return patch("shu.billing.router._resolve_usage_period", _fake_period)
 
 
 async def _seed_provider(db, *, system_managed: bool) -> str:
@@ -215,23 +216,33 @@ async def test_usage_me_excludes_byok(client, db, auth_headers):
         await _cleanup_seeded(db)
 
 
-async def test_usage_me_unknown_period(client, db, auth_headers):
-    """With no active billing period (default self-hosted test env), returns the unknown shape."""
+async def test_usage_me_defaults_to_calendar_month(client, db, auth_headers):
+    """When neither CP nor Stripe supplies a period, fall back to the current UTC calendar month."""
     headers, user_id = await create_active_user_with_id(client, auth_headers)
+
+    async def _no_cp_state():
+        return SimpleNamespace(current_period_start=None, current_period_end=None)
+
+    async def _no_stripe_period(settings):
+        return None
+
     try:
-        # No _patch_period(): get_current_billing_state -> HEALTHY_DEFAULT (no period).
-        resp = await client.get("/api/v1/billing/usage/me", headers=headers)
+        # CP has no period and the Stripe fallback is unavailable -> calendar-month default.
+        with (
+            patch("shu.billing.router.get_current_billing_state", _no_cp_state),
+            patch("shu.billing.router._stripe_subscription_period", _no_stripe_period),
+        ):
+            resp = await client.get("/api/v1/billing/usage/me", headers=headers)
         assert resp.status_code == 200, resp.text
         data = extract_data(resp)
-        assert data["current_period_unknown"] is True, data
-        assert data["period_start"] is None
-        assert data["period_end"] is None
-        assert data["total_input_tokens"] == 0
-        assert data["total_output_tokens"] == 0
-        assert data["total_cost_usd"] == 0.0
-        assert data["request_count"] == 0
-        assert data["by_model"] == []
-        assert data["by_day"] == []
+        # Period is always resolved now (never "unknown") — to the 1st of the current UTC month.
+        assert data["current_period_unknown"] is False, data
+        expected_start = datetime.now(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        assert data["period_start"].startswith(expected_start.date().isoformat()), data
+        # Fresh user has no usage in that window.
+        assert data["total_input_tokens"] == 0, data
+        assert data["total_cost_usd"] == 0.0, data
+        assert data["by_model"] == [], data
     finally:
         await cleanup_test_user(client, auth_headers, user_id)
         await _cleanup_seeded(db)
@@ -326,7 +337,7 @@ class BillingUsageMeTestSuite(BaseIntegrationTestSuite):
         return [
             test_usage_me_scopes_to_caller,
             test_usage_me_excludes_byok,
-            test_usage_me_unknown_period,
+            test_usage_me_defaults_to_calendar_month,
             test_usage_me_by_day_buckets,
             test_usage_me_requires_auth,
         ]

--- a/backend/src/tests/integ/test_billing_usage_me_integration.py
+++ b/backend/src/tests/integ/test_billing_usage_me_integration.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import sys
 import uuid
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -238,8 +238,13 @@ async def test_usage_me_defaults_to_calendar_month(client, db, auth_headers):
         data = extract_data(resp)
         # Period is always resolved now (never "unknown") — to the 1st of the current UTC month.
         assert data["current_period_unknown"] is False, data
-        expected_start = datetime.now(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        assert data["period_start"].startswith(expected_start.date().isoformat()), data
+        # Structural invariants of the calendar-month start, parsed from the
+        # response — avoids a re-sampled now() racing the request across a UTC
+        # month boundary.
+        period_start = datetime.fromisoformat(data["period_start"])
+        assert period_start.day == 1, data
+        assert period_start.hour == period_start.minute == period_start.second == period_start.microsecond == 0, data
+        assert period_start.utcoffset() == timedelta(0), data  # UTC
         # Fresh user has no usage in that window.
         assert data["total_input_tokens"] == 0, data
         assert data["total_cost_usd"] == 0.0, data

--- a/backend/src/tests/unit/billing/test_adapters.py
+++ b/backend/src/tests/unit/billing/test_adapters.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from shu.billing.adapters import (
+    _OTHER_MODEL_ID,
+    _OTHER_MODEL_NAME,
+    DailyModelUsageImpl,
     UsageProviderImpl,
+    _bound_daily_models,
     create_cycle_rollover_callback,
     get_billing_config,
     get_user_count,
@@ -26,8 +30,8 @@ def _make_billing_state(**kwargs) -> BillingState:
     state.current_period_end = kwargs.get("current_period_end", datetime(2026, 5, 1, tzinfo=UTC))
     state.cancel_at_period_end = kwargs.get("cancel_at_period_end", False)
     state.last_reported_total = kwargs.get("last_reported_total", 0)
-    state.last_reported_period_start = kwargs.get("last_reported_period_start", None)
-    state.payment_failed_at = kwargs.get("payment_failed_at", None)
+    state.last_reported_period_start = kwargs.get("last_reported_period_start")
+    state.payment_failed_at = kwargs.get("payment_failed_at")
     state.user_limit_enforcement = kwargs.get("user_limit_enforcement", "soft")
     return state
 
@@ -335,3 +339,60 @@ class TestCreateCycleRolloverCallback:
             await callback("cus_1", "sub_1", "in_1", "evt_1", reason)
 
         seat_service.rollover.assert_not_awaited()
+
+
+def _daily(day_n: int, model_id: str, cost, in_tok: int = 0, out_tok: int = 0, reqs: int = 1) -> DailyModelUsageImpl:
+    return DailyModelUsageImpl(
+        day=datetime(2026, 6, day_n, tzinfo=UTC),
+        model_id=model_id,
+        model_name=model_id,
+        input_tokens=in_tok,
+        output_tokens=out_tok,
+        cost_usd=Decimal(str(cost)),
+        request_count=reqs,
+    )
+
+
+class TestBoundDailyModels:
+    """Top-N + 'Other models' fold for the My Usage chart (SHU-844)."""
+
+    def test_noop_when_within_limit(self):
+        """At or under the limit, rows pass through untouched (the common case)."""
+        rows = [_daily(1, "a", 1), _daily(1, "b", 2), _daily(2, "a", 3)]
+        result = _bound_daily_models(rows, limit=5)
+        assert result == rows
+        assert all(r.model_id != _OTHER_MODEL_ID for r in result)
+
+    def test_folds_lowest_spend_models_into_other(self):
+        """Beyond the limit, the smallest-spend models collapse into one bucket."""
+        rows = [_daily(1, "a", 10), _daily(1, "b", 8), _daily(1, "c", 3), _daily(1, "d", 1)]
+        result = _bound_daily_models(rows, limit=2)
+
+        kept = [r for r in result if r.model_id != _OTHER_MODEL_ID]
+        other = [r for r in result if r.model_id == _OTHER_MODEL_ID]
+        assert {r.model_id for r in kept} == {"a", "b"}  # top 2 by cost
+        assert len(other) == 1
+        assert other[0].model_name == _OTHER_MODEL_NAME
+        assert other[0].cost_usd == Decimal("4")  # 3 + 1
+
+    def test_other_bucket_aggregates_per_day(self):
+        """Folded models sum into one 'Other' row per day, preserving daily totals."""
+        rows = [
+            _daily(1, "top", 100),
+            _daily(2, "top", 100),
+            _daily(1, "x", 5, in_tok=10, out_tok=20, reqs=2),
+            _daily(2, "x", 4, in_tok=8, out_tok=16, reqs=1),
+            _daily(1, "y", 3, in_tok=2, out_tok=4, reqs=1),
+        ]
+        result = _bound_daily_models(rows, limit=1)
+
+        other = {r.day.day: r for r in result if r.model_id == _OTHER_MODEL_ID}
+        assert set(other) == {1, 2}
+        # day 1: x + y
+        assert other[1].cost_usd == Decimal("8")
+        assert other[1].input_tokens == 12
+        assert other[1].output_tokens == 24
+        assert other[1].request_count == 3
+        # day 2: x only
+        assert other[2].cost_usd == Decimal("4")
+        assert other[2].request_count == 1

--- a/backend/src/tests/unit/billing/test_router.py
+++ b/backend/src/tests/unit/billing/test_router.py
@@ -175,7 +175,6 @@ _ADMIN_ONLY_KEYS = (
     "current_period_end",
     "cancel_at_period_end",
     "canceled_at",
-    "usage_markup_multiplier",
 )
 
 _FULL_BILLING_CONFIG = {
@@ -225,7 +224,6 @@ class TestSubscriptionAdminBlock:
         assert body["current_period_start"] == "2026-01-01T00:00:00+00:00"
         assert body["current_period_end"] == "2026-02-01T00:00:00+00:00"
         assert body["cancel_at_period_end"] is False
-        assert body["usage_markup_multiplier"] == 1.3
 
     @pytest.mark.asyncio
     @patch(_P_USER_COUNT)
@@ -259,6 +257,9 @@ _TRIAL_PAYLOAD_KEYS = (
     "total_grant_amount",
     "remaining_grant_amount",
     "seat_price_usd",
+    # SHU-844: the markup rate is no longer admin-gated — non-admins need it so
+    # the per-user My Usage cost can render in billed dollars (raw × markup).
+    "usage_markup_multiplier",
     "entitlements",
     "limits",
 )
@@ -286,6 +287,7 @@ class TestSubscriptionTrialAndEntitlements:
                 seat_price_usd=Decimal("20.00"),
                 limits=LimitSet(document_count_limit=100, kb_count_limit=5),
                 hard_cap=True,
+                usage_markup_multiplier=Decimal("1.3"),
             )
         )
 
@@ -303,6 +305,8 @@ class TestSubscriptionTrialAndEntitlements:
         assert body["total_grant_amount"] == "50.00"
         assert body["remaining_grant_amount"] == "12.34"
         assert body["seat_price_usd"] == "20.00"
+        # Markup rate reaches non-admins (SHU-844) so per-user cost bills correctly.
+        assert body["usage_markup_multiplier"] == 1.3
         assert body["entitlements"] == {
             "chat": True,
             "plugins": True,

--- a/backend/src/tests/unit/billing/test_router.py
+++ b/backend/src/tests/unit/billing/test_router.py
@@ -793,7 +793,7 @@ class TestGetCurrentUsage:
             patch(_P_GET_STATE_ROUTER, AsyncMock(return_value=state)),
             patch(_P_USAGE_PROVIDER_ROUTER, MagicMock(return_value=usage_provider)),
         ):
-            response = await get_current_usage(db=AsyncMock())
+            response = await get_current_usage(db=AsyncMock(), settings=MagicMock())
 
         body = _decode(response)
         assert body.get("current_period_unknown") is not True
@@ -804,21 +804,36 @@ class TestGetCurrentUsage:
         assert body["total_cost_usd"] == 1.23
 
     @pytest.mark.asyncio
-    async def test_unknown_period_response_when_wire_lacks_period_bounds(self):
-        """Cold-start / no-subscription wire (period bounds=None) → the
-        documented unknown-period response shape, not a crash.
+    async def test_calendar_month_fallback_when_wire_lacks_period_bounds(self):
+        """Cold-start / no-subscription wire (period bounds=None) and no Stripe
+        fallback → the current calendar month, not an unknown-period response
+        (SHU-844). Period resolution is CP -> Stripe -> calendar month, so the
+        CP-less dashboard stays usable.
         """
         from shu.billing.router import get_current_usage
 
         state = _make_state()  # period bounds default to None
+        usage_summary = MagicMock()
+        usage_summary.total_input_tokens = 0
+        usage_summary.total_output_tokens = 0
+        usage_summary.total_cost_usd = Decimal("0")
+        usage_summary.by_model = {}
+        usage_provider = MagicMock()
+        usage_provider.get_usage_summary = AsyncMock(return_value=usage_summary)
 
-        with patch(_P_GET_STATE_ROUTER, AsyncMock(return_value=state)):
-            response = await get_current_usage(db=AsyncMock())
+        with (
+            patch(_P_GET_STATE_ROUTER, AsyncMock(return_value=state)),
+            # Stripe fallback unavailable → falls through to the calendar month.
+            patch("shu.billing.router._stripe_subscription_period", AsyncMock(return_value=None)),
+            patch(_P_USAGE_PROVIDER_ROUTER, MagicMock(return_value=usage_provider)),
+        ):
+            response = await get_current_usage(db=AsyncMock(), settings=MagicMock())
 
         body = _decode(response)
-        assert body["current_period_unknown"] is True
-        assert body["period_start"] is None
-        assert body["period_end"] is None
+        # Period is always resolved now — never "unknown".
+        assert body["current_period_unknown"] is False
+        assert body["period_start"] is not None
+        assert body["period_end"] is not None
         assert body["total_input_tokens"] == 0
         assert body["total_output_tokens"] == 0
         assert body["total_cost_usd"] == 0.0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.0",
+        "@mui/x-charts": "^7.23.0",
         "axios": "^1.4.0",
         "cron-parser": "^5.4.0",
         "cronstrue": "^3.9.0",
@@ -73,7 +74,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
       "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.0"
       }
@@ -83,7 +83,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.0.tgz",
       "integrity": "sha512-eZFrPCnrYrF3XtL7qA4L75P0qA3TtZta8H3Yggy7UYFh8gZgu5bSMNF+v4UVCzGxzYmx8ZvPdgOce0BJ6PsW9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -103,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.1.tgz",
       "integrity": "sha512-RKxkj5pGFB+FkPJ5NGhoX3DK3xsv0pMltha7Ei1AnY3tILeq38L7tuhaWDPQI/5nlPxOog44wvqpNyyGcUsNMg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/cssinjs": "^2.1.0",
         "@babel/runtime": "^7.23.2",
@@ -118,29 +116,25 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ant-design/cssinjs/node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ant-design/cssinjs/node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ant-design/fast-color": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
       "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.x"
       }
@@ -150,7 +144,6 @@
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.0.tgz",
       "integrity": "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^8.0.0",
         "@ant-design/icons-svg": "^4.4.0",
@@ -169,15 +162,13 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
       "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ant-design/react-slick": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
       "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "clsx": "^2.1.1",
@@ -252,6 +243,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -605,6 +597,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -628,6 +621,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -690,6 +684,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -733,6 +728,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1380,6 +1376,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -1485,6 +1482,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -1562,6 +1560,84 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-charts": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-7.29.1.tgz",
+      "integrity": "sha512-5s9PX51HWhpMa+DCDa4RgjtODSaMe+PlTZUqoGIil2vaW/+4ouDLREXvyuVvIF93KfZwrPKAL2SJKSQS4YYB2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+        "@mui/x-charts-vendor": "7.20.0",
+        "@mui/x-internals": "7.29.0",
+        "@react-spring/rafz": "^9.7.5",
+        "@react-spring/web": "^9.7.5",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts-vendor": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-7.20.0.tgz",
+      "integrity": "sha512-pzlh7z/7KKs5o0Kk0oPcB+sY0+Dg7Q7RzqQowDQjpy5Slz6qqGsgOB5YUzn0L+2yRmvASc4Pe0914Ao3tMBogg==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "@types/d3-time": "^3.0.3",
+        "d3-color": "^3.1.0",
+        "d3-delaunay": "^6.0.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "d3-time": "^3.1.0",
+        "delaunator": "^5.0.1",
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
+      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1653,7 +1729,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
       "integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.4"
       },
@@ -1666,7 +1741,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
       "integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -1683,7 +1757,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
       "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1698,7 +1771,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
       "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/motion": "^1.1.4",
@@ -1715,7 +1787,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.0.tgz",
       "integrity": "sha512-o7Vavj7yyfVxFmeynXf0fCHVlC0UTE9al74c6nYuLck+gjuVdQNWSVXR8Efq/mmWFy7891SCOsfaPq6Eqe1s/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.0",
         "@rc-component/util": "^1.3.0",
@@ -1731,7 +1802,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
       "integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0"
       },
@@ -1745,7 +1815,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
       "integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.3",
         "@rc-component/portal": "^2.1.0",
@@ -1762,7 +1831,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
       "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.1.3",
@@ -1779,7 +1847,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
       "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.0.0",
         "@rc-component/util": "^1.2.1",
@@ -1795,7 +1862,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.6.2.tgz",
       "integrity": "sha512-OgIn2RAoaSBqaIgzJf/X6iflIa9LpTozci1lagLBdURDFhGA370v0+T0tXxOi8YShMjTha531sFhwtnrv+EJaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/async-validator": "^5.1.0",
         "@rc-component/util": "^1.6.2",
@@ -1814,7 +1880,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.6.0.tgz",
       "integrity": "sha512-tSfn2ZE/oP082g4QIOxeehkmgnXB7R+5AFj/lIFr4k7pEuxHBdyGIq9axoCY9qea8NN0DY6p4IB/F07tLqaT5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/portal": "^2.1.2",
@@ -1831,7 +1896,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
       "integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.4.0",
         "clsx": "^2.1.1"
@@ -1846,7 +1910,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
       "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/mini-decimal": "^1.0.1",
         "@rc-component/util": "^1.4.0",
@@ -1862,7 +1925,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
       "integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/menu": "~1.2.0",
@@ -1881,7 +1943,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
       "integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/overflow": "^1.0.0",
@@ -1899,7 +1960,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
       "integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0"
       },
@@ -1912,7 +1972,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.1.6.tgz",
       "integrity": "sha512-aEQobs/YA0kqRvHIPjQvOytdtdRVyhf/uXAal4chBjxDu6odHckExJzjn2D+Ju1aKK6hx3pAs6BXdV9+86xkgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0",
         "clsx": "^2.1.1"
@@ -1927,7 +1986,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
       "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -1944,7 +2002,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
       "integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/util": "^1.2.1",
@@ -1963,7 +2020,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.0.tgz",
       "integrity": "sha512-GSlBeoE0XTBi5cf3zl8Qh7Uqhn7v8RrlJ8ajeVpEkNe94HWy5l5BQ0Mwn2TVUq9gdgbfEMUmTX7tJFAg7mz0Rw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/resize-observer": "^1.0.1",
@@ -1980,7 +2036,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
       "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1995,7 +2050,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.0.tgz",
       "integrity": "sha512-OLisdk8AWVCG9goBU1dWzuH5QlBQk8jktmQ6p0/IyBFwdKGwyIZOSjnBYo8hooHiTdl0lU+wGf/OfMtVBw02KQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -2034,7 +2088,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
       "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -2052,7 +2105,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
       "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -2067,7 +2119,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
       "integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7"
       },
@@ -2084,7 +2135,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
       "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2102,7 +2152,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.1.tgz",
       "integrity": "sha512-NfXXMmiR+SmUuKE1NwJESzEUYUFWIDUn2uXpxCTOLwiRUUakd62DRNFjRJArgzyFW8S5rsL4aX5XlyIXyC/vRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -2116,7 +2165,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
       "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/motion": "^1.1.4",
@@ -2133,7 +2181,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.5.tgz",
       "integrity": "sha512-Cx+/OYEorXlPQ6ZFDro3HbalPZLlJWagvGtl8DGYO4losXM6gw43qbsxWqU1c3XOQVIOUDBlr7dSksSNMj8kXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/trigger": "^3.0.0",
@@ -2154,7 +2201,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
       "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2172,7 +2218,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
       "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -2190,7 +2235,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
       "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2205,7 +2249,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
       "integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/context": "^2.0.1",
         "@rc-component/resize-observer": "^1.0.0",
@@ -2226,7 +2269,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
       "integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/dropdown": "~1.0.0",
         "@rc-component/menu": "~1.2.0",
@@ -2248,7 +2290,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
       "integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -2265,7 +2306,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
       "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.7.1",
         "@rc-component/util": "^1.3.0",
@@ -2281,7 +2321,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
       "integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/portal": "^2.2.0",
         "@rc-component/trigger": "^3.0.0",
@@ -2301,7 +2340,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.3.tgz",
       "integrity": "sha512-mG8hF2ogQcKaEpfyxzPvMWqqkptofd7Sf+YiXOpPzuXLTLwNKfLDJtysc1/oybopbnzxNqWh2Vgwi+GYwNIb7w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/util": "^1.8.1",
@@ -2321,7 +2359,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
       "integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -2338,7 +2375,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
       "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.2.0",
@@ -2359,7 +2395,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
       "integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2374,7 +2409,6 @@
       "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.9.0.tgz",
       "integrity": "sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-mobile": "^5.0.0",
         "react-is": "^18.2.0"
@@ -2388,15 +2422,13 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rc-component/virtual-list": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
       "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@rc-component/resize-observer": "^1.0.1",
@@ -2409,6 +2441,78 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
+      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -2947,6 +3051,57 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3226,6 +3381,7 @@
       "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "fast-glob": "^3.3.2",
@@ -3299,6 +3455,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3773,6 +3930,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4030,8 +4188,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4152,6 +4309,121 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -4225,6 +4497,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4370,6 +4643,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -4754,6 +5036,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4810,6 +5093,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5826,6 +6110,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -6103,8 +6396,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
       "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
@@ -6449,6 +6741,7 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -6528,7 +6821,6 @@
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "string-convert": "^0.2.0"
       }
@@ -8302,6 +8594,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8449,6 +8742,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8461,6 +8755,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8829,6 +9124,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -8994,7 +9295,6 @@
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -9253,8 +9553,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
@@ -9539,7 +9838,6 @@
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
       "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       }
@@ -9976,6 +10274,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10074,6 +10373,7 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.11.16",
-        "@mui/material": "^5.13.0",
+        "@mui/material": "^5.15.14",
         "@mui/x-charts": "^8.29.0",
         "axios": "^1.4.0",
         "cron-parser": "^5.4.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.0",
-        "@mui/x-charts": "^7.23.0",
+        "@mui/x-charts": "^8.29.0",
         "axios": "^1.4.0",
         "cron-parser": "^5.4.0",
         "cronstrue": "^3.9.0",
@@ -1566,19 +1566,21 @@
       }
     },
     "node_modules/@mui/x-charts": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-7.29.1.tgz",
-      "integrity": "sha512-5s9PX51HWhpMa+DCDa4RgjtODSaMe+PlTZUqoGIil2vaW/+4ouDLREXvyuVvIF93KfZwrPKAL2SJKSQS4YYB2w==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-8.29.0.tgz",
+      "integrity": "sha512-wlrrpiz5PjbTRG1T/LIbdcmbxgW3pP8GBDR0lLf65AHNZf7ybrNpE5Sm2zIVb5As6bYbyi5BG65zRLGe/q5d1A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
-        "@mui/x-charts-vendor": "7.20.0",
-        "@mui/x-internals": "7.29.0",
-        "@react-spring/rafz": "^9.7.5",
-        "@react-spring/web": "^9.7.5",
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.5",
+        "@mui/x-charts-vendor": "8.29.0",
+        "@mui/x-internal-gestures": "0.5.0",
+        "@mui/x-internals": "8.29.0",
+        "bezier-easing": "^2.1.0",
         "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
+        "prop-types": "^15.8.1",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1601,36 +1603,102 @@
       }
     },
     "node_modules/@mui/x-charts-vendor": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-7.20.0.tgz",
-      "integrity": "sha512-pzlh7z/7KKs5o0Kk0oPcB+sY0+Dg7Q7RzqQowDQjpy5Slz6qqGsgOB5YUzn0L+2yRmvASc4Pe0914Ao3tMBogg==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-8.29.0.tgz",
+      "integrity": "sha512-nYjgW337QxvCJXct8b0UIir9ELDjMEfWSmMVSfUQsEjn3ZD5jjK3MQVZSHSM1hP79PZcjRQIAuWI1fHkqG04ug==",
       "license": "MIT AND ISC",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
+        "@babel/runtime": "^7.28.4",
+        "@types/d3-array": "^3.2.2",
         "@types/d3-color": "^3.1.3",
-        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-format": "^3.0.4",
         "@types/d3-interpolate": "^3.0.4",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-shape": "^3.1.6",
-        "@types/d3-time": "^3.0.3",
+        "@types/d3-path": "^3.1.1",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-shape": "^3.1.8",
+        "@types/d3-time": "^3.0.4",
+        "@types/d3-time-format": "^4.0.3",
+        "@types/d3-timer": "^3.0.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-delaunay": "^6.0.4",
+        "d3-format": "^3.1.2",
         "d3-interpolate": "^3.0.1",
+        "d3-path": "^3.1.0",
         "d3-scale": "^4.0.2",
         "d3-shape": "^3.2.0",
         "d3-time": "^3.1.0",
-        "delaunator": "^5.0.1",
-        "robust-predicates": "^3.0.2"
+        "d3-time-format": "^4.1.0",
+        "d3-timer": "^3.0.1",
+        "flatqueue": "^3.0.0",
+        "internmap": "^2.0.3"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@mui/types": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@mui/utils": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
+      "integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/types": "^7.4.12",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internal-gestures": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internal-gestures/-/x-internal-gestures-0.5.0.tgz",
+      "integrity": "sha512-LTnaD8WAWld9ecW8Q5tO4Sq2ucyMWca4SKDu6Cx+0RHO3XfgMa7NxB7aBzldAYMN8QrSquBVdu8Zcf9cnp8qwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
       }
     },
     "node_modules/@mui/x-internals": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
-      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "version": "8.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.29.0.tgz",
+      "integrity": "sha512-xlqq765k39g6vkVGIypOBlsdYGawIP0JdSh+qqrkUCIIN39AUZRNMA/nGH0nSkhVHMHcCSDWBM5/6+6BLfc7Mg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.5",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1641,6 +1709,53 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-internals/node_modules/@mui/types": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
+      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals/node_modules/@mui/utils": {
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
+      "integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@mui/types": "^7.4.12",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2490,78 +2605,6 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@react-spring/animated": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
-      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/core": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
-      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-spring/donate"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/rafz": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
-      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
-      "license": "MIT"
-    },
-    "node_modules/@react-spring/shared": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
-      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/rafz": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/types": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
-      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
-      "license": "MIT"
-    },
-    "node_modules/@react-spring/web": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
-      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/core": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -3098,16 +3141,22 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -3147,6 +3196,18 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/debug": {
@@ -3897,6 +3958,12 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
+      "license": "MIT"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -4375,18 +4442,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
@@ -4465,6 +4520,15 @@
       "dependencies": {
         "d3-time": "1 - 3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -4687,15 +4751,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delaunator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -5536,6 +5591,12 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatqueue": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.1.0.tgz",
+      "integrity": "sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==",
+      "license": "ISC"
     },
     "node_modules/flatted": {
       "version": "3.3.3",
@@ -9108,6 +9169,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -9163,12 +9230,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/robust-predicates": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.57.1",
@@ -10281,6 +10342,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vfile": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,6 +74,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
       "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.0"
       }
@@ -83,6 +84,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.0.tgz",
       "integrity": "sha512-eZFrPCnrYrF3XtL7qA4L75P0qA3TtZta8H3Yggy7UYFh8gZgu5bSMNF+v4UVCzGxzYmx8ZvPdgOce0BJ6PsW9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -102,6 +104,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.1.tgz",
       "integrity": "sha512-RKxkj5pGFB+FkPJ5NGhoX3DK3xsv0pMltha7Ei1AnY3tILeq38L7tuhaWDPQI/5nlPxOog44wvqpNyyGcUsNMg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/cssinjs": "^2.1.0",
         "@babel/runtime": "^7.23.2",
@@ -116,25 +119,29 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ant-design/cssinjs/node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ant-design/cssinjs/node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ant-design/fast-color": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
       "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.x"
       }
@@ -144,6 +151,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.0.tgz",
       "integrity": "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^8.0.0",
         "@ant-design/icons-svg": "^4.4.0",
@@ -162,13 +170,15 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
       "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ant-design/react-slick": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
       "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "clsx": "^2.1.1",
@@ -243,7 +253,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -597,7 +606,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -621,7 +629,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -684,7 +691,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -728,7 +734,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1376,7 +1381,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -1482,7 +1486,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -1729,6 +1732,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
       "integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.4"
       },
@@ -1741,6 +1745,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
       "integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -1757,6 +1762,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
       "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1771,6 +1777,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
       "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/motion": "^1.1.4",
@@ -1787,6 +1794,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.0.tgz",
       "integrity": "sha512-o7Vavj7yyfVxFmeynXf0fCHVlC0UTE9al74c6nYuLck+gjuVdQNWSVXR8Efq/mmWFy7891SCOsfaPq6Eqe1s/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.0",
         "@rc-component/util": "^1.3.0",
@@ -1802,6 +1810,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
       "integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0"
       },
@@ -1815,6 +1824,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
       "integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.3",
         "@rc-component/portal": "^2.1.0",
@@ -1831,6 +1841,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
       "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.1.3",
@@ -1847,6 +1858,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
       "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.0.0",
         "@rc-component/util": "^1.2.1",
@@ -1862,6 +1874,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.6.2.tgz",
       "integrity": "sha512-OgIn2RAoaSBqaIgzJf/X6iflIa9LpTozci1lagLBdURDFhGA370v0+T0tXxOi8YShMjTha531sFhwtnrv+EJaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/async-validator": "^5.1.0",
         "@rc-component/util": "^1.6.2",
@@ -1880,6 +1893,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.6.0.tgz",
       "integrity": "sha512-tSfn2ZE/oP082g4QIOxeehkmgnXB7R+5AFj/lIFr4k7pEuxHBdyGIq9axoCY9qea8NN0DY6p4IB/F07tLqaT5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/portal": "^2.1.2",
@@ -1896,6 +1910,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
       "integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.4.0",
         "clsx": "^2.1.1"
@@ -1910,6 +1925,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
       "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/mini-decimal": "^1.0.1",
         "@rc-component/util": "^1.4.0",
@@ -1925,6 +1941,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
       "integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/menu": "~1.2.0",
@@ -1943,6 +1960,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
       "integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/overflow": "^1.0.0",
@@ -1960,6 +1978,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
       "integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0"
       },
@@ -1972,6 +1991,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.1.6.tgz",
       "integrity": "sha512-aEQobs/YA0kqRvHIPjQvOytdtdRVyhf/uXAal4chBjxDu6odHckExJzjn2D+Ju1aKK6hx3pAs6BXdV9+86xkgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0",
         "clsx": "^2.1.1"
@@ -1986,6 +2006,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
       "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -2002,6 +2023,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
       "integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/util": "^1.2.1",
@@ -2020,6 +2042,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.0.tgz",
       "integrity": "sha512-GSlBeoE0XTBi5cf3zl8Qh7Uqhn7v8RrlJ8ajeVpEkNe94HWy5l5BQ0Mwn2TVUq9gdgbfEMUmTX7tJFAg7mz0Rw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/resize-observer": "^1.0.1",
@@ -2036,6 +2059,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
       "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2050,6 +2074,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.0.tgz",
       "integrity": "sha512-OLisdk8AWVCG9goBU1dWzuH5QlBQk8jktmQ6p0/IyBFwdKGwyIZOSjnBYo8hooHiTdl0lU+wGf/OfMtVBw02KQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -2088,6 +2113,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
       "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -2105,6 +2131,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
       "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -2119,6 +2146,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
       "integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7"
       },
@@ -2135,6 +2163,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
       "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2152,6 +2181,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.1.tgz",
       "integrity": "sha512-NfXXMmiR+SmUuKE1NwJESzEUYUFWIDUn2uXpxCTOLwiRUUakd62DRNFjRJArgzyFW8S5rsL4aX5XlyIXyC/vRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -2165,6 +2195,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
       "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/motion": "^1.1.4",
@@ -2181,6 +2212,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.5.tgz",
       "integrity": "sha512-Cx+/OYEorXlPQ6ZFDro3HbalPZLlJWagvGtl8DGYO4losXM6gw43qbsxWqU1c3XOQVIOUDBlr7dSksSNMj8kXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/trigger": "^3.0.0",
@@ -2201,6 +2233,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
       "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2218,6 +2251,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
       "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -2235,6 +2269,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
       "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2249,6 +2284,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
       "integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/context": "^2.0.1",
         "@rc-component/resize-observer": "^1.0.0",
@@ -2269,6 +2305,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
       "integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/dropdown": "~1.0.0",
         "@rc-component/menu": "~1.2.0",
@@ -2290,6 +2327,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
       "integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -2306,6 +2344,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
       "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.7.1",
         "@rc-component/util": "^1.3.0",
@@ -2321,6 +2360,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
       "integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/portal": "^2.2.0",
         "@rc-component/trigger": "^3.0.0",
@@ -2340,6 +2380,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.3.tgz",
       "integrity": "sha512-mG8hF2ogQcKaEpfyxzPvMWqqkptofd7Sf+YiXOpPzuXLTLwNKfLDJtysc1/oybopbnzxNqWh2Vgwi+GYwNIb7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/util": "^1.8.1",
@@ -2359,6 +2400,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
       "integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -2375,6 +2417,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
       "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.2.0",
@@ -2395,6 +2438,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
       "integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -2409,6 +2453,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.9.0.tgz",
       "integrity": "sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-mobile": "^5.0.0",
         "react-is": "^18.2.0"
@@ -2422,13 +2467,15 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rc-component/virtual-list": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
       "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@rc-component/resize-observer": "^1.0.1",
@@ -3381,7 +3428,6 @@
       "integrity": "sha512-xa57bCPGuzEFqGjPs3vVLyqareG8DX0uMkr5U/v5vLv5/ZUrBrPL7gzxzTJedEyZxFMfsozwTIbbYfEQVo3kgg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "fast-glob": "^3.3.2",
@@ -3455,7 +3501,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3930,7 +3975,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4188,7 +4232,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4497,7 +4542,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5036,7 +5080,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5093,7 +5136,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6396,7 +6438,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
       "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
@@ -6741,7 +6784,6 @@
       "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^2.0.1",
         "cssstyle": "^4.0.1",
@@ -6821,6 +6863,7 @@
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-convert": "^0.2.0"
       }
@@ -8594,7 +8637,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8742,7 +8784,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8755,7 +8796,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9295,6 +9335,7 @@
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -9553,7 +9594,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
@@ -9838,6 +9880,7 @@
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
       "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       }
@@ -10274,7 +10317,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -10373,7 +10415,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",
+    "@mui/x-charts": "^7.23.0",
     "axios": "^1.4.0",
     "cron-parser": "^5.4.0",
     "cronstrue": "^3.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.0",
-    "@mui/x-charts": "^7.23.0",
+    "@mui/x-charts": "^8.29.0",
     "axios": "^1.4.0",
     "cron-parser": "^5.4.0",
     "cronstrue": "^3.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.11.16",
-    "@mui/material": "^5.13.0",
+    "@mui/material": "^5.15.14",
     "@mui/x-charts": "^8.29.0",
     "axios": "^1.4.0",
     "cron-parser": "^5.4.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -34,6 +34,7 @@ import ModernChat from './components/ModernChat';
 import UserPermissionsDashboard from './components/UserPermissionsDashboard';
 import ConnectedAccountsPage from './components/ConnectedAccountsPage';
 import UserPreferencesPage from './components/UserPreferencesPage';
+import MyUsagePage from './pages/MyUsagePage';
 
 // Auth Components
 import AuthPage from './components/AuthPage';
@@ -215,6 +216,16 @@ const AuthenticatedApp = () => {
                   element={
                     <RoleBasedRoute layout="user">
                       <UserPermissionsDashboard />
+                    </RoleBasedRoute>
+                  }
+                />
+
+                {/* My Usage dashboard (SHU-844) - Available to ALL users */}
+                <Route
+                  path="/usage"
+                  element={
+                    <RoleBasedRoute layout="user">
+                      <MyUsagePage />
                     </RoleBasedRoute>
                   }
                 />

--- a/frontend/src/components/UserMenuCommonItems.jsx
+++ b/frontend/src/components/UserMenuCommonItems.jsx
@@ -5,6 +5,7 @@ import {
   ChatBubbleOutline as ChatIcon,
   ManageAccounts as AccountsIcon,
   Settings as SettingsIcon,
+  Insights as UsageIcon,
 } from '@mui/icons-material';
 import { useFeatureEnabled } from '../config/featureFlags';
 
@@ -30,6 +31,12 @@ export default function UserMenuCommonItems({ onNavigate }) {
           <SecurityIcon fontSize="small" />
         </ListItemIcon>
         My Permissions
+      </MenuItem>
+      <MenuItem onClick={go('/usage')}>
+        <ListItemIcon>
+          <UsageIcon fontSize="small" />
+        </ListItemIcon>
+        My Usage
       </MenuItem>
       {canPlugins && (
         <MenuItem onClick={go('/settings/connected-accounts')}>

--- a/frontend/src/components/billing/KbLimitsTile.jsx
+++ b/frontend/src/components/billing/KbLimitsTile.jsx
@@ -1,0 +1,61 @@
+import { Box, LinearProgress } from '@mui/material';
+
+import { KpiTile, pickUsedColor } from './KpiTiles';
+import { formatFullTokens } from '../../utils/billingFormatters';
+
+// Clamp at 100% — concurrent plugin/feed batch ingestion can transiently
+// overshoot the cap, so usage isn't guaranteed <= limit.
+function buildStat(label, used, cap) {
+  const u = Math.max(used ?? 0, 0);
+  const percent = Math.min(Math.round((u / cap) * 100), 100);
+  return { key: label, label, value: `${formatFullTokens(u)} / ${formatFullTokens(cap)}`, percent };
+}
+
+/**
+ * Workspace (tenant-wide) Knowledge Base limit tiles for My Usage (SHU-844):
+ * documents-used / cap and KBs-used / cap, each with a color-banded bar.
+ *
+ * These are TENANT-shared counts — the kb_count/document_count + limits blocks
+ * on /billing/subscription are tenant-wide RLS counts, not per-user — so they're
+ * framed "Across your workspace", mirroring the Shared Pool tile. Renders only
+ * when control-plane supplies the limits/usage blocks (hidden self-hosted) and
+ * only for caps > 0 (0 is a real zero cap on cold-start, not "unlimited").
+ */
+export default function KbLimitsTile({ usage, limits }) {
+  if (!usage || !limits) {
+    return null;
+  }
+
+  const stats = [];
+  if (limits.document_count_limit > 0) {
+    stats.push(buildStat('Documents', usage.document_count, limits.document_count_limit));
+  }
+  if (limits.kb_count_limit > 0) {
+    stats.push(buildStat('Knowledge Bases', usage.kb_count, limits.kb_count_limit));
+  }
+  if (!stats.length) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}>
+      {stats.map((s) => (
+        <KpiTile
+          key={s.key}
+          label={s.label}
+          value={s.value}
+          ariaLabel={`${s.label}: ${s.value} across your workspace`}
+          subline="Across your workspace"
+          bottom={
+            <LinearProgress
+              variant="determinate"
+              value={s.percent}
+              color={pickUsedColor(s.percent)}
+              aria-label={`${s.percent}% of ${s.label.toLowerCase()} limit used`}
+            />
+          }
+        />
+      ))}
+    </Box>
+  );
+}

--- a/frontend/src/components/billing/KpiTiles.jsx
+++ b/frontend/src/components/billing/KpiTiles.jsx
@@ -4,7 +4,9 @@ import { formatCurrency, INCLUDED_USAGE_PER_SEAT_USD, USAGE_MARKUP_MULTIPLIER } 
 
 const PLACEHOLDER = '—';
 
-function KpiTile({ label, value, ariaLabel, valueColor, subline, bottom }) {
+// Exported so the per-user My Usage tiles (SHU-844) reuse the exact tile
+// presentation instead of duplicating the card markup.
+export function KpiTile({ label, value, ariaLabel, valueColor, subline, bottom }) {
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
       <CardContent>

--- a/frontend/src/components/billing/MyUsageChart.jsx
+++ b/frontend/src/components/billing/MyUsageChart.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Chip, Stack, Typography } from '@mui/material';
 import { BarChart } from '@mui/x-charts/BarChart';
 
@@ -29,6 +29,29 @@ const SERIES_COLORS = [
   '#fca5a5',
 ];
 
+// Stable references for the chart's props, defined once at module scope, plus
+// the per-render derived props (series, xAxis) memoized below — @mui/x-charts
+// re-runs internal layout effects when its prop identities change, so keeping
+// them stable avoids needless re-renders.
+const seriesValueFormatter = (v) => (v === null || v === undefined ? '' : formatCurrency(v));
+const Y_AXIS = [{ valueFormatter: (v) => formatCurrency(v) }];
+const CHART_MARGIN = { left: 72 };
+
+// Format a "YYYY-MM-DD" UTC day key into a short axis label like "Jun 1". v8
+// drops x-axis tick labels that would overlap their neighbour
+// (ChartsXAxis/getVisibleLabels); full ISO strings are wide enough that nearly
+// all of them collapse, so we render a narrow label that fits. Parsed at UTC
+// midnight to match the "Day (UTC)" axis (a bare "YYYY-MM-DD" parses as local
+// and would shift a day in negative-offset zones).
+const fmtDay = (iso) => {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+};
+
+const periodTotal = (s) => s.data.reduce((sum, v) => sum + (v || 0), 0);
+
 /**
  * Daily cost chart for My Usage (SHU-844): one stacked bar per day, split by
  * model, with a click-to-toggle legend. Stacked bars (not a line) because daily
@@ -45,6 +68,84 @@ export default function MyUsageChart({ byDay, modelsMap }) {
   // Models hidden via the legend toggle; default all visible.
   const [hidden, setHidden] = useState(() => new Set());
 
+  // Animate only the initial mount (the load grow-in); make legend toggles
+  // instant. v8 animates a series entering the series array from the x-axis
+  // baseline upward (useAnimateBar), which on a stacked chart reads as the
+  // toggled slice flying up through the other colors — and there's no enter-only
+  // animation knob. So animate the first render, then switch to instant updates.
+  // A ref (not state) so flipping it never triggers an extra render that could
+  // cut the load animation short.
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+  }, []);
+
+  // Order biggest-spend first so the chart, legend, and tooltip all read
+  // most-to-least (the tooltip renders series in array order). Colors are then
+  // assigned by rank — stable across toggles, since the full list never changes.
+  // Memoized so the identity is stable across tooltip-driven re-renders.
+  const colored = useMemo(
+    () =>
+      [...series]
+        .sort((a, b) => periodTotal(b) - periodTotal(a))
+        .map((s, i) => ({ ...s, color: SERIES_COLORS[i % SERIES_COLORS.length] })),
+    [series]
+  );
+
+  // Visible series only; toggled-off models drop from both the chart and the
+  // tooltip. Shared stack key → one stacked bar per day (height = daily total).
+  // Stable `id` (the model id) so v8 diffs series by identity across toggles
+  // rather than re-keying them by array index.
+  const chartSeries = useMemo(
+    () =>
+      colored
+        .filter((s) => !hidden.has(s.modelId))
+        .map((s) => ({
+          id: s.modelId,
+          data: s.data,
+          label: s.label,
+          color: s.color,
+          stack: 'cost',
+          valueFormatter: seriesValueFormatter,
+        })),
+    [colored, hidden]
+  );
+
+  // Slim the bars when only a few days are present (e.g. the start of a billing
+  // period) so they don't balloon to fill their band; let them fill out as days
+  // accrue. x-charts has no absolute max-bar-width knob, so this gap ratio —
+  // bar width as a fraction of the band — is the available lever.
+  const xAxis = useMemo(
+    () => [
+      {
+        data: dates,
+        scaleType: 'band',
+        label: 'Day (UTC)',
+        valueFormatter: fmtDay,
+        categoryGapRatio: dates.length <= 3 ? 0.7 : 0.3,
+        // v8 splits the axis height between the axis label and the tick labels;
+        // at the default 45px, "Day (UTC)" leaves too little for the dates and
+        // shortenLabels ellipsizes them to nothing. Reserve enough for both.
+        height: 60,
+      },
+    ],
+    [dates]
+  );
+
+  const toggle = useCallback(
+    (modelId) =>
+      setHidden((prev) => {
+        const next = new Set(prev);
+        if (next.has(modelId)) {
+          next.delete(modelId);
+        } else {
+          next.add(modelId);
+        }
+        return next;
+      }),
+    []
+  );
+
   if (!dates.length) {
     return (
       <Box sx={{ py: 4, textAlign: 'center' }}>
@@ -54,42 +155,6 @@ export default function MyUsageChart({ byDay, modelsMap }) {
       </Box>
     );
   }
-
-  const toggle = (modelId) =>
-    setHidden((prev) => {
-      const next = new Set(prev);
-      if (next.has(modelId)) {
-        next.delete(modelId);
-      } else {
-        next.add(modelId);
-      }
-      return next;
-    });
-
-  // Order biggest-spend first so the chart, legend, and tooltip all read
-  // most-to-least (the tooltip renders series in array order). Colors are then
-  // assigned by rank — stable across toggles, since the full list never changes.
-  const periodTotal = (s) => s.data.reduce((sum, v) => sum + (v || 0), 0);
-  const colored = [...series]
-    .sort((a, b) => periodTotal(b) - periodTotal(a))
-    .map((s, i) => ({ ...s, color: SERIES_COLORS[i % SERIES_COLORS.length] }));
-
-  const chartSeries = colored
-    .filter((s) => !hidden.has(s.modelId))
-    .map((s) => ({
-      data: s.data,
-      label: s.label,
-      color: s.color,
-      // Shared stack key → segments stack into one bar per day (height = daily total).
-      stack: 'cost',
-      valueFormatter: (v) => (v === null || v === undefined ? '' : formatCurrency(v)),
-    }));
-
-  // Slim the bars when only a few days are present (e.g. the start of a billing
-  // period) so they don't balloon to fill their band; let them fill out as days
-  // accrue. v7 has no absolute maxBarWidth (a v8 feature), so this gap ratio —
-  // bar width as a fraction of the band — is the available lever.
-  const categoryGapRatio = dates.length <= 3 ? 0.7 : 0.3;
 
   return (
     <Box>
@@ -117,13 +182,12 @@ export default function MyUsageChart({ byDay, modelsMap }) {
       </Stack>
       <BarChart
         height={300}
-        xAxis={[{ data: dates, scaleType: 'band', label: 'Day (UTC)', categoryGapRatio }]}
-        yAxis={[{ valueFormatter: (v) => formatCurrency(v) }]}
-        series={
-          chartSeries.length ? chartSeries : [{ data: dates.map(() => 0), label: 'No models selected', stack: 'cost' }]
-        }
-        slotProps={{ legend: { hidden: true } }}
-        margin={{ left: 72 }}
+        xAxis={xAxis}
+        yAxis={Y_AXIS}
+        series={chartSeries}
+        hideLegend
+        skipAnimation={mountedRef.current}
+        margin={CHART_MARGIN}
       />
     </Box>
   );

--- a/frontend/src/components/billing/MyUsageChart.jsx
+++ b/frontend/src/components/billing/MyUsageChart.jsx
@@ -5,11 +5,38 @@ import { LineChart } from '@mui/x-charts/LineChart';
 import { buildDailySeries } from '../../utils/myUsageChart';
 import { formatCurrency } from '../../utils/billingFormatters';
 
+// Distinct, dark-theme-friendly categorical palette. Each model gets a stable
+// color by its index in the FULL series list (not the visible subset), so
+// colors don't reshuffle as lines are toggled. 16 entries — wider than
+// @mui/x-charts' default cycle, which repeated hues once more than ~8 models
+// were charted, making similar lines hard to tell apart.
+const SERIES_COLORS = [
+  '#60a5fa',
+  '#f59e0b',
+  '#34d399',
+  '#f472b6',
+  '#a78bfa',
+  '#facc15',
+  '#22d3ee',
+  '#fb7185',
+  '#a3e635',
+  '#c084fc',
+  '#fdba74',
+  '#2dd4bf',
+  '#e879f9',
+  '#38bdf8',
+  '#4ade80',
+  '#fca5a5',
+];
+
 /**
  * Daily cost-over-time chart for My Usage (SHU-844): one line per model with a
  * click-to-toggle legend. Imported lazily by MyUsagePage so @mui/x-charts and
- * its d3 vendor bundle stay code-split to this route — they are not in the
- * app's initial bundle.
+ * its d3 vendor bundle stay code-split to this route.
+ *
+ * The toggle chips double as the legend (each carries its line's color dot), so
+ * the chart's built-in legend is hidden — with many models it wrapped over the
+ * plot area and y-axis labels.
  */
 export default function MyUsageChart({ byDay, modelsMap }) {
   const { dates, series } = useMemo(() => buildDailySeries(byDay, modelsMap), [byDay, modelsMap]);
@@ -37,11 +64,20 @@ export default function MyUsageChart({ byDay, modelsMap }) {
       return next;
     });
 
-  const chartSeries = series
+  // Order biggest-spend first so the chart, legend, and tooltip all read
+  // most-to-least (the tooltip renders series in array order). Colors are then
+  // assigned by rank — stable across toggles, since the full list never changes.
+  const periodTotal = (s) => s.data.reduce((sum, v) => sum + (v || 0), 0);
+  const colored = [...series]
+    .sort((a, b) => periodTotal(b) - periodTotal(a))
+    .map((s, i) => ({ ...s, color: SERIES_COLORS[i % SERIES_COLORS.length] }));
+
+  const chartSeries = colored
     .filter((s) => !hidden.has(s.modelId))
     .map((s) => ({
       data: s.data,
       label: s.label,
+      color: s.color,
       showMark: false,
       valueFormatter: (v) => (v === null || v === undefined ? '' : formatCurrency(v)),
     }));
@@ -49,17 +85,23 @@ export default function MyUsageChart({ byDay, modelsMap }) {
   return (
     <Box>
       <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mb: 1.5 }}>
-        {series.map((s) => {
+        {colored.map((s) => {
           const isHidden = hidden.has(s.modelId);
           return (
             <Chip
               key={s.modelId}
-              label={s.label}
               size="small"
               variant={isHidden ? 'outlined' : 'filled'}
-              color={isHidden ? 'default' : 'primary'}
               onClick={() => toggle(s.modelId)}
               aria-pressed={!isHidden}
+              icon={
+                <Box
+                  component="span"
+                  sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: s.color, flexShrink: 0 }}
+                />
+              }
+              label={s.label}
+              sx={{ opacity: isHidden ? 0.45 : 1 }}
             />
           );
         })}
@@ -73,6 +115,7 @@ export default function MyUsageChart({ byDay, modelsMap }) {
             ? chartSeries
             : [{ data: dates.map(() => 0), label: 'No models selected', showMark: false }]
         }
+        slotProps={{ legend: { hidden: true } }}
         margin={{ left: 72 }}
       />
     </Box>

--- a/frontend/src/components/billing/MyUsageChart.jsx
+++ b/frontend/src/components/billing/MyUsageChart.jsx
@@ -1,0 +1,80 @@
+import { useMemo, useState } from 'react';
+import { Box, Chip, Stack, Typography } from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
+
+import { buildDailySeries } from '../../utils/myUsageChart';
+import { formatCurrency } from '../../utils/billingFormatters';
+
+/**
+ * Daily cost-over-time chart for My Usage (SHU-844): one line per model with a
+ * click-to-toggle legend. Imported lazily by MyUsagePage so @mui/x-charts and
+ * its d3 vendor bundle stay code-split to this route — they are not in the
+ * app's initial bundle.
+ */
+export default function MyUsageChart({ byDay, modelsMap }) {
+  const { dates, series } = useMemo(() => buildDailySeries(byDay, modelsMap), [byDay, modelsMap]);
+  // Models hidden via the legend toggle; default all visible.
+  const [hidden, setHidden] = useState(() => new Set());
+
+  if (!dates.length) {
+    return (
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          No usage to chart in this billing period yet.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const toggle = (modelId) =>
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(modelId)) {
+        next.delete(modelId);
+      } else {
+        next.add(modelId);
+      }
+      return next;
+    });
+
+  const chartSeries = series
+    .filter((s) => !hidden.has(s.modelId))
+    .map((s) => ({
+      data: s.data,
+      label: s.label,
+      showMark: false,
+      valueFormatter: (v) => (v === null || v === undefined ? '' : formatCurrency(v)),
+    }));
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" sx={{ mb: 1.5 }}>
+        {series.map((s) => {
+          const isHidden = hidden.has(s.modelId);
+          return (
+            <Chip
+              key={s.modelId}
+              label={s.label}
+              size="small"
+              variant={isHidden ? 'outlined' : 'filled'}
+              color={isHidden ? 'default' : 'primary'}
+              onClick={() => toggle(s.modelId)}
+              aria-pressed={!isHidden}
+            />
+          );
+        })}
+      </Stack>
+      <LineChart
+        height={300}
+        xAxis={[{ data: dates, scaleType: 'point', label: 'Day (UTC)' }]}
+        yAxis={[{ valueFormatter: (v) => formatCurrency(v) }]}
+        series={
+          chartSeries.length
+            ? chartSeries
+            : [{ data: dates.map(() => 0), label: 'No models selected', showMark: false }]
+        }
+        margin={{ left: 72 }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/billing/MyUsageChart.jsx
+++ b/frontend/src/components/billing/MyUsageChart.jsx
@@ -1,13 +1,13 @@
 import { useMemo, useState } from 'react';
 import { Box, Chip, Stack, Typography } from '@mui/material';
-import { LineChart } from '@mui/x-charts/LineChart';
+import { BarChart } from '@mui/x-charts/BarChart';
 
 import { buildDailySeries } from '../../utils/myUsageChart';
 import { formatCurrency } from '../../utils/billingFormatters';
 
 // Distinct, dark-theme-friendly categorical palette. Each model gets a stable
 // color by its index in the FULL series list (not the visible subset), so
-// colors don't reshuffle as lines are toggled. 16 entries — wider than
+// colors don't reshuffle as series are toggled. 16 entries — wider than
 // @mui/x-charts' default cycle, which repeated hues once more than ~8 models
 // were charted, making similar lines hard to tell apart.
 const SERIES_COLORS = [
@@ -30,13 +30,15 @@ const SERIES_COLORS = [
 ];
 
 /**
- * Daily cost-over-time chart for My Usage (SHU-844): one line per model with a
- * click-to-toggle legend. Imported lazily by MyUsagePage so @mui/x-charts and
- * its d3 vendor bundle stay code-split to this route.
+ * Daily cost chart for My Usage (SHU-844): one stacked bar per day, split by
+ * model, with a click-to-toggle legend. Stacked bars (not a line) because daily
+ * cost buckets are discrete — a line would imply continuity between days that
+ * doesn't exist. Imported lazily by MyUsagePage so @mui/x-charts and its d3
+ * vendor bundle stay code-split to this route.
  *
- * The toggle chips double as the legend (each carries its line's color dot), so
- * the chart's built-in legend is hidden — with many models it wrapped over the
- * plot area and y-axis labels.
+ * The toggle chips double as the legend (each carries its segment's color dot),
+ * so the chart's built-in legend is hidden — with many models it wrapped over
+ * the plot area and y-axis labels.
  */
 export default function MyUsageChart({ byDay, modelsMap }) {
   const { dates, series } = useMemo(() => buildDailySeries(byDay, modelsMap), [byDay, modelsMap]);
@@ -78,9 +80,16 @@ export default function MyUsageChart({ byDay, modelsMap }) {
       data: s.data,
       label: s.label,
       color: s.color,
-      showMark: false,
+      // Shared stack key → segments stack into one bar per day (height = daily total).
+      stack: 'cost',
       valueFormatter: (v) => (v === null || v === undefined ? '' : formatCurrency(v)),
     }));
+
+  // Slim the bars when only a few days are present (e.g. the start of a billing
+  // period) so they don't balloon to fill their band; let them fill out as days
+  // accrue. v7 has no absolute maxBarWidth (a v8 feature), so this gap ratio —
+  // bar width as a fraction of the band — is the available lever.
+  const categoryGapRatio = dates.length <= 3 ? 0.7 : 0.3;
 
   return (
     <Box>
@@ -106,14 +115,12 @@ export default function MyUsageChart({ byDay, modelsMap }) {
           );
         })}
       </Stack>
-      <LineChart
+      <BarChart
         height={300}
-        xAxis={[{ data: dates, scaleType: 'point', label: 'Day (UTC)' }]}
+        xAxis={[{ data: dates, scaleType: 'band', label: 'Day (UTC)', categoryGapRatio }]}
         yAxis={[{ valueFormatter: (v) => formatCurrency(v) }]}
         series={
-          chartSeries.length
-            ? chartSeries
-            : [{ data: dates.map(() => 0), label: 'No models selected', showMark: false }]
+          chartSeries.length ? chartSeries : [{ data: dates.map(() => 0), label: 'No models selected', stack: 'cost' }]
         }
         slotProps={{ legend: { hidden: true } }}
         margin={{ left: 72 }}

--- a/frontend/src/components/billing/MyUsageChart.jsx
+++ b/frontend/src/components/billing/MyUsageChart.jsx
@@ -34,8 +34,11 @@ const SERIES_COLORS = [
 // re-runs internal layout effects when its prop identities change, so keeping
 // them stable avoids needless re-renders.
 const seriesValueFormatter = (v) => (v === null || v === undefined ? '' : formatCurrency(v));
-const Y_AXIS = [{ valueFormatter: (v) => formatCurrency(v) }];
-const CHART_MARGIN = { left: 72 };
+// width: v8 ellipsizes y-axis tick labels that don't fit the axis's own width
+// (ChartsYAxis/shortenLabels). Sub-cent costs render 4 decimals ($0.0019); the
+// 45px default truncated them to "$0.0…", so widen the axis to fit. In v8 the
+// axis reserves this width itself, so no left chart margin is needed.
+const Y_AXIS = [{ valueFormatter: (v) => formatCurrency(v), width: 72 }];
 
 // Format a "YYYY-MM-DD" UTC day key into a short axis label like "Jun 1". v8
 // drops x-axis tick labels that would overlap their neighbour
@@ -187,7 +190,6 @@ export default function MyUsageChart({ byDay, modelsMap }) {
         series={chartSeries}
         hideLegend
         skipAnimation={mountedRef.current}
-        margin={CHART_MARGIN}
       />
     </Box>
   );

--- a/frontend/src/components/billing/MyUsageKpiTiles.jsx
+++ b/frontend/src/components/billing/MyUsageKpiTiles.jsx
@@ -1,0 +1,104 @@
+import { Grid, LinearProgress, Skeleton, Tooltip } from '@mui/material';
+
+import { KpiTile, pickUsedColor } from './KpiTiles';
+import { formatCompactTokens, formatCurrency, formatFullTokens } from '../../utils/billingFormatters';
+
+const PLACEHOLDER = '—';
+
+/**
+ * KPI tiles for the per-user My Usage dashboard (SHU-844).
+ *
+ * Volume tiles (Your Usage Cost / Requests / Tokens) come from the per-user
+ * `/billing/usage/me` payload. "Your Usage Cost" is the raw provider cost —
+ * the same basis as the reused Cost by Model table — not a marked-up figure
+ * (non-admins are not sent the markup multiplier).
+ *
+ * The Shared Pool tile is tenant-level context from BillingStatusContext
+ * (`pool` prop). It renders only when a pool is present (CP configured); when
+ * `pool` is null the page degrades to the three volume tiles. It is captioned
+ * "across all seats & shared activity" because the pool spans every seat plus
+ * system/shared usage, so a user's own cost is expected to be a subset.
+ */
+export default function MyUsageKpiTiles({ usageData, isLoading, pool }) {
+  const data = usageData || {};
+  const isPeriodUnknown = data.current_period_unknown === true;
+
+  const cost = isPeriodUnknown ? null : (data.total_cost_usd ?? 0);
+  const requests = isPeriodUnknown ? null : (data.request_count ?? 0);
+  const totalTokens = isPeriodUnknown ? null : (data.total_input_tokens ?? 0) + (data.total_output_tokens ?? 0);
+
+  const tiles = [
+    {
+      key: 'cost',
+      label: 'Your Usage Cost',
+      value: cost === null ? PLACEHOLDER : formatCurrency(cost),
+      ariaLabel: cost === null ? 'Your usage cost: not available' : `Your usage cost: ${formatCurrency(cost)}`,
+      subline: 'this billing period',
+    },
+    {
+      key: 'requests',
+      label: 'Requests',
+      value: requests === null ? PLACEHOLDER : formatFullTokens(requests),
+      ariaLabel: requests === null ? 'Requests: not available' : `Requests: ${formatFullTokens(requests)}`,
+    },
+    {
+      key: 'tokens',
+      label: 'Tokens',
+      value:
+        totalTokens === null ? (
+          PLACEHOLDER
+        ) : (
+          <Tooltip title={formatFullTokens(totalTokens)} arrow>
+            <span aria-label={`Tokens: ${formatFullTokens(totalTokens)}`}>{formatCompactTokens(totalTokens)}</span>
+          </Tooltip>
+        ),
+      ariaLabel: totalTokens === null ? 'Tokens: not available' : undefined,
+      subline: 'input + output',
+    },
+  ];
+
+  // Shared-pool context (tenant-level). Only when CP shipped a positive pool.
+  if (pool && Number.isFinite(pool.total) && pool.total > 0) {
+    const remaining = Math.min(Math.max(pool.remaining ?? pool.total, 0), pool.total);
+    const used = Math.max(pool.total - remaining, 0);
+    const percent = Math.min(Math.max(Math.round((used / pool.total) * 100), 0), 100);
+    tiles.push({
+      key: 'pool',
+      label: 'Shared Pool',
+      value: `${formatCurrency(used)} / ${formatCurrency(pool.total)}`,
+      ariaLabel: `Shared pool: ${formatCurrency(used)} of ${formatCurrency(pool.total)} used`,
+      subline: 'across all seats & shared activity',
+      bottom: (
+        <LinearProgress
+          variant="determinate"
+          value={percent}
+          color={pickUsedColor(percent)}
+          aria-label={`${percent}% of shared pool used`}
+        />
+      ),
+    });
+  }
+
+  // 4 tiles → 4-up on md; 3 tiles → 3-up so the row stays balanced.
+  const md = tiles.length >= 4 ? 3 : 4;
+
+  return (
+    <Grid container spacing={2}>
+      {tiles.map((tile) => (
+        <Grid item xs={12} sm={6} md={md} key={tile.key}>
+          {isLoading ? (
+            <Skeleton variant="rounded" height={108} />
+          ) : (
+            <KpiTile
+              label={tile.label}
+              value={tile.value}
+              ariaLabel={tile.ariaLabel}
+              subline={tile.subline}
+              bottom={tile.bottom}
+            />
+          )}
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/frontend/src/components/billing/MyUsageKpiTiles.jsx
+++ b/frontend/src/components/billing/MyUsageKpiTiles.jsx
@@ -1,4 +1,4 @@
-import { Grid, LinearProgress, Skeleton, Tooltip } from '@mui/material';
+import { Box, LinearProgress, Skeleton, Tooltip } from '@mui/material';
 
 import { KpiTile, pickUsedColor } from './KpiTiles';
 import { formatCompactTokens, formatCurrency, formatFullTokens } from '../../utils/billingFormatters';
@@ -79,26 +79,33 @@ export default function MyUsageKpiTiles({ usageData, isLoading, pool }) {
     });
   }
 
-  // 4 tiles → 4-up on md; 3 tiles → 3-up so the row stays balanced.
-  const md = tiles.length >= 4 ? 3 : 4;
+  // 1-up on xs, 2-up on sm, all-in-one-row on md+. CSS grid with `gap` (not MUI
+  // Grid `spacing`) so there are no negative container margins — the tiles stay
+  // symmetric on thin mobile widths instead of drifting right.
+  const columns = tiles.length;
 
   return (
-    <Grid container spacing={2}>
-      {tiles.map((tile) => (
-        <Grid item xs={12} sm={6} md={md} key={tile.key}>
-          {isLoading ? (
-            <Skeleton variant="rounded" height={108} />
-          ) : (
-            <KpiTile
-              label={tile.label}
-              value={tile.value}
-              ariaLabel={tile.ariaLabel}
-              subline={tile.subline}
-              bottom={tile.bottom}
-            />
-          )}
-        </Grid>
-      ))}
-    </Grid>
+    <Box
+      sx={{
+        display: 'grid',
+        gap: 2,
+        gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: `repeat(${columns}, 1fr)` },
+      }}
+    >
+      {tiles.map((tile) =>
+        isLoading ? (
+          <Skeleton key={tile.key} variant="rounded" height={108} />
+        ) : (
+          <KpiTile
+            key={tile.key}
+            label={tile.label}
+            value={tile.value}
+            ariaLabel={tile.ariaLabel}
+            subline={tile.subline}
+            bottom={tile.bottom}
+          />
+        )
+      )}
+    </Box>
   );
 }

--- a/frontend/src/components/billing/MyUsageKpiTiles.jsx
+++ b/frontend/src/components/billing/MyUsageKpiTiles.jsx
@@ -1,7 +1,12 @@
 import { Box, LinearProgress, Skeleton, Tooltip } from '@mui/material';
 
 import { KpiTile, pickUsedColor } from './KpiTiles';
-import { formatCompactTokens, formatCurrency, formatFullTokens } from '../../utils/billingFormatters';
+import {
+  formatCompactTokens,
+  formatCurrency,
+  formatFullTokens,
+  USAGE_MARKUP_MULTIPLIER,
+} from '../../utils/billingFormatters';
 
 const PLACEHOLDER = '—';
 
@@ -9,9 +14,11 @@ const PLACEHOLDER = '—';
  * KPI tiles for the per-user My Usage dashboard (SHU-844).
  *
  * Volume tiles (Your Usage Cost / Requests / Tokens) come from the per-user
- * `/billing/usage/me` payload. "Your Usage Cost" is the raw provider cost —
- * the same basis as the reused Cost by Model table — not a marked-up figure
- * (non-admins are not sent the markup multiplier).
+ * `/billing/usage/me` payload. "Your Usage Cost" is shown in BILLED dollars
+ * (provider cost × markup) so it reconciles with the billed Shared Pool and
+ * matches the admin dashboard; the raw provider cost + markup % are noted in
+ * the sub-line. The reused Cost by Model table and time chart stay at raw
+ * provider cost (same as the admin page), which the sub-line accounts for.
  *
  * The Shared Pool tile is tenant-level context from BillingStatusContext
  * (`pool` prop). It renders only when a pool is present (CP configured); when
@@ -19,7 +26,7 @@ const PLACEHOLDER = '—';
  * "across all seats & shared activity" because the pool spans every seat plus
  * system/shared usage, so a user's own cost is expected to be a subset.
  */
-export default function MyUsageKpiTiles({ usageData, isLoading, pool }) {
+export default function MyUsageKpiTiles({ usageData, isLoading, pool, markup }) {
   const data = usageData || {};
   const isPeriodUnknown = data.current_period_unknown === true;
 
@@ -27,13 +34,23 @@ export default function MyUsageKpiTiles({ usageData, isLoading, pool }) {
   const requests = isPeriodUnknown ? null : (data.request_count ?? 0);
   const totalTokens = isPeriodUnknown ? null : (data.total_input_tokens ?? 0) + (data.total_output_tokens ?? 0);
 
+  // Bill the headline: provider cost × markup. The live rate arrives via the
+  // `markup` prop (/billing/subscription); fall back to the published constant
+  // when CP supplied none (self-hosted / pre-Stripe).
+  const markupMultiplier = typeof markup === 'number' && markup > 0 ? markup : USAGE_MARKUP_MULTIPLIER;
+  const markupPercent = Math.round((markupMultiplier - 1) * 100);
+  const billedCost = cost === null ? null : cost * markupMultiplier;
+
   const tiles = [
     {
       key: 'cost',
       label: 'Your Usage Cost',
-      value: cost === null ? PLACEHOLDER : formatCurrency(cost),
-      ariaLabel: cost === null ? 'Your usage cost: not available' : `Your usage cost: ${formatCurrency(cost)}`,
-      subline: 'this billing period',
+      value: billedCost === null ? PLACEHOLDER : formatCurrency(billedCost),
+      ariaLabel:
+        billedCost === null ? 'Your usage cost: not available' : `Your usage cost: ${formatCurrency(billedCost)}`,
+      // When there's spend, explain the billed headline vs the raw provider
+      // cost (which the chart/table show); otherwise just note the period.
+      subline: cost > 0 ? `${formatCurrency(cost)} provider cost, billed at +${markupPercent}%` : 'this billing period',
     },
     {
       key: 'requests',

--- a/frontend/src/components/billing/PersonalKbStatsTile.jsx
+++ b/frontend/src/components/billing/PersonalKbStatsTile.jsx
@@ -1,0 +1,76 @@
+import { useQuery } from 'react-query';
+import { Box, Card, CardContent, Grid, Skeleton, Stack, Typography } from '@mui/material';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+
+import { knowledgeBaseAPI, extractDataFromResponse } from '../../services/api';
+import { formatFullTokens } from '../../utils/billingFormatters';
+
+// getPersonal returns the caller's personal KB or null (SHU-817). Owner-scoped
+// server-side, so no list scan and no id needed.
+const fetchPersonalKb = () => knowledgeBaseAPI.getPersonal().then(extractDataFromResponse);
+
+function Stat({ label, value }) {
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ fontWeight: 600 }}>
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * Shows the value of the user's Personal Knowledge Base (SHU-844): document
+ * count, chunk count, and last-synced — all first-class KB columns, no JSON
+ * digging. "How often your KB was cited in a response" is a follow-up that
+ * needs a dedicated usage table. Renders a neutral state when the user has no
+ * personal KB yet.
+ */
+export default function PersonalKbStatsTile() {
+  const { data: kb, isLoading } = useQuery(['my-usage:personal-kb'], fetchPersonalKb, { staleTime: 60_000 });
+
+  if (isLoading) {
+    return <Skeleton variant="rounded" height={120} />;
+  }
+
+  if (!kb) {
+    return (
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="body2" color="text.secondary">
+            You don&apos;t have a Personal Knowledge Base yet. Attach the brain icon in chat to start building one.
+          </Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const lastSynced = kb.last_sync_at ? new Date(kb.last_sync_at).toLocaleDateString() : 'never';
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+          <MenuBookIcon fontSize="small" color="primary" />
+          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+            {kb.name || 'Personal Knowledge'}
+          </Typography>
+        </Stack>
+        <Grid container spacing={2}>
+          <Grid item xs={4}>
+            <Stat label="Documents" value={formatFullTokens(kb.document_count ?? 0)} />
+          </Grid>
+          <Grid item xs={4}>
+            <Stat label="Chunks" value={formatFullTokens(kb.total_chunks ?? 0)} />
+          </Grid>
+          <Grid item xs={4}>
+            <Stat label="Last synced" value={lastSynced} />
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/billing/PersonalKbStatsTile.jsx
+++ b/frontend/src/components/billing/PersonalKbStatsTile.jsx
@@ -1,5 +1,5 @@
 import { useQuery } from 'react-query';
-import { Box, Card, CardContent, Grid, Skeleton, Stack, Typography } from '@mui/material';
+import { Alert, Box, Button, Card, CardContent, Grid, Skeleton, Stack, Typography } from '@mui/material';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
 
 import { knowledgeBaseAPI, extractDataFromResponse } from '../../services/api';
@@ -30,10 +30,35 @@ function Stat({ label, value }) {
  * personal KB yet.
  */
 export default function PersonalKbStatsTile() {
-  const { data: kb, isLoading } = useQuery(['my-usage:personal-kb'], fetchPersonalKb, { staleTime: 60_000 });
+  const {
+    data: kb,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery(['my-usage:personal-kb'], fetchPersonalKb, {
+    staleTime: 60_000,
+  });
 
   if (isLoading) {
     return <Skeleton variant="rounded" height={120} />;
+  }
+
+  // Distinguish a fetch failure from a successful "no KB" response — otherwise a
+  // transient API/network error would render the onboarding copy and tell a user
+  // who has a KB to go create one.
+  if (isError) {
+    return (
+      <Alert
+        severity="warning"
+        action={
+          <Button color="inherit" size="small" onClick={() => refetch()}>
+            Retry
+          </Button>
+        }
+      >
+        We couldn&apos;t load your Personal Knowledge Base stats.
+      </Alert>
+    );
   }
 
   if (!kb) {

--- a/frontend/src/components/billing/UpsellCard.jsx
+++ b/frontend/src/components/billing/UpsellCard.jsx
@@ -1,0 +1,73 @@
+import { Alert, Box, Button, LinearProgress, Stack, Typography } from '@mui/material';
+
+import { useBillingStatus } from '../../contexts/BillingStatusContext';
+import log from '../../utils/log';
+
+// Surface the upsell once the user is most of the way through their pool.
+const NEAR_LIMIT_PERCENT = 80;
+
+/**
+ * Free-tier / trial upsell surface for My Usage (SHU-844).
+ *
+ * Renders only for capped plans (trial or free-tier `hard_cap`) once usage
+ * reaches NEAR_LIMIT_PERCENT of the shared pool — the moment an upgrade nudge
+ * is relevant. Trigger data comes from BillingStatusContext (already polled);
+ * the budget math mirrors TrialBanner. The CTA is a stub per the SHU-844 plan:
+ * the real conversion flow is future work and there is no billing write path.
+ */
+export default function UpsellCard() {
+  const { isTrial, hardCap, totalGrantAmount, remainingGrantAmount, loading } = useBillingStatus();
+
+  if (loading) {
+    return null;
+  }
+
+  // Only capped plans get the nudge. Paid tenants with overage billing don't.
+  const capped = isTrial || hardCap;
+  const total = totalGrantAmount;
+  if (!capped || !total || total <= 0) {
+    return null;
+  }
+
+  const remaining = Math.min(Math.max(remainingGrantAmount ?? 0, 0), total);
+  const used = Math.max(total - remaining, 0);
+  const percentUsed = Math.min(Math.max((used / total) * 100, 0), 100);
+  if (percentUsed < NEAR_LIMIT_PERCENT) {
+    return null;
+  }
+
+  const exhausted = percentUsed >= 100;
+  const percentLabel = Math.round(percentUsed);
+
+  // Stub CTA — intentionally no billing write path. Wire to the real upgrade
+  // flow in a follow-up.
+  const handleSeePlans = () => {
+    log.info('My Usage upsell CTA clicked (stub)');
+  };
+
+  return (
+    <Alert severity={exhausted ? 'warning' : 'info'} icon={false} sx={{ borderRadius: 2 }}>
+      <Stack spacing={1}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          {exhausted ? 'You’ve used your full plan allowance' : `You’ve used ${percentLabel}% of your plan`}
+        </Typography>
+        <Typography variant="body2">
+          Your plan includes a shared ${total.toFixed(2)} usage pool. Upgrade for more usage, more knowledge bases, and
+          additional features.
+        </Typography>
+        <LinearProgress
+          variant="determinate"
+          value={percentUsed}
+          color={exhausted ? 'error' : 'warning'}
+          sx={{ height: 8, borderRadius: 1 }}
+          aria-label={`${percentLabel}% of plan used`}
+        />
+        <Box>
+          <Button variant="contained" size="small" onClick={handleSeePlans}>
+            See upgrade options
+          </Button>
+        </Box>
+      </Stack>
+    </Alert>
+  );
+}

--- a/frontend/src/components/billing/__tests__/KbLimitsTile.test.jsx
+++ b/frontend/src/components/billing/__tests__/KbLimitsTile.test.jsx
@@ -1,0 +1,65 @@
+/**
+ * Tests for KbLimitsTile (SHU-844): tenant-wide KB document/KB-count limits.
+ * Renders only when CP supplies limits + usage, and only for caps > 0.
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+import KbLimitsTile from '../KbLimitsTile';
+
+const renderTile = (usage, limits) =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <KbLimitsTile usage={usage} limits={limits} />
+    </ThemeProvider>
+  );
+
+describe('KbLimitsTile', () => {
+  describe('shown', () => {
+    it('renders documents and KB tiles with used/cap and a workspace caption', () => {
+      renderTile({ kb_count: 2, document_count: 40 }, { kb_count_limit: 5, document_count_limit: 1000 });
+      expect(screen.getByText('Documents')).toBeInTheDocument();
+      expect(screen.getByText('Knowledge Bases')).toBeInTheDocument();
+      expect(screen.getByText('40 / 1,000')).toBeInTheDocument();
+      expect(screen.getByText('2 / 5')).toBeInTheDocument();
+      expect(screen.getAllByText('Across your workspace')).toHaveLength(2);
+      expect(screen.getAllByRole('progressbar')).toHaveLength(2);
+    });
+
+    it('clamps the bar at 100% when usage exceeds the cap (batch overshoot)', () => {
+      renderTile({ kb_count: 1, document_count: 1500 }, { kb_count_limit: 5, document_count_limit: 1000 });
+      expect(screen.getByText('1,500 / 1,000')).toBeInTheDocument();
+      expect(screen.getByLabelText(/100% of documents limit used/)).toBeInTheDocument();
+    });
+  });
+
+  describe('hidden', () => {
+    it('returns null when limits is absent (self-hosted / CP-less)', () => {
+      const { container } = renderTile({ kb_count: 2, document_count: 40 }, null);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('returns null when usage is absent', () => {
+      const { container } = renderTile(null, { kb_count_limit: 5, document_count_limit: 1000 });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('returns null when both caps are zero (cold-start fail-closed)', () => {
+      const { container } = renderTile(
+        { kb_count: 0, document_count: 0 },
+        { kb_count_limit: 0, document_count_limit: 0 }
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('omits a stat whose cap is zero', () => {
+      renderTile({ kb_count: 2, document_count: 40 }, { kb_count_limit: 5, document_count_limit: 0 });
+      expect(screen.queryByText('Documents')).not.toBeInTheDocument();
+      expect(screen.getByText('Knowledge Bases')).toBeInTheDocument();
+      expect(screen.getByText('2 / 5')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/billing/__tests__/MyUsageKpiTiles.test.jsx
+++ b/frontend/src/components/billing/__tests__/MyUsageKpiTiles.test.jsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for MyUsageKpiTiles (SHU-844).
+ *
+ * Three volume tiles from per-user usage, plus a fourth Shared-Pool tile when a
+ * positive pool is supplied. All data is via props (no hooks/context).
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+import MyUsageKpiTiles from '../MyUsageKpiTiles';
+
+const renderTiles = (usageData, isLoading = false, pool = null) =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <MyUsageKpiTiles usageData={usageData} isLoading={isLoading} pool={pool} />
+    </ThemeProvider>
+  );
+
+const usage = (overrides = {}) => ({
+  current_period_unknown: false,
+  total_cost_usd: 50,
+  request_count: 1000,
+  total_input_tokens: 500_000,
+  total_output_tokens: 350_000,
+  ...overrides,
+});
+
+describe('MyUsageKpiTiles', () => {
+  describe('without a pool', () => {
+    it('renders exactly 3 volume tiles', () => {
+      const { container } = renderTiles(usage(), false, null);
+      expect(container.querySelectorAll('.MuiGrid-item')).toHaveLength(3);
+      expect(screen.getByText('Your Usage Cost')).toBeInTheDocument();
+      expect(screen.getByText('Requests')).toBeInTheDocument();
+      expect(screen.getByText('Tokens')).toBeInTheDocument();
+      expect(screen.queryByText('Shared Pool')).not.toBeInTheDocument();
+    });
+
+    it('formats cost as currency', () => {
+      renderTiles(usage({ total_cost_usd: 12.34 }), false, null);
+      expect(screen.getByText('$12.34')).toBeInTheDocument();
+    });
+
+    it('formats requests with thousands separators', () => {
+      renderTiles(usage({ request_count: 1_234_567 }), false, null);
+      expect(screen.getByText('1,234,567')).toBeInTheDocument();
+    });
+
+    it('formats tokens compactly with the full count in an aria-label', () => {
+      renderTiles(usage({ total_input_tokens: 1_250_000, total_output_tokens: 850_000 }), false, null);
+      expect(screen.getByText('2.1M')).toBeInTheDocument();
+      expect(screen.getByLabelText(/Tokens: 2,100,000/)).toBeInTheDocument();
+    });
+  });
+
+  describe('with a positive pool', () => {
+    it('renders a 4th Shared Pool tile with used / total', () => {
+      const { container } = renderTiles(usage(), false, { total: 500, remaining: 100 });
+      expect(container.querySelectorAll('.MuiGrid-item')).toHaveLength(4);
+      expect(screen.getByText('Shared Pool')).toBeInTheDocument();
+      expect(screen.getByText('$400.00 / $500.00')).toBeInTheDocument();
+      expect(screen.getByText(/across all seats & shared activity/)).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('omits the pool tile when total is zero', () => {
+      const { container } = renderTiles(usage(), false, { total: 0, remaining: 0 });
+      expect(container.querySelectorAll('.MuiGrid-item')).toHaveLength(3);
+    });
+
+    it('clamps remaining above total so used never goes negative', () => {
+      // remaining > total → clamped to total → used 0 → "$0.00 / $100.00"
+      renderTiles(usage(), false, { total: 100, remaining: 150 });
+      expect(screen.getByText('$0.00 / $100.00')).toBeInTheDocument();
+    });
+  });
+
+  describe('period unknown', () => {
+    it('shows placeholders for the volume tiles', () => {
+      renderTiles(usage({ current_period_unknown: true }), false, null);
+      expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('loading', () => {
+    it('renders 3 skeletons without a pool', () => {
+      const { container } = renderTiles(usage(), true, null);
+      expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('renders 4 skeletons with a pool', () => {
+      const { container } = renderTiles(usage(), true, { total: 500, remaining: 100 });
+      expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThanOrEqual(4);
+    });
+  });
+});

--- a/frontend/src/components/billing/__tests__/MyUsageKpiTiles.test.jsx
+++ b/frontend/src/components/billing/__tests__/MyUsageKpiTiles.test.jsx
@@ -11,11 +11,12 @@ import { render, screen } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 import MyUsageKpiTiles from '../MyUsageKpiTiles';
+import { formatCurrency, USAGE_MARKUP_MULTIPLIER } from '../../../utils/billingFormatters';
 
-const renderTiles = (usageData, isLoading = false, pool = null) =>
+const renderTiles = (usageData, isLoading = false, pool = null, markup = undefined) =>
   render(
     <ThemeProvider theme={createTheme()}>
-      <MyUsageKpiTiles usageData={usageData} isLoading={isLoading} pool={pool} />
+      <MyUsageKpiTiles usageData={usageData} isLoading={isLoading} pool={pool} markup={markup} />
     </ThemeProvider>
   );
 
@@ -39,9 +40,18 @@ describe('MyUsageKpiTiles', () => {
       expect(screen.queryByText('Shared Pool')).not.toBeInTheDocument();
     });
 
-    it('formats cost as currency', () => {
-      renderTiles(usage({ total_cost_usd: 12.34 }), false, null);
-      expect(screen.getByText('$12.34')).toBeInTheDocument();
+    it('bills the cost at the live markup and explains it in the sub-line', () => {
+      renderTiles(usage({ total_cost_usd: 10 }), false, null, 1.5);
+      expect(screen.getByText('$15.00')).toBeInTheDocument(); // 10 × 1.5
+      expect(screen.getByText('$10.00 provider cost, billed at +50%')).toBeInTheDocument();
+    });
+
+    it('falls back to the default markup when none is supplied', () => {
+      renderTiles(usage({ total_cost_usd: 10 }), false, null);
+      const billed = 10 * USAGE_MARKUP_MULTIPLIER;
+      const pct = Math.round((USAGE_MARKUP_MULTIPLIER - 1) * 100);
+      expect(screen.getByText(formatCurrency(billed))).toBeInTheDocument();
+      expect(screen.getByText(`$10.00 provider cost, billed at +${pct}%`)).toBeInTheDocument();
     });
 
     it('formats requests with thousands separators', () => {

--- a/frontend/src/components/billing/__tests__/MyUsageKpiTiles.test.jsx
+++ b/frontend/src/components/billing/__tests__/MyUsageKpiTiles.test.jsx
@@ -32,7 +32,7 @@ describe('MyUsageKpiTiles', () => {
   describe('without a pool', () => {
     it('renders exactly 3 volume tiles', () => {
       const { container } = renderTiles(usage(), false, null);
-      expect(container.querySelectorAll('.MuiGrid-item')).toHaveLength(3);
+      expect(container.querySelectorAll('.MuiCard-root')).toHaveLength(3);
       expect(screen.getByText('Your Usage Cost')).toBeInTheDocument();
       expect(screen.getByText('Requests')).toBeInTheDocument();
       expect(screen.getByText('Tokens')).toBeInTheDocument();
@@ -59,7 +59,7 @@ describe('MyUsageKpiTiles', () => {
   describe('with a positive pool', () => {
     it('renders a 4th Shared Pool tile with used / total', () => {
       const { container } = renderTiles(usage(), false, { total: 500, remaining: 100 });
-      expect(container.querySelectorAll('.MuiGrid-item')).toHaveLength(4);
+      expect(container.querySelectorAll('.MuiCard-root')).toHaveLength(4);
       expect(screen.getByText('Shared Pool')).toBeInTheDocument();
       expect(screen.getByText('$400.00 / $500.00')).toBeInTheDocument();
       expect(screen.getByText(/across all seats & shared activity/)).toBeInTheDocument();
@@ -68,7 +68,7 @@ describe('MyUsageKpiTiles', () => {
 
     it('omits the pool tile when total is zero', () => {
       const { container } = renderTiles(usage(), false, { total: 0, remaining: 0 });
-      expect(container.querySelectorAll('.MuiGrid-item')).toHaveLength(3);
+      expect(container.querySelectorAll('.MuiCard-root')).toHaveLength(3);
     });
 
     it('clamps remaining above total so used never goes negative', () => {

--- a/frontend/src/components/billing/__tests__/UpsellCard.test.jsx
+++ b/frontend/src/components/billing/__tests__/UpsellCard.test.jsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for UpsellCard (SHU-844).
+ *
+ * Conditional surface: renders only for capped plans (trial or free-tier
+ * hard_cap) once usage reaches >= 80% of the shared pool. Reads context via
+ * useBillingStatus.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../../contexts/BillingStatusContext', () => ({
+  useBillingStatus: vi.fn(),
+}));
+vi.mock('../../../utils/log', () => ({
+  default: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { useBillingStatus } from '../../../contexts/BillingStatusContext';
+import UpsellCard from '../UpsellCard';
+
+const status = (overrides = {}) => ({
+  isTrial: false,
+  hardCap: false,
+  totalGrantAmount: null,
+  remainingGrantAmount: null,
+  loading: false,
+  ...overrides,
+});
+
+describe('UpsellCard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('hidden', () => {
+    it('while loading', () => {
+      useBillingStatus.mockReturnValue(status({ loading: true }));
+      const { container } = render(<UpsellCard />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('when not on a capped plan', () => {
+      useBillingStatus.mockReturnValue(status({ totalGrantAmount: 100, remainingGrantAmount: 5 }));
+      const { container } = render(<UpsellCard />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('when there is no pool (totalGrantAmount null)', () => {
+      useBillingStatus.mockReturnValue(status({ isTrial: true, totalGrantAmount: null }));
+      const { container } = render(<UpsellCard />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('when the pool is zero', () => {
+      useBillingStatus.mockReturnValue(status({ isTrial: true, totalGrantAmount: 0, remainingGrantAmount: 0 }));
+      const { container } = render(<UpsellCard />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('when usage is below the 80% threshold', () => {
+      // 100 total, 30 remaining → 70% used
+      useBillingStatus.mockReturnValue(status({ isTrial: true, totalGrantAmount: 100, remainingGrantAmount: 30 }));
+      const { container } = render(<UpsellCard />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('shown', () => {
+    it('at exactly 80% on a trial (info wording)', () => {
+      useBillingStatus.mockReturnValue(status({ isTrial: true, totalGrantAmount: 100, remainingGrantAmount: 20 }));
+      render(<UpsellCard />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText(/used 80% of your plan/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /see upgrade options/i })).toBeInTheDocument();
+    });
+
+    it('when exhausted (>= 100%) with allowance wording', () => {
+      useBillingStatus.mockReturnValue(status({ isTrial: true, totalGrantAmount: 100, remainingGrantAmount: 0 }));
+      render(<UpsellCard />);
+      expect(screen.getByText(/used your full plan allowance/i)).toBeInTheDocument();
+    });
+
+    it('on a free-tier hard_cap plan (not trial) at >= 80%', () => {
+      // hardCap path, 100 total, 10 remaining → 90% used
+      useBillingStatus.mockReturnValue(status({ hardCap: true, totalGrantAmount: 100, remainingGrantAmount: 10 }));
+      render(<UpsellCard />);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText(/used 90% of your plan/)).toBeInTheDocument();
+    });
+
+    it('shows the pool total and a progress bar', () => {
+      useBillingStatus.mockReturnValue(status({ isTrial: true, totalGrantAmount: 250.5, remainingGrantAmount: 10 }));
+      render(<UpsellCard />);
+      // The amount is a separate JSX expression node, so assert on the
+      // alert's concatenated text content rather than a single text node.
+      expect(screen.getByRole('alert')).toHaveTextContent('shared $250.50 usage pool');
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/contexts/BillingStatusContext.jsx
+++ b/frontend/src/contexts/BillingStatusContext.jsx
@@ -32,6 +32,10 @@ const HEALTHY_STATE = {
   totalGrantAmount: null,
   remainingGrantAmount: null,
   seatPriceUsd: null,
+  // Markup multiplier (e.g. 1.3) applied to provider cost for billed figures.
+  // null when the backend supplied none → consumers fall back to the
+  // USAGE_MARKUP_MULTIPLIER constant.
+  usageMarkupMultiplier: null,
   userCount: 0,
   // SHU-773: the backend omits these blocks on self-hosted (no control plane).
   // null is the "unknown → don't gate" signal consumers key off of.
@@ -72,6 +76,7 @@ export const BillingStatusProvider = ({ children }) => {
         totalGrantAmount: parseDecimalField(data.total_grant_amount),
         remainingGrantAmount: parseDecimalField(data.remaining_grant_amount),
         seatPriceUsd: parseDecimalField(data.seat_price_usd),
+        usageMarkupMultiplier: parseDecimalField(data.usage_markup_multiplier),
         userCount: data.user_count ?? 0,
         // Absent on self-hosted responses → null, which useEntitlement reads
         // as "all enabled" so dev/self-hosted UIs keep showing every page.
@@ -115,6 +120,7 @@ export const BillingStatusProvider = ({ children }) => {
     totalGrantAmount: status.totalGrantAmount,
     remainingGrantAmount: status.remainingGrantAmount,
     seatPriceUsd: status.seatPriceUsd,
+    usageMarkupMultiplier: status.usageMarkupMultiplier,
     userCount: status.userCount,
     entitlements: status.entitlements,
     limits: status.limits,

--- a/frontend/src/hooks/useMyUsageData.js
+++ b/frontend/src/hooks/useMyUsageData.js
@@ -1,0 +1,65 @@
+/**
+ * Data hook for the per-user "My Usage" dashboard (SHU-844).
+ *
+ * Mirrors useUsageData but hits the self-scoped `/billing/usage/me` endpoint
+ * and drops the subscription/seat queries — the per-user page gets its
+ * plan/pool context from BillingStatusContext (already polled app-wide), not a
+ * second subscription fetch. Models + providers are fetched to resolve
+ * model_id → display name for the reused Cost by Model table and the chart.
+ *
+ * Query keys are namespaced under `my-usage:` so they don't collide with the
+ * admin dashboard's `billing-`/`cost-usage:` caches, which use the same
+ * endpoints with a different (tenant-wide) payload shape.
+ */
+
+import { useMemo, useCallback } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
+
+import { billingAPI, llmAPI, extractDataFromResponse } from '../services/api';
+
+const USAGE_KEY = ['my-usage:usage'];
+const MODELS_KEY = ['my-usage:llm-models'];
+const PROVIDERS_KEY = ['my-usage:llm-providers'];
+
+const REFERENCE_STALE_MS = 5 * 60 * 1000;
+
+const fetchMyUsage = () => billingAPI.getMyUsage().then(extractDataFromResponse);
+const fetchModels = () => llmAPI.getModels().then(extractDataFromResponse);
+const fetchProviders = () => llmAPI.getProviders().then(extractDataFromResponse);
+
+export function useMyUsageData() {
+  const queryClient = useQueryClient();
+
+  const usage = useQuery(USAGE_KEY, fetchMyUsage, { staleTime: 0 });
+  const models = useQuery(MODELS_KEY, fetchModels, { staleTime: REFERENCE_STALE_MS });
+  const providers = useQuery(PROVIDERS_KEY, fetchProviders, { staleTime: REFERENCE_STALE_MS });
+
+  const modelsMap = useMemo(() => {
+    const map = new Map();
+    const modelsList = Array.isArray(models.data) ? models.data : [];
+    const providersList = Array.isArray(providers.data) ? providers.data : [];
+    const providerNamesById = new Map(providersList.map((p) => [p.id, p.name]));
+    for (const model of modelsList) {
+      if (!model || !model.id) {
+        continue;
+      }
+      map.set(model.id, {
+        display_name: model.display_name || model.model_name || null,
+        provider_name: providerNamesById.get(model.provider_id) || null,
+      });
+    }
+    return map;
+  }, [models.data, providers.data]);
+
+  const refetch = useCallback(() => {
+    queryClient.invalidateQueries(USAGE_KEY);
+  }, [queryClient]);
+
+  return {
+    usage,
+    modelsMap,
+    modelsLoading: models.isLoading || providers.isLoading,
+    refetch,
+    lastUpdatedAt: usage.dataUpdatedAt || 0,
+  };
+}

--- a/frontend/src/hooks/useMyUsageData.js
+++ b/frontend/src/hooks/useMyUsageData.js
@@ -4,8 +4,14 @@
  * Mirrors useUsageData but hits the self-scoped `/billing/usage/me` endpoint
  * and drops the subscription/seat queries — the per-user page gets its
  * plan/pool context from BillingStatusContext (already polled app-wide), not a
- * second subscription fetch. Models + providers are fetched to resolve
- * model_id → display name for the reused Cost by Model table and the chart.
+ * second subscription fetch. Models are fetched to resolve model_id → display
+ * name for the reused Cost by Model table and the chart.
+ *
+ * Provider names are intentionally NOT resolved here. `/llm/providers` is
+ * admin-only, but this page is visible to ALL roles, so fetching it 403s for
+ * non-admins (and there is no role-open endpoint that returns provider names).
+ * `/llm/models` is open to every authenticated user and carries the display
+ * name — the primary label — so the provider sub-label is simply omitted here.
  *
  * Query keys are namespaced under `my-usage:` so they don't collide with the
  * admin dashboard's `billing-`/`cost-usage:` caches, which use the same
@@ -19,37 +25,35 @@ import { billingAPI, llmAPI, extractDataFromResponse } from '../services/api';
 
 const USAGE_KEY = ['my-usage:usage'];
 const MODELS_KEY = ['my-usage:llm-models'];
-const PROVIDERS_KEY = ['my-usage:llm-providers'];
 
 const REFERENCE_STALE_MS = 5 * 60 * 1000;
 
 const fetchMyUsage = () => billingAPI.getMyUsage().then(extractDataFromResponse);
 const fetchModels = () => llmAPI.getModels().then(extractDataFromResponse);
-const fetchProviders = () => llmAPI.getProviders().then(extractDataFromResponse);
 
 export function useMyUsageData() {
   const queryClient = useQueryClient();
 
   const usage = useQuery(USAGE_KEY, fetchMyUsage, { staleTime: 0 });
   const models = useQuery(MODELS_KEY, fetchModels, { staleTime: REFERENCE_STALE_MS });
-  const providers = useQuery(PROVIDERS_KEY, fetchProviders, { staleTime: REFERENCE_STALE_MS });
 
   const modelsMap = useMemo(() => {
     const map = new Map();
     const modelsList = Array.isArray(models.data) ? models.data : [];
-    const providersList = Array.isArray(providers.data) ? providers.data : [];
-    const providerNamesById = new Map(providersList.map((p) => [p.id, p.name]));
     for (const model of modelsList) {
       if (!model || !model.id) {
         continue;
       }
       map.set(model.id, {
         display_name: model.display_name || model.model_name || null,
-        provider_name: providerNamesById.get(model.provider_id) || null,
+        // Provider name is only available via the admin-only /llm/providers
+        // endpoint, which this all-roles page can't call — left null so
+        // CostByModelTable omits the provider sub-label.
+        provider_name: null,
       });
     }
     return map;
-  }, [models.data, providers.data]);
+  }, [models.data]);
 
   const refetch = useCallback(() => {
     queryClient.invalidateQueries(USAGE_KEY);
@@ -58,7 +62,7 @@ export function useMyUsageData() {
   return {
     usage,
     modelsMap,
-    modelsLoading: models.isLoading || providers.isLoading,
+    modelsLoading: models.isLoading,
     refetch,
     lastUpdatedAt: usage.dataUpdatedAt || 0,
   };

--- a/frontend/src/hooks/useMyUsageData.js
+++ b/frontend/src/hooks/useMyUsageData.js
@@ -29,7 +29,11 @@ const MODELS_KEY = ['my-usage:llm-models'];
 const REFERENCE_STALE_MS = 5 * 60 * 1000;
 
 const fetchMyUsage = () => billingAPI.getMyUsage().then(extractDataFromResponse);
-const fetchModels = () => llmAPI.getModels().then(extractDataFromResponse);
+// `model_type: 'all'` — My Usage reports billable embedding/OCR rows too, and
+// /llm/models defaults to chat-only, so the full catalog is needed to resolve
+// non-chat model_ids to live display names (otherwise they fall back to the
+// usage row's snapshot model_name).
+const fetchModels = () => llmAPI.getModels(null, 'all').then(extractDataFromResponse);
 
 export function useMyUsageData() {
   const queryClient = useQueryClient();

--- a/frontend/src/pages/MyUsagePage.jsx
+++ b/frontend/src/pages/MyUsagePage.jsx
@@ -130,70 +130,72 @@ function MyUsagePage() {
   const isPeriodKnown = Boolean(usage.data) && !usage.data.current_period_unknown;
 
   return (
-    <Box sx={{ p: { xs: 1.5, sm: 3 }, maxWidth: 1400, mx: 'auto' }}>
-      <PageHeader usageQuery={usage} lastUpdatedAt={lastUpdatedAt} onRefresh={refetch} timezone={timezone} />
+    <Box sx={{ flexGrow: 1, overflow: 'auto' }}>
+      <Box sx={{ p: { xs: 1.5, sm: 3 }, maxWidth: 1400, mx: 'auto' }}>
+        <PageHeader usageQuery={usage} lastUpdatedAt={lastUpdatedAt} onRefresh={refetch} timezone={timezone} />
 
-      <Stack spacing={3}>
-        <UpsellCard />
+        <Stack spacing={3}>
+          <UpsellCard />
 
-        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
-          <Stack spacing={2}>
-            <Typography variant="overline" sx={SECTION_HEADING_SX}>
-              Summary
-            </Typography>
-            {usage.isError ? (
-              <UsageErrorAlert onRefresh={refetch} />
-            ) : (
-              <MyUsageKpiTiles usageData={usage.data} isLoading={usage.isLoading} pool={pool} />
-            )}
-          </Stack>
-        </Paper>
+          <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+            <Stack spacing={2}>
+              <Typography variant="overline" sx={SECTION_HEADING_SX}>
+                Summary
+              </Typography>
+              {usage.isError ? (
+                <UsageErrorAlert onRefresh={refetch} />
+              ) : (
+                <MyUsageKpiTiles usageData={usage.data} isLoading={usage.isLoading} pool={pool} />
+              )}
+            </Stack>
+          </Paper>
 
-        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
-          <Stack spacing={2}>
-            <Typography variant="overline" sx={SECTION_HEADING_SX}>
-              Usage Over Time
-            </Typography>
-            {usage.isError ? (
-              <UsageErrorAlert onRefresh={refetch} />
-            ) : usage.isLoading ? (
-              <Skeleton variant="rounded" height={320} />
-            ) : isPeriodKnown ? (
-              <Suspense fallback={<Skeleton variant="rounded" height={320} />}>
-                <MyUsageChart byDay={usage.data?.by_day} modelsMap={modelsMap} />
-              </Suspense>
-            ) : (
-              <Box sx={{ py: 4, textAlign: 'center' }}>
-                <Typography variant="body2" color="text.secondary">
-                  Usage trends will appear here once a billing period is active.
-                </Typography>
-              </Box>
-            )}
-          </Stack>
-        </Paper>
+          <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+            <Stack spacing={2}>
+              <Typography variant="overline" sx={SECTION_HEADING_SX}>
+                Usage Over Time
+              </Typography>
+              {usage.isError ? (
+                <UsageErrorAlert onRefresh={refetch} />
+              ) : usage.isLoading ? (
+                <Skeleton variant="rounded" height={320} />
+              ) : isPeriodKnown ? (
+                <Suspense fallback={<Skeleton variant="rounded" height={320} />}>
+                  <MyUsageChart byDay={usage.data?.by_day} modelsMap={modelsMap} />
+                </Suspense>
+              ) : (
+                <Box sx={{ py: 4, textAlign: 'center' }}>
+                  <Typography variant="body2" color="text.secondary">
+                    Usage trends will appear here once a billing period is active.
+                  </Typography>
+                </Box>
+              )}
+            </Stack>
+          </Paper>
 
-        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
-          <Stack spacing={2}>
-            <Typography variant="overline" sx={SECTION_HEADING_SX}>
-              Cost by Model
-            </Typography>
-            {usage.isError ? (
-              <UsageErrorAlert onRefresh={refetch} />
-            ) : (
-              <CostByModelTable usageQuery={usage} modelsMap={modelsMap} />
-            )}
-          </Stack>
-        </Paper>
+          <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+            <Stack spacing={2}>
+              <Typography variant="overline" sx={SECTION_HEADING_SX}>
+                Cost by Model
+              </Typography>
+              {usage.isError ? (
+                <UsageErrorAlert onRefresh={refetch} />
+              ) : (
+                <CostByModelTable usageQuery={usage} modelsMap={modelsMap} />
+              )}
+            </Stack>
+          </Paper>
 
-        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
-          <Stack spacing={2}>
-            <Typography variant="overline" sx={SECTION_HEADING_SX}>
-              Your Personal Knowledge Base
-            </Typography>
-            <PersonalKbStatsTile />
-          </Stack>
-        </Paper>
-      </Stack>
+          <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+            <Stack spacing={2}>
+              <Typography variant="overline" sx={SECTION_HEADING_SX}>
+                Your Personal Knowledge Base
+              </Typography>
+              <PersonalKbStatsTile />
+            </Stack>
+          </Paper>
+        </Stack>
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/pages/MyUsagePage.jsx
+++ b/frontend/src/pages/MyUsagePage.jsx
@@ -112,7 +112,13 @@ function MyUsagePage() {
   const { usage, modelsMap, refetch, lastUpdatedAt } = useMyUsageData();
   // `limits`/`usage` are the tenant-wide KB caps + counts (aliased to avoid
   // colliding with the per-user `usage` query above).
-  const { totalGrantAmount, remainingGrantAmount, limits: kbLimits, usage: kbUsage } = useBillingStatus();
+  const {
+    totalGrantAmount,
+    remainingGrantAmount,
+    usageMarkupMultiplier,
+    limits: kbLimits,
+    usage: kbUsage,
+  } = useBillingStatus();
 
   // Resolve the user's local timezone once for the period label.
   const timezone = useMemo(() => {
@@ -148,7 +154,12 @@ function MyUsagePage() {
               {usage.isError ? (
                 <UsageErrorAlert onRefresh={refetch} />
               ) : (
-                <MyUsageKpiTiles usageData={usage.data} isLoading={usage.isLoading} pool={pool} />
+                <MyUsageKpiTiles
+                  usageData={usage.data}
+                  isLoading={usage.isLoading}
+                  pool={pool}
+                  markup={usageMarkupMultiplier}
+                />
               )}
             </Stack>
           </Paper>

--- a/frontend/src/pages/MyUsagePage.jsx
+++ b/frontend/src/pages/MyUsagePage.jsx
@@ -3,6 +3,7 @@ import { Alert, Box, Button, IconButton, Paper, Skeleton, Stack, Tooltip, Typogr
 import RefreshIcon from '@mui/icons-material/Refresh';
 
 import CostByModelTable from '../components/billing/CostByModelTable';
+import KbLimitsTile from '../components/billing/KbLimitsTile';
 import MyUsageKpiTiles from '../components/billing/MyUsageKpiTiles';
 import PersonalKbStatsTile from '../components/billing/PersonalKbStatsTile';
 import UpsellCard from '../components/billing/UpsellCard';
@@ -109,7 +110,9 @@ function UsageErrorAlert({ onRefresh }) {
  */
 function MyUsagePage() {
   const { usage, modelsMap, refetch, lastUpdatedAt } = useMyUsageData();
-  const { totalGrantAmount, remainingGrantAmount } = useBillingStatus();
+  // `limits`/`usage` are the tenant-wide KB caps + counts (aliased to avoid
+  // colliding with the per-user `usage` query above).
+  const { totalGrantAmount, remainingGrantAmount, limits: kbLimits, usage: kbUsage } = useBillingStatus();
 
   // Resolve the user's local timezone once for the period label.
   const timezone = useMemo(() => {
@@ -189,8 +192,9 @@ function MyUsagePage() {
           <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
             <Stack spacing={2}>
               <Typography variant="overline" sx={SECTION_HEADING_SX}>
-                Your Personal Knowledge Base
+                Knowledge Bases
               </Typography>
+              <KbLimitsTile usage={kbUsage} limits={kbLimits} />
               <PersonalKbStatsTile />
             </Stack>
           </Paper>

--- a/frontend/src/pages/MyUsagePage.jsx
+++ b/frontend/src/pages/MyUsagePage.jsx
@@ -1,0 +1,201 @@
+import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
+import { Alert, Box, Button, IconButton, Paper, Skeleton, Stack, Tooltip, Typography } from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+
+import CostByModelTable from '../components/billing/CostByModelTable';
+import MyUsageKpiTiles from '../components/billing/MyUsageKpiTiles';
+import PersonalKbStatsTile from '../components/billing/PersonalKbStatsTile';
+import UpsellCard from '../components/billing/UpsellCard';
+import { useMyUsageData } from '../hooks/useMyUsageData';
+import { useBillingStatus } from '../contexts/BillingStatusContext';
+import { formatBillingPeriod, formatLastUpdated } from '../utils/billingFormatters';
+
+// Code-split the chart so @mui/x-charts (and its d3 vendor bundle) loads only
+// when a user opens this route — it stays out of the app's initial bundle.
+const MyUsageChart = lazy(() => import('../components/billing/MyUsageChart'));
+
+const SECTION_HEADING_SX = {
+  fontWeight: 600,
+  letterSpacing: '0.1em',
+  color: 'primary.main',
+};
+
+function PageHeader({ usageQuery, lastUpdatedAt, onRefresh, timezone }) {
+  // Tick every minute so "Last updated X ago" recomputes against the clock
+  // even when no other state changed.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  let subtitle;
+  if (usageQuery.isLoading) {
+    subtitle = <Skeleton width={280} />;
+  } else if (usageQuery.isError) {
+    subtitle = (
+      <Typography variant="body2" color="text.secondary">
+        Period unavailable
+      </Typography>
+    );
+  } else if (usageQuery.data?.current_period_unknown) {
+    subtitle = (
+      <Typography variant="body2" color="text.secondary">
+        No active billing period
+      </Typography>
+    );
+  } else {
+    subtitle = (
+      <Typography variant="body2" color="text.secondary">
+        Current billing period:{' '}
+        {formatBillingPeriod(usageQuery.data?.period_start, usageQuery.data?.period_end, timezone)}
+      </Typography>
+    );
+  }
+
+  const lastUpdatedAbsolute = lastUpdatedAt ? new Date(lastUpdatedAt).toLocaleString() : 'never';
+
+  return (
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      alignItems={{ xs: 'flex-start', sm: 'center' }}
+      justifyContent="space-between"
+      spacing={1}
+      sx={{ mb: 2 }}
+    >
+      <Box>
+        <Typography variant="h4" sx={{ fontWeight: 600 }}>
+          My Usage
+        </Typography>
+        {subtitle}
+      </Box>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Tooltip title={`Last updated: ${lastUpdatedAbsolute}`} arrow>
+          <Typography variant="caption" color="text.secondary">
+            Last updated {formatLastUpdated(lastUpdatedAt)}
+          </Typography>
+        </Tooltip>
+        <IconButton size="small" onClick={onRefresh} aria-label="Refresh usage data" disabled={usageQuery.isFetching}>
+          <RefreshIcon />
+        </IconButton>
+      </Stack>
+    </Stack>
+  );
+}
+
+function UsageErrorAlert({ onRefresh }) {
+  return (
+    <Alert
+      severity="error"
+      action={
+        <Button color="inherit" size="small" onClick={onRefresh}>
+          Retry
+        </Button>
+      }
+    >
+      We couldn&apos;t load your usage data. Please try again.
+    </Alert>
+  );
+}
+
+/**
+ * Per-user "My Usage" dashboard (SHU-844).
+ *
+ * Self-service counterpart to the admin Cost & Usage dashboard (SHU-733),
+ * available to every role from the user menu. All usage is scoped to the
+ * requesting user via `/billing/usage/me`; plan/pool context comes from
+ * BillingStatusContext. Reuses the Cost by Model table, KPI tile, and
+ * formatters from the admin dashboard.
+ */
+function MyUsagePage() {
+  const { usage, modelsMap, refetch, lastUpdatedAt } = useMyUsageData();
+  const { totalGrantAmount, remainingGrantAmount } = useBillingStatus();
+
+  // Resolve the user's local timezone once for the period label.
+  const timezone = useMemo(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || null;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // Shared-pool context from the billing status poll. null when CP isn't
+  // configured → the KPI tiles degrade to volume-only.
+  const pool =
+    typeof totalGrantAmount === 'number'
+      ? { total: totalGrantAmount, remaining: remainingGrantAmount ?? totalGrantAmount }
+      : null;
+
+  const isPeriodKnown = Boolean(usage.data) && !usage.data.current_period_unknown;
+
+  return (
+    <Box sx={{ p: { xs: 1.5, sm: 3 }, maxWidth: 1400, mx: 'auto' }}>
+      <PageHeader usageQuery={usage} lastUpdatedAt={lastUpdatedAt} onRefresh={refetch} timezone={timezone} />
+
+      <Stack spacing={3}>
+        <UpsellCard />
+
+        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+          <Stack spacing={2}>
+            <Typography variant="overline" sx={SECTION_HEADING_SX}>
+              Summary
+            </Typography>
+            {usage.isError ? (
+              <UsageErrorAlert onRefresh={refetch} />
+            ) : (
+              <MyUsageKpiTiles usageData={usage.data} isLoading={usage.isLoading} pool={pool} />
+            )}
+          </Stack>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+          <Stack spacing={2}>
+            <Typography variant="overline" sx={SECTION_HEADING_SX}>
+              Usage Over Time
+            </Typography>
+            {usage.isError ? (
+              <UsageErrorAlert onRefresh={refetch} />
+            ) : usage.isLoading ? (
+              <Skeleton variant="rounded" height={320} />
+            ) : isPeriodKnown ? (
+              <Suspense fallback={<Skeleton variant="rounded" height={320} />}>
+                <MyUsageChart byDay={usage.data?.by_day} modelsMap={modelsMap} />
+              </Suspense>
+            ) : (
+              <Box sx={{ py: 4, textAlign: 'center' }}>
+                <Typography variant="body2" color="text.secondary">
+                  Usage trends will appear here once a billing period is active.
+                </Typography>
+              </Box>
+            )}
+          </Stack>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+          <Stack spacing={2}>
+            <Typography variant="overline" sx={SECTION_HEADING_SX}>
+              Cost by Model
+            </Typography>
+            {usage.isError ? (
+              <UsageErrorAlert onRefresh={refetch} />
+            ) : (
+              <CostByModelTable usageQuery={usage} modelsMap={modelsMap} />
+            )}
+          </Stack>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 } }}>
+          <Stack spacing={2}>
+            <Typography variant="overline" sx={SECTION_HEADING_SX}>
+              Your Personal Knowledge Base
+            </Typography>
+            <PersonalKbStatsTile />
+          </Stack>
+        </Paper>
+      </Stack>
+    </Box>
+  );
+}
+
+export default MyUsagePage;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -296,6 +296,9 @@ export const authAPI = {
 // Billing endpoints (subscription state, seat management, Cost & Usage dashboard)
 export const billingAPI = {
   getUsage: () => api.get('/billing/usage'),
+  // Per-user self usage for the "My Usage" dashboard (SHU-844). Scoped
+  // server-side to the caller — no user id param.
+  getMyUsage: () => api.get('/billing/usage/me'),
   getSubscription: () => api.get('/billing/subscription'),
   getPortalUrl: () => api.get('/billing/portal'),
   releaseSeat: () => api.post('/billing/seats/release'),

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -423,9 +423,14 @@ export const llmAPI = {
   getProviderType: (key) => api.get(`/llm/provider-types/${encodeURIComponent(key)}`),
 
   // Model management
-  getModels: (providerId = null) =>
+  // modelType: omit for chat-only (the endpoint default), or pass 'all' to
+  // include embedding/OCR models (e.g. usage dashboards that report them).
+  getModels: (providerId = null, modelType = null) =>
     api.get('/llm/models', {
-      params: providerId ? { provider_id: providerId } : {},
+      params: {
+        ...(providerId ? { provider_id: providerId } : {}),
+        ...(modelType ? { model_type: modelType } : {}),
+      },
     }),
   createModel: (providerId, data) => api.post(`/llm/providers/${providerId}/models`, data),
 

--- a/frontend/src/utils/__tests__/myUsageChart.test.js
+++ b/frontend/src/utils/__tests__/myUsageChart.test.js
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the buildDailySeries transform (SHU-844).
+ *
+ * Pure pivot from the /billing/usage/me `by_day` payload into a sorted date
+ * axis + one cost series per model. No React/MUI.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDailySeries } from '../myUsageChart';
+
+describe('buildDailySeries', () => {
+  it('sums cost per (model, date) and keeps a series per model', () => {
+    const byDay = [
+      { date: '2026-04-01', model_id: 'm-1', model_name: 'Haiku', cost_usd: 10.5 },
+      { date: '2026-04-01', model_id: 'm-1', model_name: 'Haiku', cost_usd: 5.5 },
+      { date: '2026-04-01', model_id: 'm-2', model_name: 'GPT-4o', cost_usd: 3.0 },
+    ];
+    const { dates, series } = buildDailySeries(byDay);
+    expect(dates).toEqual(['2026-04-01']);
+    expect(series).toHaveLength(2);
+    expect(series[0].modelId).toBe('m-1');
+    expect(series[0].data).toEqual([16.0]);
+    expect(series[1].modelId).toBe('m-2');
+    expect(series[1].data).toEqual([3.0]);
+  });
+
+  it('sorts dates chronologically and aligns each series to them', () => {
+    const byDay = [
+      { date: '2026-04-03', model_id: 'm-1', cost_usd: 1 },
+      { date: '2026-04-01', model_id: 'm-1', cost_usd: 2 },
+      { date: '2026-04-02', model_id: 'm-1', cost_usd: 3 },
+    ];
+    const { dates, series } = buildDailySeries(byDay);
+    expect(dates).toEqual(['2026-04-01', '2026-04-02', '2026-04-03']);
+    expect(series[0].data).toEqual([2, 3, 1]);
+  });
+
+  it('zero-fills a model on dates it lacks but another model has', () => {
+    // The axis is the union of dates present in the data (absent calendar days
+    // are not synthesized); each series is zero-filled to align to that axis.
+    const byDay = [
+      { date: '2026-04-01', model_id: 'm-1', cost_usd: 10 },
+      { date: '2026-04-02', model_id: 'm-2', cost_usd: 20 },
+    ];
+    const { dates, series } = buildDailySeries(byDay);
+    expect(dates).toEqual(['2026-04-01', '2026-04-02']);
+    expect(series[0].data).toEqual([10, 0]);
+    expect(series[1].data).toEqual([0, 20]);
+  });
+
+  it('preserves first-seen model order', () => {
+    const byDay = [
+      { date: '2026-04-01', model_id: 'm-3', cost_usd: 1 },
+      { date: '2026-04-01', model_id: 'm-1', cost_usd: 2 },
+      { date: '2026-04-01', model_id: 'm-2', cost_usd: 3 },
+    ];
+    const { series } = buildDailySeries(byDay);
+    expect(series.map((s) => s.modelId)).toEqual(['m-3', 'm-1', 'm-2']);
+  });
+
+  it('returns empty for empty or null input', () => {
+    expect(buildDailySeries([])).toEqual({ dates: [], series: [] });
+    expect(buildDailySeries(null)).toEqual({ dates: [], series: [] });
+    expect(buildDailySeries(undefined)).toEqual({ dates: [], series: [] });
+  });
+
+  it('skips rows missing a date', () => {
+    const byDay = [
+      { model_id: 'm-1', cost_usd: 10 },
+      { date: '2026-04-01', model_id: 'm-1', cost_usd: 5 },
+    ];
+    const { dates, series } = buildDailySeries(byDay);
+    expect(dates).toEqual(['2026-04-01']);
+    expect(series[0].data).toEqual([5]);
+  });
+
+  describe('label resolution', () => {
+    it('prefers the live catalog display_name', () => {
+      const modelsMap = new Map([['m-1', { display_name: 'Claude Haiku 4.5', provider_name: 'anthropic' }]]);
+      const byDay = [{ date: '2026-04-01', model_id: 'm-1', model_name: 'claude-haiku', cost_usd: 10 }];
+      expect(buildDailySeries(byDay, modelsMap).series[0].label).toBe('Claude Haiku 4.5');
+    });
+
+    it('falls back to the snapshot model_name', () => {
+      const byDay = [{ date: '2026-04-01', model_id: 'm-1', model_name: 'claude-haiku-4-5', cost_usd: 10 }];
+      expect(buildDailySeries(byDay, new Map()).series[0].label).toBe('claude-haiku-4-5');
+    });
+
+    it('falls back to a truncated id when nothing resolves', () => {
+      const byDay = [{ date: '2026-04-01', model_id: 'a3f9b2d4-c1e5-4a8c-9f3e-2d6b8c4a1e7f', cost_usd: 10 }];
+      expect(buildDailySeries(byDay, new Map()).series[0].label).toBe('model_a3f9b2d4');
+    });
+
+    it('merges null and "unknown" model ids into one "Unattributed" series', () => {
+      const byDay = [
+        { date: '2026-04-01', model_id: null, cost_usd: 5 },
+        { date: '2026-04-01', model_id: 'unknown', cost_usd: 3 },
+      ];
+      const { series } = buildDailySeries(byDay);
+      expect(series).toHaveLength(1);
+      expect(series[0].label).toBe('Unattributed');
+      expect(series[0].data).toEqual([8]);
+    });
+  });
+
+  describe('numeric coercion', () => {
+    it('coerces string costs to numbers', () => {
+      const byDay = [{ date: '2026-04-01', model_id: 'm-1', cost_usd: '12.5' }];
+      expect(buildDailySeries(byDay).series[0].data[0]).toBe(12.5);
+    });
+
+    it('treats missing or non-numeric cost as 0', () => {
+      const byDay = [
+        { date: '2026-04-01', model_id: 'm-1', cost_usd: undefined },
+        { date: '2026-04-01', model_id: 'm-2', cost_usd: 'nope' },
+      ];
+      const { series } = buildDailySeries(byDay);
+      expect(series[0].data[0]).toBe(0);
+      expect(series[1].data[0]).toBe(0);
+    });
+  });
+});

--- a/frontend/src/utils/myUsageChart.js
+++ b/frontend/src/utils/myUsageChart.js
@@ -1,0 +1,78 @@
+/**
+ * Pure transform from the `/billing/usage/me` `by_day` payload into chart
+ * series for the My Usage time-series (SHU-844).
+ *
+ * The backend returns one row per (UTC day, model). This pivots them into a
+ * sorted date axis plus one cost series per model, so @mui/x-charts can render
+ * a line per model with a visibility toggle. Kept pure (no React, no MUI) so it
+ * is unit-testable in isolation.
+ */
+
+// Truncated-UUID fallback dimensions, matching the Cost by Model table.
+const SHORT_ID_THRESHOLD = 12;
+const SHORT_ID_CHARS = 8;
+
+/**
+ * Resolve a model's display label using the same three-tier fallback as the
+ * Cost by Model table: live catalog name → backend snapshot name → short id.
+ */
+function resolveLabel(modelId, modelName, modelsMap) {
+  if (modelId === 'unknown' || !modelId) {
+    return 'Unattributed';
+  }
+  const resolved = modelsMap?.get?.(modelId);
+  if (resolved && resolved.display_name) {
+    return resolved.display_name;
+  }
+  if (modelName) {
+    return modelName;
+  }
+  const id = String(modelId);
+  return id.length > SHORT_ID_THRESHOLD ? `model_${id.slice(0, SHORT_ID_CHARS)}` : `model_${id}`;
+}
+
+/**
+ * @param {Array<{date:string, model_id:string|null, model_name:string|null, cost_usd:number}>} byDay
+ * @param {Map<string,{display_name?:string,provider_name?:string}>} [modelsMap]
+ * @returns {{ dates: string[], series: Array<{ modelId:string, label:string, data:number[] }> }}
+ */
+export function buildDailySeries(byDay, modelsMap) {
+  const rows = Array.isArray(byDay) ? byDay : [];
+
+  const dateSet = new Set();
+  const modelOrder = [];
+  const modelSeen = new Set();
+  // modelId -> (date -> summed cost)
+  const costByModelDate = new Map();
+
+  for (const row of rows) {
+    if (!row || !row.date) {
+      continue;
+    }
+    dateSet.add(row.date);
+    const modelId = row.model_id || 'unknown';
+    if (!modelSeen.has(modelId)) {
+      modelSeen.add(modelId);
+      modelOrder.push({ modelId, modelName: row.model_name });
+    }
+    let perDate = costByModelDate.get(modelId);
+    if (!perDate) {
+      perDate = new Map();
+      costByModelDate.set(modelId, perDate);
+    }
+    const cost = Number(row.cost_usd) || 0;
+    perDate.set(row.date, (perDate.get(row.date) || 0) + cost);
+  }
+
+  const dates = Array.from(dateSet).sort();
+  const series = modelOrder.map(({ modelId, modelName }) => {
+    const perDate = costByModelDate.get(modelId) || new Map();
+    return {
+      modelId,
+      label: resolveLabel(modelId, modelName, modelsMap),
+      data: dates.map((d) => perDate.get(d) || 0),
+    };
+  });
+
+  return { dates, series };
+}


### PR DESCRIPTION
## Description
### What's new
A new **My Usage** page in the user menu, available to **every role** — including free‑tier/trial users who have no admin panel. It's read‑only and always scoped to the person viewing it (you can never see another user's usage).

It shows, for the current billing period:
- **Your cost** (in billed dollars), **requests**, and **tokens**
- A **usage‑over‑time chart** — one stacked bar per day, split by model, with click‑to‑toggle series
- A **Cost by Model** breakdown table
- **Shared plan pool** usage (used / limit) when a plan is configured
- **Knowledge Base limits** — documents and KBs used vs. your workspace caps
- A stubbed **upsell** prompt for trial users approaching their cap

When the control plane isn't configured (e.g. self‑hosted), the plan/pool/KB‑limit tiles simply hide and the page degrades to the volume tiles + chart + table.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Issues
ALL users (non-admin) version of the usage dashboard created here: #

## Changes Made
**Backend**
- New `GET /api/v1/billing/usage/me` — scoped to the caller, billable‑only (BYOK excluded), with the period resolved via **CP → Stripe → calendar‑month** fallback so it's never blank.
- Daily per‑(day, model) series for the chart, **bounded to the top‑N models** (the rest folded into "Other models") to keep it readable under heavy model churn.
- New composite index `ix_llm_usage_tenant_user_created` for the per‑user query.
- Markup rate is now sent to all roles so per‑user cost displays in **billed dollars** (matching the shared pool).
- Attribution fixes so interactive usage records the real user.

**Frontend**
- New `MyUsagePage` + KPI tiles, reachable from the user menu for all roles.
- Time chart on **@mui/x‑charts v8** (code‑split to this route), reused **Cost by Model** table, **KB‑limits** tile, and conditional upsell card.


## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing locally
- [ ] 
**Automated (added/updated)**
- `test_adapters.py` — usage aggregation + the top‑N "Other models" fold (no‑op within cap / folds beyond cap / per‑day aggregation).
- `test_router.py` — subscription payload exposes the markup to all roles; period resolution incl. calendar‑month fallback.
- `test_billing_usage_me_integration.py` — per‑user scoping (no cross‑user leakage), BYOK exclusion, calendar‑month fallback, `by_day` bucketing, auth required.
- `MyUsageKpiTiles.test.jsx` — volume + shared‑pool tiles; billed cost = raw × markup with constant fallback.
- `KbLimitsTile.test.jsx` — renders/clamps bars; hidden when CP absent or a cap is 0.

**Manual (executed during QA)**
- Opened My Usage as an **admin** and as a **regular user** — each saw only their own data (verified against the DB).
- KPI values (cost / requests / tokens) matched the DB.
- Chart — per‑model toggle, stacked bars, UTC day labels, sub‑cent y‑axis labels, load animation, and **no console "maximum update depth" warning** after the v8 migration.
- Personal KB stats updated after adding a document.
- Per‑model cost breakdown correct (majority from the expected model).
- Plan/pool and KB‑limit tiles hidden when the control plane isn't configured.
- Mobile — KPI tiles stay centered on narrow screens.

## Screenshots (if applicable)
<img width="1796" height="1010" alt="image" src="https://github.com/user-attachments/assets/13876d6b-52e1-4a65-ad7b-0bc48b6bc40d" />


## Reviewer Notes
Please let me know if there is any weird behavior displayed on CP enabled env's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "My Usage" dashboard page with per-user totals, KPIs, and a daily stacked cost chart with interactive model filters.
  * New "My Usage" menu item and quick-access route.
  * Knowledge-base and shared-pool usage tiles with progress indicators and upsell card.

* **Behavior Changes**
  * Usage period is now reliably resolved (no unknown-period responses); calendar-month fallback applied when needed.

* **Performance**
  * Faster and more reliable per-user usage queries for the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->