### PR TITLE
Shu 857 contact support mailto dialog

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -19,6 +19,14 @@ VITE_EXPERIENCES_ENABLED=true
 # Automatically forced to false when VITE_PLUGINS_ENABLED=false.
 VITE_CHAT_PLUGINS_ENABLED=false
 
+# Show the "Shu Assistant" how-to chat entry in the Contact Support dialog (default false).
+# Enable once the seeded assistant model config exists; until then it would open an empty chat.
+VITE_SHU_ASSISTANT_ENABLED=false
+
+# Customer-support email shown in the Contact Support dialog (default support@openshu.ai).
+# Override for white-label deployments.
+VITE_SUPPORT_EMAIL=support@shu.ai
+
 
 # Global API timeout in milliseconds for frontend requests (Axios)
 # Defaults to 90000 if unset. Increase for long-running admin/test operations.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -23,7 +23,7 @@ VITE_CHAT_PLUGINS_ENABLED=false
 # Enable once the seeded assistant model config exists; until then it would open an empty chat.
 VITE_SHU_ASSISTANT_ENABLED=false
 
-# Customer-support email shown in the Contact Support dialog (default support@openshu.ai).
+# Customer-support email shown in the Contact Support dialog (default support@shu.ai).
 # Override for white-label deployments.
 VITE_SUPPORT_EMAIL=support@shu.ai
 

--- a/frontend/src/components/UserMenuCommonItems.jsx
+++ b/frontend/src/components/UserMenuCommonItems.jsx
@@ -6,6 +6,7 @@ import {
   ManageAccounts as AccountsIcon,
   Settings as SettingsIcon,
   Insights as UsageIcon,
+  SupportAgent as SupportAgentIcon,
 } from '@mui/icons-material';
 import { useFeatureEnabled } from '../config/featureFlags';
 
@@ -14,8 +15,9 @@ import { useFeatureEnabled } from '../config/featureFlags';
  * Shared user menu entries used in both UserLayout and AdminLayout.
  * Props:
  *  - onNavigate: (path: string) => void
+ *  - onContactSupport?: () => void — opens the Contact Support dialog
  */
-export default function UserMenuCommonItems({ onNavigate }) {
+export default function UserMenuCommonItems({ onNavigate, onContactSupport }) {
   const go = (path) => () => onNavigate && onNavigate(path);
   const canPlugins = useFeatureEnabled('plugins');
   return (
@@ -52,6 +54,14 @@ export default function UserMenuCommonItems({ onNavigate }) {
         </ListItemIcon>
         User Preferences
       </MenuItem>
+      {onContactSupport && (
+        <MenuItem onClick={onContactSupport}>
+          <ListItemIcon>
+            <SupportAgentIcon fontSize="small" />
+          </ListItemIcon>
+          Contact Support
+        </MenuItem>
+      )}
       <Divider />
     </>
   );

--- a/frontend/src/components/layout/TopBar.jsx
+++ b/frontend/src/components/layout/TopBar.jsx
@@ -7,6 +7,7 @@ import { useTheme as useAppTheme } from '../../contexts/ThemeContext';
 import { getBrandingAppName, getBrandingFaviconUrlForTheme, getTopbarTextColor } from '../../utils/constants';
 import UserMenuCommonItems from '../UserMenuCommonItems.jsx';
 import UserAvatar from '../shared/UserAvatar.jsx';
+import ContactSupportDialog from '../support/ContactSupportDialog.jsx';
 import useVersion from '../../hooks/useVersion';
 
 /**
@@ -38,6 +39,7 @@ const TopBar = ({
   const { displayVersion } = useVersion();
 
   const [anchorEl, setAnchorEl] = React.useState(null);
+  const [contactSupportOpen, setContactSupportOpen] = React.useState(false);
   const handleUserMenuOpen = (e) => setAnchorEl(e.currentTarget);
   const handleUserMenuClose = () => setAnchorEl(null);
   const handleLogout = () => {
@@ -157,6 +159,10 @@ const TopBar = ({
               handleUserMenuClose();
               navigate(path);
             }}
+            onContactSupport={() => {
+              handleUserMenuClose();
+              setContactSupportOpen(true);
+            }}
           />
           {showAdminLink && canAccessAdmin && (
             <MenuItem onClick={handleAdminPanel}>
@@ -187,6 +193,14 @@ const TopBar = ({
             </MenuItem>
           )}
         </Menu>
+
+        <ContactSupportDialog
+          open={contactSupportOpen}
+          onClose={() => setContactSupportOpen(false)}
+          user={user}
+          appName={appDisplayName}
+          version={displayVersion}
+        />
       </Toolbar>
     </AppBar>
   );

--- a/frontend/src/components/support/ContactSupportDialog.jsx
+++ b/frontend/src/components/support/ContactSupportDialog.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Stack,
+  Typography,
+  Divider,
+  Tooltip,
+  IconButton,
+} from '@mui/material';
+import {
+  SupportAgent as SupportAgentIcon,
+  Email as EmailIcon,
+  ContentCopy as CopyIcon,
+  Check as CheckIcon,
+  SmartToy as BotIcon,
+} from '@mui/icons-material';
+
+import { SUPPORT_EMAIL } from '../../utils/constants';
+import log from '../../utils/log';
+
+// How long the Copy button shows its "Copied" confirmation before resetting.
+const COPIED_RESET_MS = 2000;
+
+/**
+ * ContactSupportDialog (SHU-857)
+ *
+ * Lightweight, pure-frontend support entry point opened from the profile menu.
+ * Surfaces the support address with copy + mailto actions, and a distinct
+ * "Shu Bot" how-to-use-the-app stub that opens a new chat. This is NOT a
+ * customer-support bot — the copy keeps the two paths clearly separated.
+ *
+ * Props:
+ *  - open: boolean
+ *  - onClose: () => void
+ *  - user?: { name, email, role } — used to prefill the mailto body
+ *  - appName?: string — used in the mailto subject/body
+ *  - version?: string — display version, shown inline and in the mailto body
+ */
+export default function ContactSupportDialog({ open, onClose, user, appName = 'Shu', version }) {
+  const navigate = useNavigate();
+  const [copied, setCopied] = useState(false);
+
+  // Prefill the mail body with the user's own account context (no privacy
+  // concern — it's their data) so support can triage without a round-trip.
+  // Kept short to stay well under mailto URL length limits (~2000 chars).
+  const subject = `${appName} Support Request`;
+  const body = [
+    `App: ${appName}${version ? ` ${version}` : ''}`,
+    `Name: ${user?.name || ''}`,
+    `Email: ${user?.email || ''}`,
+    `Role: ${user?.role || ''}`,
+    '',
+    'Describe your issue below:',
+    '',
+  ].join('\n');
+  const mailtoHref = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
+  const handleCopy = async () => {
+    // Selectable address text below is the fallback when the Clipboard API is
+    // unavailable (e.g. insecure HTTP context) — never throw at the user.
+    if (!navigator.clipboard?.writeText) {
+      log.warn('Clipboard API unavailable; address must be copied manually');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(SUPPORT_EMAIL);
+      setCopied(true);
+      setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    } catch (err) {
+      log.warn('Failed to copy support address to clipboard', err);
+    }
+  };
+
+  const handleChatWithBot = () => {
+    onClose();
+    navigate('/chat');
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth aria-labelledby="contact-support-title">
+      <DialogTitle id="contact-support-title" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <SupportAgentIcon fontSize="small" />
+        Contact Support
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Stack spacing={1}>
+          <Typography variant="subtitle2">Need to reach our team?</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Email us and we&apos;ll get back to you as soon as we can.
+          </Typography>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="body1" sx={{ fontWeight: 600, userSelect: 'all', wordBreak: 'break-all' }}>
+              {SUPPORT_EMAIL}
+            </Typography>
+            <Tooltip title={copied ? 'Copied' : 'Copy address'}>
+              <IconButton size="small" onClick={handleCopy} aria-label="Copy support email address">
+                {copied ? <CheckIcon fontSize="small" color="success" /> : <CopyIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+          </Box>
+
+          <Box>
+            <Button variant="contained" size="small" startIcon={<EmailIcon />} component="a" href={mailtoHref}>
+              Email us
+            </Button>
+          </Box>
+
+          {version && (
+            <Typography variant="caption" color="text.disabled">
+              {version}
+            </Typography>
+          )}
+        </Stack>
+
+        <Divider sx={{ my: 2 }} />
+
+        <Stack spacing={1}>
+          <Typography variant="subtitle2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <BotIcon fontSize="small" />
+            Have a question on how to use the app?
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Try chatting with Shu Bot — a guide for getting around the app. For account or billing issues, email our
+            team above instead.
+          </Typography>
+          <Box>
+            <Button variant="outlined" size="small" startIcon={<BotIcon />} onClick={handleChatWithBot}>
+              Chat with Shu Bot
+            </Button>
+          </Box>
+        </Stack>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/support/ContactSupportDialog.jsx
+++ b/frontend/src/components/support/ContactSupportDialog.jsx
@@ -22,6 +22,7 @@ import {
 } from '@mui/icons-material';
 
 import { SUPPORT_EMAIL } from '../../utils/constants';
+import { SHU_ASSISTANT_ENABLED } from '../../config/featureFlags';
 import log from '../../utils/log';
 
 // How long the Copy button shows its "Copied" confirmation before resetting.
@@ -120,23 +121,27 @@ export default function ContactSupportDialog({ open, onClose, user, appName = 'S
           )}
         </Stack>
 
-        <Divider sx={{ my: 2 }} />
+        {SHU_ASSISTANT_ENABLED && (
+          <>
+            <Divider sx={{ my: 2 }} />
 
-        <Stack spacing={1}>
-          <Typography variant="subtitle2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <AssistantIcon fontSize="small" />
-            Have a question on how to use the app?
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Try chatting with Shu Assistant — a guide for getting around the app. For account, billing, or technical
-            issues, email our team above instead.
-          </Typography>
-          <Box>
-            <Button variant="outlined" size="small" startIcon={<AssistantIcon />} onClick={handleChatWithAssistant}>
-              Chat with Shu Assistant
-            </Button>
-          </Box>
-        </Stack>
+            <Stack spacing={1}>
+              <Typography variant="subtitle2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <AssistantIcon fontSize="small" />
+                Have a question on how to use the app?
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Try chatting with Shu Assistant — a guide for getting around the app. For account, billing, or technical
+                issues, email our team above instead.
+              </Typography>
+              <Box>
+                <Button variant="outlined" size="small" startIcon={<AssistantIcon />} onClick={handleChatWithAssistant}>
+                  Chat with Shu Assistant
+                </Button>
+              </Box>
+            </Stack>
+          </>
+        )}
       </DialogContent>
 
       <DialogActions>

--- a/frontend/src/components/support/ContactSupportDialog.jsx
+++ b/frontend/src/components/support/ContactSupportDialog.jsx
@@ -18,7 +18,7 @@ import {
   Email as EmailIcon,
   ContentCopy as CopyIcon,
   Check as CheckIcon,
-  SmartToy as BotIcon,
+  AutoAwesome as AssistantIcon,
 } from '@mui/icons-material';
 
 import { SUPPORT_EMAIL } from '../../utils/constants';
@@ -32,8 +32,8 @@ const COPIED_RESET_MS = 2000;
  *
  * Lightweight, pure-frontend support entry point opened from the profile menu.
  * Surfaces the support address with copy + mailto actions, and a distinct
- * "Shu Bot" how-to-use-the-app stub that opens a new chat. This is NOT a
- * customer-support bot — the copy keeps the two paths clearly separated.
+ * "Shu Assistant" how-to-use-the-app stub that opens a new chat. This is NOT
+ * a customer-support assistant — the copy keeps the two paths clearly separated.
  *
  * Props:
  *  - open: boolean
@@ -77,7 +77,7 @@ export default function ContactSupportDialog({ open, onClose, user, appName = 'S
     }
   };
 
-  const handleChatWithBot = () => {
+  const handleChatWithAssistant = () => {
     onClose();
     navigate('/chat');
   };
@@ -124,16 +124,16 @@ export default function ContactSupportDialog({ open, onClose, user, appName = 'S
 
         <Stack spacing={1}>
           <Typography variant="subtitle2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <BotIcon fontSize="small" />
+            <AssistantIcon fontSize="small" />
             Have a question on how to use the app?
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            Try chatting with Shu Bot — a guide for getting around the app. For account or billing issues, email our
-            team above instead.
+            Try chatting with Shu Assistant — a guide for getting around the app. For account, billing, or technical
+            issues, email our team above instead.
           </Typography>
           <Box>
-            <Button variant="outlined" size="small" startIcon={<BotIcon />} onClick={handleChatWithBot}>
-              Chat with Shu Bot
+            <Button variant="outlined" size="small" startIcon={<AssistantIcon />} onClick={handleChatWithAssistant}>
+              Chat with Shu Assistant
             </Button>
           </Box>
         </Stack>

--- a/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
+++ b/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for ContactSupportDialog (SHU-857).
+ *
+ * Asserts the load-bearing behavior: the support address renders, Copy hits
+ * the Clipboard API, "Email us" builds a correct mailto href with prefilled
+ * subject/body, the version shows inline, and the Shu Bot stub navigates to
+ * /chat (and closes the dialog).
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
+
+import ContactSupportDialog from '../ContactSupportDialog';
+
+// `mock`-prefixed so Vitest allows referencing it inside the hoisted vi.mock factory.
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const USER = { name: 'Eric Longville', email: 'eric@example.com', role: 'admin' };
+
+const renderDialog = (props = {}) =>
+  render(
+    <ThemeProvider theme={createTheme()}>
+      <MemoryRouter>
+        <ContactSupportDialog
+          open
+          onClose={props.onClose || vi.fn()}
+          user={USER}
+          appName="Shu"
+          version="v1.2.3 • abc1234"
+          {...props}
+        />
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+});
+
+describe('ContactSupportDialog', () => {
+  it('renders the support address and version inline', () => {
+    renderDialog();
+    expect(screen.getByText('support@openshu.ai')).toBeInTheDocument();
+    expect(screen.getByText('v1.2.3 • abc1234')).toBeInTheDocument();
+  });
+
+  it('builds an "Email us" mailto with prefilled subject and account context', () => {
+    renderDialog();
+    const link = screen.getByRole('link', { name: /email us/i });
+    const href = link.getAttribute('href');
+    expect(href).toMatch(/^mailto:support@openshu\.ai\?/);
+
+    const params = new URLSearchParams(new URL(href).search);
+    expect(params.get('subject')).toBe('Shu Support Request');
+    const body = params.get('body');
+    expect(body).toContain('App: Shu v1.2.3 • abc1234');
+    expect(body).toContain('Name: Eric Longville');
+    expect(body).toContain('Email: eric@example.com');
+    expect(body).toContain('Role: admin');
+  });
+
+  it('copies the address to the clipboard when Copy is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /copy support email address/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('support@openshu.ai'));
+  });
+
+  it('does not throw when the Clipboard API is unavailable', () => {
+    Object.assign(navigator, { clipboard: undefined });
+    renderDialog();
+    // Should be a no-op, not a thrown error.
+    expect(() => fireEvent.click(screen.getByRole('button', { name: /copy support email address/i }))).not.toThrow();
+  });
+
+  it('navigates to /chat and closes when "Chat with Shu Bot" is clicked', () => {
+    const onClose = vi.fn();
+    renderDialog({ onClose });
+
+    fireEvent.click(screen.getByRole('button', { name: /chat with shu bot/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/chat');
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
+++ b/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
@@ -83,11 +83,11 @@ describe('ContactSupportDialog', () => {
     expect(() => fireEvent.click(screen.getByRole('button', { name: /copy support email address/i }))).not.toThrow();
   });
 
-  it('navigates to /chat and closes when "Chat with Shu Bot" is clicked', () => {
+  it('navigates to /chat and closes when "Chat with Shu Assistant" is clicked', () => {
     const onClose = vi.fn();
     renderDialog({ onClose });
 
-    fireEvent.click(screen.getByRole('button', { name: /chat with shu bot/i }));
+    fireEvent.click(screen.getByRole('button', { name: /chat with shu assistant/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/chat');
     expect(onClose).toHaveBeenCalled();

--- a/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
+++ b/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { MemoryRouter } from 'react-router-dom';
@@ -49,9 +49,17 @@ const renderDialog = (props = {}) =>
     </ThemeProvider>
   );
 
+// Capture the original clipboard so the tests that stub it (Copy / unavailable
+// cases) don't leak a mutated global to anything added later in this file.
+const originalClipboard = navigator.clipboard;
+
 beforeEach(() => {
   mockNavigate.mockClear();
   mockAssistantEnabled = true;
+});
+
+afterEach(() => {
+  Object.assign(navigator, { clipboard: originalClipboard });
 });
 
 describe('ContactSupportDialog', () => {

--- a/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
+++ b/frontend/src/components/support/__tests__/ContactSupportDialog.test.jsx
@@ -22,6 +22,15 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
+// Build-time flag gating the Shu Assistant section. A getter lets each test
+// toggle it via the `mock`-prefixed holder before rendering.
+let mockAssistantEnabled = true;
+vi.mock('../../../config/featureFlags', () => ({
+  get SHU_ASSISTANT_ENABLED() {
+    return mockAssistantEnabled;
+  },
+}));
+
 const USER = { name: 'Eric Longville', email: 'eric@example.com', role: 'admin' };
 
 const renderDialog = (props = {}) =>
@@ -42,12 +51,13 @@ const renderDialog = (props = {}) =>
 
 beforeEach(() => {
   mockNavigate.mockClear();
+  mockAssistantEnabled = true;
 });
 
 describe('ContactSupportDialog', () => {
   it('renders the support address and version inline', () => {
     renderDialog();
-    expect(screen.getByText('support@openshu.ai')).toBeInTheDocument();
+    expect(screen.getByText('support@shu.ai')).toBeInTheDocument();
     expect(screen.getByText('v1.2.3 • abc1234')).toBeInTheDocument();
   });
 
@@ -55,7 +65,7 @@ describe('ContactSupportDialog', () => {
     renderDialog();
     const link = screen.getByRole('link', { name: /email us/i });
     const href = link.getAttribute('href');
-    expect(href).toMatch(/^mailto:support@openshu\.ai\?/);
+    expect(href).toMatch(/^mailto:support@shu\.ai\?/);
 
     const params = new URLSearchParams(new URL(href).search);
     expect(params.get('subject')).toBe('Shu Support Request');
@@ -73,7 +83,7 @@ describe('ContactSupportDialog', () => {
     renderDialog();
     fireEvent.click(screen.getByRole('button', { name: /copy support email address/i }));
 
-    await waitFor(() => expect(writeText).toHaveBeenCalledWith('support@openshu.ai'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('support@shu.ai'));
   });
 
   it('does not throw when the Clipboard API is unavailable', () => {
@@ -91,5 +101,15 @@ describe('ContactSupportDialog', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith('/chat');
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('hides the Shu Assistant section when the flag is disabled', () => {
+    mockAssistantEnabled = false;
+    renderDialog();
+
+    // Support contact path remains; the assistant entry is gone.
+    expect(screen.getByText('support@shu.ai')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /chat with shu assistant/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/have a question on how to use the app/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/config/featureFlags.js
+++ b/frontend/src/config/featureFlags.js
@@ -24,6 +24,11 @@ export const PLUGINS_ENABLED = parseBoolean('VITE_PLUGINS_ENABLED', true);
 export const MCP_ENABLED = parseBoolean('VITE_MCP_ENABLED', true);
 export const EXPERIENCES_ENABLED = parseBoolean('VITE_EXPERIENCES_ENABLED', true);
 
+// Shu Assistant (how-to chat) entry in the Contact Support dialog. Defaults OFF:
+// the seeded assistant model config does not exist yet, so showing it would drop
+// users into an empty chat. Flip to 'true' once the assistant ships (SHU-857 follow-up).
+export const SHU_ASSISTANT_ENABLED = parseBoolean('VITE_SHU_ASSISTANT_ENABLED', false);
+
 // Single source of truth for feature gating. Each entry pairs the build-time
 // env flag with the runtime entitlement keys (from the billing API). To gate a
 // new feature, add one row here and reference its key via `useFeatureEnabled`.

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -591,7 +591,7 @@ export {
 // Customer-support contact address surfaced in the Contact Support dialog.
 // White-label deployments override it via the VITE_SUPPORT_EMAIL build-time
 // env var; defaults to the canonical Shu support inbox when unset.
-export const SUPPORT_EMAIL = import.meta.env.VITE_SUPPORT_EMAIL || 'support@openshu.ai';
+export const SUPPORT_EMAIL = import.meta.env.VITE_SUPPORT_EMAIL || 'support@shu.ai';
 
 export const getThemeConfig = (mode = 'light', branding, userFontPref = null) => {
   const resolved = resolveBranding(branding);

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -588,6 +588,11 @@ export {
   derivePrimaryVariants,
 } from './brandingUtils';
 
+// Customer-support contact address surfaced in the Contact Support dialog.
+// White-label deployments override it via the VITE_SUPPORT_EMAIL build-time
+// env var; defaults to the canonical Shu support inbox when unset.
+export const SUPPORT_EMAIL = import.meta.env.VITE_SUPPORT_EMAIL || 'support@openshu.ai';
+
 export const getThemeConfig = (mode = 'light', branding, userFontPref = null) => {
   const resolved = resolveBranding(branding);
   const base = mode === 'dark' ? darkThemeBase : lightThemeBase;


### PR DESCRIPTION
## Description
Adds a **Contact Support** entry point to the user profile menu (visible in both user and admin layouts). Clicking it opens a lightweight, frontend-only dialog that surfaces the support email (`support@shu.ai`) with copy and `mailto:` actions, prefilled with the signed-in user's account context for faster triage.

The dialog also includes a **Shu Assistant** "how-to-use-the-app" section that opens a chat — gated behind a feature flag and **hidden by default**, since the seeded assistant configuration doesn't exist yet. It can be enabled later without code changes.

A backend-backed contact form and the seeded Shu Assistant model config are intentionally out of scope (deferred follow-ups). Ticket: SHU-857.


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made
- **New `ContactSupportDialog` component** — MUI dialog with a selectable support address, a Copy-to-clipboard button (graceful fallback when the Clipboard API is unavailable), an "Email us" `mailto:` button prefilled with subject + account context (app name/version, name, email, role), the app version shown inline, and the optional Shu Assistant section.
- **"Contact Support" menu item** (`SupportAgentIcon`) added to the shared `UserMenuCommonItems` so it appears for all roles; dialog state mounted in `TopBar` (outside the menu so it survives the menu closing).
- **`SUPPORT_EMAIL` constant** in `constants.js`, overridable via `VITE_SUPPORT_EMAIL` (defaults to `support@shu.ai`).
- **`SHU_ASSISTANT_ENABLED` feature flag** in `featureFlags.js` (`VITE_SHU_ASSISTANT_ENABLED`, default off) gating the Shu Assistant section.
- **Documented** `VITE_SUPPORT_EMAIL` and `VITE_SHU_ASSISTANT_ENABLED` in `.env.example`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing locally

New Vitest suite `ContactSupportDialog.test.jsx` — **6 tests, all passing**:

1. Renders the support address and app version inline
2. Builds the "Email us" `mailto:` href with the correct subject and account-context body
3. Copies the address to the clipboard when Copy is clicked
4. Does not throw when the Clipboard API is unavailable (graceful degradation)
5. Navigates to `/chat` and closes when "Chat with Shu Assistant" is clicked
6. Hides the Shu Assistant section when the feature flag is disabled

## Screenshots (if applicable)
<img width="567" height="377" alt="image" src="https://github.com/user-attachments/assets/8ac29fca-a4c4-42aa-b89a-e83c64b6a94b" />

## Reviewer Notes
Pretty simple here! Please note there is a hidden feature that references a "Shu Assistant" if and when we add one to help the user with informational questions. As of now, it is feature flagged off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Contact Support" menu option with dedicated support dialog
  * Users can copy support email and send pre-filled support emails with app context
  * Optional "Chat with Shu Assistant" integration (configurable via feature flag)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->